### PR TITLE
Cleanup struct comments and remove DefaultConfig()

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,16 +55,16 @@ func mainWithError() (err error) {
 		// New custom service implements the business logic.
 		var newService *service.Service
 		{
-			serviceConfig := service.DefaultConfig()
+			serviceConfig := service.Config{
+				Flag:   f,
+				Logger: newLogger,
+				Viper:  v,
 
-			serviceConfig.Flag = f
-			serviceConfig.Logger = newLogger
-			serviceConfig.Viper = v
-
-			serviceConfig.Description = description
-			serviceConfig.GitCommit = gitCommit
-			serviceConfig.Name = name
-			serviceConfig.Source = source
+				Description: description,
+				GitCommit:   gitCommit,
+				Name:        name,
+				Source:      source,
+			}
 
 			newService, err = service.New(serviceConfig)
 			if err != nil {
@@ -97,13 +97,15 @@ func mainWithError() (err error) {
 		// New custom server that bundles microkit endpoints.
 		var newServer microserver.Server
 		{
-			serverConfig := server.DefaultConfig()
+			serverConfig := server.Config{
+				MicroServerConfig: microserver.DefaultConfig(),
+				Service:           newService,
+			}
 
 			serverConfig.MicroServerConfig.Logger = newLogger
 			serverConfig.MicroServerConfig.ServiceName = name
 			serverConfig.MicroServerConfig.TransactionResponder = transactionResponder
 			serverConfig.MicroServerConfig.Viper = v
-			serverConfig.Service = newService
 
 			newServer, err = server.New(serverConfig)
 			if err != nil {

--- a/server/endpoint/endpoint.go
+++ b/server/endpoint/endpoint.go
@@ -9,15 +9,9 @@ import (
 
 // Config represents the configuration used to construct an endpoint.
 type Config struct {
-	// Dependencies
 	Logger     micrologger.Logger
 	Middleware *middleware.Middleware
 	Service    *service.Service
-}
-
-// DefaultConfig provides a default configuration to create a new endpoint.
-func DefaultConfig() Config {
-	return Config{}
 }
 
 // New creates a new endpoint with given configuration.

--- a/server/middleware/middleware.go
+++ b/server/middleware/middleware.go
@@ -8,14 +8,8 @@ import (
 
 // Config represents the configuration used to construct middleware.
 type Config struct {
-	// Dependencies
 	Logger  micrologger.Logger
 	Service *service.Service
-}
-
-// DefaultConfig provides a default configuration to construct a new middleware.
-func DefaultConfig() Config {
-	return Config{}
 }
 
 // New creates a new configured middleware.

--- a/server/server.go
+++ b/server/server.go
@@ -14,31 +14,14 @@ import (
 
 // Config represents the configuration used to construct server object.
 type Config struct {
-	// Dependencies
-	Service *service.Service
-
-	//Settings
+	Service           *service.Service
 	MicroServerConfig microserver.Config
-}
-
-// DefaultConfig provides a default configuration to create a new server object.
-func DefaultConfig() Config {
-	return Config{
-		// Dependencies
-		Service: nil,
-
-		// Settings
-		MicroServerConfig: microserver.DefaultConfig(),
-	}
 }
 
 // New creates a new server object with given configuration.
 func New(config Config) (microserver.Server, error) {
 	newServer := &server{
-		// Dependencies
-		logger: config.MicroServerConfig.Logger,
-
-		// Internals
+		logger:       config.MicroServerConfig.Logger,
 		bootOnce:     sync.Once{},
 		config:       config.MicroServerConfig,
 		serviceName:  config.MicroServerConfig.ServiceName,
@@ -53,10 +36,7 @@ func New(config Config) (microserver.Server, error) {
 }
 
 type server struct {
-	// Dependencies
-	logger micrologger.Logger
-
-	// Internals
+	logger       micrologger.Logger
 	bootOnce     sync.Once
 	config       microserver.Config
 	serviceName  string

--- a/service/service.go
+++ b/service/service.go
@@ -13,10 +13,8 @@ import (
 
 // Config represents the configuration used to create a new service.
 type Config struct {
-	// Dependencies
 	Logger micrologger.Logger
 
-	// Settings
 	Flag  *flag.Flag
 	Viper *viper.Viper
 
@@ -26,20 +24,13 @@ type Config struct {
 	Source      string
 }
 
-// DefaultConfig provides a default configuration to create a new service.
-func DefaultConfig() Config {
-	return Config{}
-}
-
 // New creates a new service with given configuration.
 func New(config Config) (*Service, error) {
-	// Dependencies
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
 	}
 	config.Logger.Log("debug", fmt.Sprintf("creating cluster-operator gitCommit:%s", config.GitCommit))
 
-	// Settings
 	if config.Flag == nil {
 		return nil, microerror.Maskf(invalidConfigError, "config.Flag must not be empty")
 	}
@@ -49,9 +40,6 @@ func New(config Config) (*Service, error) {
 	}
 
 	newService := &Service{
-		// Dependencies
-
-		// Internals
 		bootOnce: sync.Once{},
 	}
 
@@ -60,9 +48,6 @@ func New(config Config) (*Service, error) {
 
 // Service is a type providing implementation of microkit service interface.
 type Service struct {
-	// Dependencies
-
-	// Internals
 	bootOnce sync.Once
 }
 


### PR DESCRIPTION
As agreed today, comments describing struct dependency section and
settings section can be omitted as those don't bring much value.

Also DefaultConfig() functions that don't produce working default
configuration were removed as those were mostly the same as constructing
the public struct type with empty values.