### PR TITLE
Separate Endpoint construction from return statement

### DIFF
--- a/server/endpoint/endpoint.go
+++ b/server/endpoint/endpoint.go
@@ -43,9 +43,11 @@ func New(config Config) (*Endpoint, error) {
 		}
 	}
 
-	return &Endpoint{
+	endpoint := &Endpoint{
 		Healthz: healthzEndpoint,
-	}, nil
+	}
+
+	return endpoint, nil
 }
 
 // Endpoint is the endpoint collection.


### PR DESCRIPTION
When bundled together, the nil error value might be easily missed so
separating construction from return makes it more explicit.