### PR TITLE
Change helm chart version to 1.0.0

### DIFF
--- a/helm/cluster-operator-chart/Chart.yaml
+++ b/helm/cluster-operator-chart/Chart.yaml
@@ -1,2 +1,2 @@
 name: cluster-operator-chart
-version: 0.0.1-[[ .SHA ]]
+version: 1.0.0-[[ .SHA ]]


### PR DESCRIPTION
Draughtsman assumes Helm charts are always 1.0.0 version (see:
https://github.com/giantswarm/draughtsman/blob/master/service/installer/helm/helm.go#L23-L28)

Deployments use SHA for determining deployed version.