### PR TITLE
Implement encryptionkey.NewUpdatePatch()

### DIFF
--- a/service/kvmclusterconfig/v1/resource/encryptionkey/common_test.go
+++ b/service/kvmclusterconfig/v1/resource/encryptionkey/common_test.go
@@ -12,7 +12,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func createCustomObject(clusterID string) *v1alpha1.KVMClusterConfig {
+func newCustomObject(clusterID string) *v1alpha1.KVMClusterConfig {
 	return &v1alpha1.KVMClusterConfig{
 		Spec: v1alpha1.KVMClusterConfigSpec{
 			Guest: v1alpha1.KVMClusterConfigSpecGuest{
@@ -24,15 +24,15 @@ func createCustomObject(clusterID string) *v1alpha1.KVMClusterConfig {
 	}
 }
 
-func createEncryptionSecret(t *testing.T, clusterID string, data map[string]string) *v1.Secret {
+func newEncryptionSecret(t *testing.T, clusterID string, data map[string]string) *v1.Secret {
 	t.Helper()
-	return createSecret(t, createCustomObject(clusterID), map[string]string{
+	return newSecret(t, newCustomObject(clusterID), map[string]string{
 		randomkeytpr.ClusterIDLabel: clusterID,
 		randomkeytpr.KeyLabel:       randomkeytpr.EncryptionKey.String(),
 	}, data)
 }
 
-func createSecret(t *testing.T, customObject *v1alpha1.KVMClusterConfig, labels, data map[string]string) *v1.Secret {
+func newSecret(t *testing.T, customObject *v1alpha1.KVMClusterConfig, labels, data map[string]string) *v1.Secret {
 	t.Helper()
 	return &v1.Secret{
 		TypeMeta: apismetav1.TypeMeta{

--- a/service/kvmclusterconfig/v1/resource/encryptionkey/common_test.go
+++ b/service/kvmclusterconfig/v1/resource/encryptionkey/common_test.go
@@ -1,0 +1,66 @@
+package encryptionkey
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/cluster-operator/service/kvmclusterconfig/v1/key"
+	"github.com/giantswarm/operatorkit/framework"
+	"github.com/giantswarm/randomkeytpr"
+	"k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func createCustomObject(clusterID string) *v1alpha1.KVMClusterConfig {
+	return &v1alpha1.KVMClusterConfig{
+		Spec: v1alpha1.KVMClusterConfigSpec{
+			Guest: v1alpha1.KVMClusterConfigSpecGuest{
+				ClusterGuestConfig: v1alpha1.ClusterGuestConfig{
+					ID: clusterID,
+				},
+			},
+		},
+	}
+}
+
+func createEncryptionSecret(t *testing.T, clusterID string, data map[string]string) *v1.Secret {
+	t.Helper()
+	return createSecret(t, createCustomObject(clusterID), map[string]string{
+		randomkeytpr.ClusterIDLabel: clusterID,
+		randomkeytpr.KeyLabel:       randomkeytpr.EncryptionKey.String(),
+	}, data)
+}
+
+func createSecret(t *testing.T, customObject *v1alpha1.KVMClusterConfig, labels, data map[string]string) *v1.Secret {
+	t.Helper()
+	return &v1.Secret{
+		TypeMeta: apismetav1.TypeMeta{
+			Kind:       "secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: apismetav1.ObjectMeta{
+			Name:      key.EncryptionKeySecretName(*customObject),
+			Namespace: v1.NamespaceDefault,
+			Labels:    labels,
+		},
+		StringData: data,
+	}
+}
+
+func assertPatch(t *testing.T, testNum int, computedPatch, expectedPatch *framework.Patch) {
+	t.Helper()
+
+	if expectedPatch == nil && computedPatch != nil {
+		t.Errorf("TestCase %d: Expected nil patch. Received %#v", testNum, computedPatch)
+		return
+	} else if expectedPatch != nil && computedPatch == nil {
+		t.Errorf("TestCase %d: Expected non-nil patch. Received nil.", testNum)
+		return
+	}
+
+	if !reflect.DeepEqual(computedPatch, expectedPatch) {
+		t.Errorf("TestCase %d: Computed patch %#v doesn't match expected: %#v",
+			testNum, computedPatch, expectedPatch)
+	}
+}

--- a/service/kvmclusterconfig/v1/resource/encryptionkey/common_test.go
+++ b/service/kvmclusterconfig/v1/resource/encryptionkey/common_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/cluster-operator/service/kvmclusterconfig/v1/key"
-	"github.com/giantswarm/operatorkit/framework"
 	"github.com/giantswarm/randomkeytpr"
 	"k8s.io/api/core/v1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,19 +47,19 @@ func newSecret(t *testing.T, customObject *v1alpha1.KVMClusterConfig, labels, da
 	}
 }
 
-func assertPatch(t *testing.T, testNum int, computedPatch, expectedPatch *framework.Patch) {
+func assertSecret(t *testing.T, computedSecret, expectedSecret *v1.Secret) {
 	t.Helper()
 
-	if expectedPatch == nil && computedPatch != nil {
-		t.Errorf("TestCase %d: Expected nil patch. Received %#v", testNum, computedPatch)
+	if expectedSecret == nil && computedSecret != nil {
+		t.Errorf("Expected nil secret. Received %#v", computedSecret)
 		return
-	} else if expectedPatch != nil && computedPatch == nil {
-		t.Errorf("TestCase %d: Expected non-nil patch. Received nil.", testNum)
+	} else if expectedSecret != nil && computedSecret == nil {
+		t.Error("Expected non-nil secret. Received nil.")
 		return
 	}
 
-	if !reflect.DeepEqual(computedPatch, expectedPatch) {
-		t.Errorf("TestCase %d: Computed patch %#v doesn't match expected: %#v",
-			testNum, computedPatch, expectedPatch)
+	if !reflect.DeepEqual(computedSecret, expectedSecret) {
+		t.Errorf("Computed secret %#v doesn't match expected: %#v",
+			computedSecret, expectedSecret)
 	}
 }

--- a/service/kvmclusterconfig/v1/resource/encryptionkey/create.go
+++ b/service/kvmclusterconfig/v1/resource/encryptionkey/create.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/giantswarm/microerror"
+	"k8s.io/api/core/v1"
 )
 
 // ApplyCreateChange takes observed custom object and create portion of the
@@ -13,7 +14,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 	return nil
 }
 
-func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (*v1.Secret, error) {
 	currentSecret, err := toSecret(currentState)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -25,9 +26,7 @@ func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desir
 
 	r.logger.LogCtx(ctx, "debug", "finding out if the secret has to be created")
 
-	// secretToCreate must be an empty interface instead of *v1.Secret because
-	// that makes a difference when comparing return value for nil.
-	var secretToCreate interface{}
+	var secretToCreate *v1.Secret
 	if currentSecret == nil {
 		secretToCreate = desiredSecret
 	}
@@ -35,5 +34,4 @@ func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desir
 	r.logger.LogCtx(ctx, "debug", "found out if the secret has to be created")
 
 	return secretToCreate, nil
-
 }

--- a/service/kvmclusterconfig/v1/resource/encryptionkey/create.go
+++ b/service/kvmclusterconfig/v1/resource/encryptionkey/create.go
@@ -2,6 +2,8 @@ package encryptionkey
 
 import (
 	"context"
+
+	"github.com/giantswarm/microerror"
 )
 
 // ApplyCreateChange takes observed custom object and create portion of the
@@ -9,4 +11,29 @@ import (
 // for encryption key if needed.
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
 	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentSecret, err := toSecret(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredSecret, err := toSecret(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "debug", "finding out if the secret has to be created")
+
+	// secretToCreate must be an empty interface instead of *v1.Secret because
+	// that makes a difference when comparing return value for nil.
+	var secretToCreate interface{}
+	if currentSecret == nil {
+		secretToCreate = desiredSecret
+	}
+
+	r.logger.LogCtx(ctx, "debug", "found out if the secret has to be created")
+
+	return secretToCreate, nil
+
 }

--- a/service/kvmclusterconfig/v1/resource/encryptionkey/create_test.go
+++ b/service/kvmclusterconfig/v1/resource/encryptionkey/create_test.go
@@ -68,8 +68,7 @@ func Test_newCreateChange(t *testing.T) {
 
 			secret, err := r.newCreateChange(context.TODO(), tc.CustomObject, tc.CurrentState, tc.DesiredState)
 			if microerror.Cause(err) != tc.ExpectedError {
-				t.Errorf("Unexpected error returned: %#v, expected %#v", err, tc.ExpectedError)
-				return
+				t.Fatalf("Unexpected error returned: %#v, expected %#v", err, tc.ExpectedError)
 			}
 
 			assertSecret(t, secret, tc.ExpectedSecret)

--- a/service/kvmclusterconfig/v1/resource/encryptionkey/create_test.go
+++ b/service/kvmclusterconfig/v1/resource/encryptionkey/create_test.go
@@ -1,1 +1,78 @@
 package encryptionkey
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_newCreateChange(t *testing.T) {
+	testCases := []struct {
+		Description    string
+		CustomObject   *v1alpha1.KVMClusterConfig
+		CurrentState   interface{}
+		DesiredState   interface{}
+		ExpectedSecret *v1.Secret
+		ExpectedError  error
+	}{
+		{
+			Description:    "encryption key secret doesn't exist yet - secret should create it",
+			CustomObject:   newCustomObject("cluster-1"),
+			CurrentState:   nil,
+			DesiredState:   newEncryptionSecret(t, "cluster-1", map[string]string{}),
+			ExpectedSecret: newEncryptionSecret(t, "cluster-1", map[string]string{}),
+			ExpectedError:  nil,
+		},
+		{
+			Description:    "encryption key secret already exists - secret must not be created",
+			CustomObject:   newCustomObject("cluster-1"),
+			CurrentState:   newEncryptionSecret(t, "cluster-1", map[string]string{}),
+			DesiredState:   newEncryptionSecret(t, "cluster-1", map[string]string{}),
+			ExpectedSecret: nil,
+			ExpectedError:  nil,
+		},
+		{
+			Description:    "verify currentState type verification error handling",
+			CustomObject:   newCustomObject("cluster-1"),
+			CurrentState:   &v1.Pod{},
+			DesiredState:   newEncryptionSecret(t, "cluster-1", map[string]string{}),
+			ExpectedSecret: nil,
+			ExpectedError:  wrongTypeError,
+		},
+		{
+			Description:    "verify desiredState type verification error handling",
+			CustomObject:   newCustomObject("cluster-1"),
+			CurrentState:   nil,
+			DesiredState:   &v1.Pod{},
+			ExpectedSecret: nil,
+			ExpectedError:  wrongTypeError,
+		},
+	}
+
+	logger, err := micrologger.New(micrologger.DefaultConfig())
+	if err != nil {
+		t.Fatalf("micrologger.New() failed: %#v", err)
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Description, func(t *testing.T) {
+			r, err := New(Config{
+				K8sClient: fake.NewSimpleClientset(),
+				Logger:    logger,
+			})
+
+			secret, err := r.newCreateChange(context.TODO(), tc.CustomObject, tc.CurrentState, tc.DesiredState)
+			if microerror.Cause(err) != tc.ExpectedError {
+				t.Errorf("Unexpected error returned: %#v, expected %#v", err, tc.ExpectedError)
+				return
+			}
+
+			assertSecret(t, secret, tc.ExpectedSecret)
+		})
+	}
+}

--- a/service/kvmclusterconfig/v1/resource/encryptionkey/current_test.go
+++ b/service/kvmclusterconfig/v1/resource/encryptionkey/current_test.go
@@ -6,12 +6,10 @@ import (
 	"testing"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
-	"github.com/giantswarm/cluster-operator/service/kvmclusterconfig/v1/key"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/randomkeytpr"
 	"k8s.io/api/core/v1"
-	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
@@ -123,42 +121,6 @@ func Test_GetCurrentState_Reads_Secrets_For_Relevant_ClusterID(t *testing.T) {
 				secret.Labels[randomkeytpr.ClusterIDLabel],
 			)
 		}
-	}
-}
-
-func createCustomObject(clusterID string) *v1alpha1.KVMClusterConfig {
-	return &v1alpha1.KVMClusterConfig{
-		Spec: v1alpha1.KVMClusterConfigSpec{
-			Guest: v1alpha1.KVMClusterConfigSpecGuest{
-				ClusterGuestConfig: v1alpha1.ClusterGuestConfig{
-					ID: clusterID,
-				},
-			},
-		},
-	}
-}
-
-func createEncryptionSecret(t *testing.T, clusterID string, data map[string]string) *v1.Secret {
-	t.Helper()
-	return createSecret(t, createCustomObject(clusterID), map[string]string{
-		randomkeytpr.ClusterIDLabel: clusterID,
-		randomkeytpr.KeyLabel:       randomkeytpr.EncryptionKey.String(),
-	}, data)
-}
-
-func createSecret(t *testing.T, customObject *v1alpha1.KVMClusterConfig, labels, data map[string]string) *v1.Secret {
-	t.Helper()
-	return &v1.Secret{
-		TypeMeta: apismetav1.TypeMeta{
-			Kind:       "secret",
-			APIVersion: "v1",
-		},
-		ObjectMeta: apismetav1.ObjectMeta{
-			Name:      key.EncryptionKeySecretName(*customObject),
-			Namespace: v1.NamespaceDefault,
-			Labels:    labels,
-		},
-		StringData: data,
 	}
 }
 

--- a/service/kvmclusterconfig/v1/resource/encryptionkey/current_test.go
+++ b/service/kvmclusterconfig/v1/resource/encryptionkey/current_test.go
@@ -28,21 +28,21 @@ func Test_GetCurrentState_Reads_Secrets_For_Relevant_ClusterID(t *testing.T) {
 		// Cluster exists: Success case when there are three cluster secrets
 		// present and one of them is correct
 		{
-			CustomObject: createCustomObject("cluster-2"),
+			CustomObject: newCustomObject("cluster-2"),
 			PresentSecrets: []*v1.Secret{
-				createEncryptionSecret(t, "cluster-1", make(map[string]string)),
-				createEncryptionSecret(t, "cluster-2", make(map[string]string)),
-				createEncryptionSecret(t, "cluster-3", make(map[string]string)),
+				newEncryptionSecret(t, "cluster-1", make(map[string]string)),
+				newEncryptionSecret(t, "cluster-2", make(map[string]string)),
+				newEncryptionSecret(t, "cluster-3", make(map[string]string)),
 			},
 			APIReactors:    []k8stesting.Reactor{},
-			ExpectedSecret: createEncryptionSecret(t, "cluster-2", make(map[string]string)),
+			ExpectedSecret: newEncryptionSecret(t, "cluster-2", make(map[string]string)),
 			ExpectedError:  nil,
 		},
 
 		// First cluster: Success case when there are no cluster secrets
 		// present but new cluster is about to be created
 		{
-			CustomObject:   createCustomObject("cluster-1"),
+			CustomObject:   newCustomObject("cluster-1"),
 			PresentSecrets: []*v1.Secret{},
 			APIReactors:    []k8stesting.Reactor{},
 			ExpectedSecret: nil,
@@ -52,11 +52,11 @@ func Test_GetCurrentState_Reads_Secrets_For_Relevant_ClusterID(t *testing.T) {
 		// New cluster: Success case when there are three cluster secrets
 		// present but expected secret doesn't exist (yet)
 		{
-			CustomObject: createCustomObject("cluster-4"),
+			CustomObject: newCustomObject("cluster-4"),
 			PresentSecrets: []*v1.Secret{
-				createEncryptionSecret(t, "cluster-1", make(map[string]string)),
-				createEncryptionSecret(t, "cluster-2", make(map[string]string)),
-				createEncryptionSecret(t, "cluster-3", make(map[string]string)),
+				newEncryptionSecret(t, "cluster-1", make(map[string]string)),
+				newEncryptionSecret(t, "cluster-2", make(map[string]string)),
+				newEncryptionSecret(t, "cluster-3", make(map[string]string)),
 			},
 			APIReactors:    []k8stesting.Reactor{},
 			ExpectedSecret: nil,
@@ -65,7 +65,7 @@ func Test_GetCurrentState_Reads_Secrets_For_Relevant_ClusterID(t *testing.T) {
 
 		// API Error: Kubernetes API client returns unknown error
 		{
-			CustomObject:   createCustomObject("cluster-4"),
+			CustomObject:   newCustomObject("cluster-4"),
 			PresentSecrets: []*v1.Secret{},
 			APIReactors: []k8stesting.Reactor{
 				alwaysReactWithError(unknownAPIError),

--- a/service/kvmclusterconfig/v1/resource/encryptionkey/desired.go
+++ b/service/kvmclusterconfig/v1/resource/encryptionkey/desired.go
@@ -48,7 +48,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		},
 	}
 
-	r.logger.LogCtx(ctx, "debug", "desired encryption key secret computed")
+	r.logger.LogCtx(ctx, "debug", "computed desired encryption key secret")
 
 	return secret, nil
 }

--- a/service/kvmclusterconfig/v1/resource/encryptionkey/desired.go
+++ b/service/kvmclusterconfig/v1/resource/encryptionkey/desired.go
@@ -48,6 +48,8 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		},
 	}
 
+	r.logger.LogCtx(ctx, "debug", "desired encryption key secret computed")
+
 	return secret, nil
 }
 

--- a/service/kvmclusterconfig/v1/resource/encryptionkey/resource.go
+++ b/service/kvmclusterconfig/v1/resource/encryptionkey/resource.go
@@ -4,6 +4,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/operatorkit/framework"
+	"k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -52,4 +53,17 @@ func (r *Resource) Name() string {
 // Underlying returns underlying framework.Resource.
 func (r *Resource) Underlying() framework.Resource {
 	return r
+}
+
+func toSecret(v interface{}) (*v1.Secret, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	secret, ok := v.(*v1.Secret)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", secret, v)
+	}
+
+	return secret, nil
 }

--- a/service/kvmclusterconfig/v1/resource/encryptionkey/update.go
+++ b/service/kvmclusterconfig/v1/resource/encryptionkey/update.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/framework"
+	"k8s.io/api/core/v1"
 )
 
 // ApplyUpdateChange takes observed custom object and update portion of the
@@ -28,19 +29,13 @@ func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desire
 	}
 
 	patch := framework.NewPatch()
-
-	if create != nil {
-		patch.SetCreateChange(create)
-	}
-
-	if update != nil {
-		patch.SetUpdateChange(update)
-	}
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
 
 	return patch, nil
 }
 
-func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (*v1.Secret, error) {
 	// for now encryption key should not be updated when one already exists
 	return nil, nil
 }

--- a/service/kvmclusterconfig/v1/resource/encryptionkey/update.go
+++ b/service/kvmclusterconfig/v1/resource/encryptionkey/update.go
@@ -3,6 +3,7 @@ package encryptionkey
 import (
 	"context"
 
+	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/framework"
 )
 
@@ -16,5 +17,25 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 // NewUpdatePatch computes appropriate Patch based on difference in current
 // state and desired state.
 func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
-	return nil, nil
+	r.logger.LogCtx(ctx, "debug", "computing update patch for encryption key")
+
+	currentSecret, err := toSecret(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	desiredSecret, err := toSecret(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := framework.NewPatch()
+
+	if currentSecret == nil && desiredSecret != nil {
+		patch.SetCreateChange(desiredSecret)
+	}
+
+	r.logger.LogCtx(ctx, "debug", "update patch for encryption key computed")
+
+	return patch, nil
 }

--- a/service/kvmclusterconfig/v1/resource/encryptionkey/update.go
+++ b/service/kvmclusterconfig/v1/resource/encryptionkey/update.go
@@ -17,25 +17,30 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 // NewUpdatePatch computes appropriate Patch based on difference in current
 // state and desired state.
 func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
-	r.logger.LogCtx(ctx, "debug", "computing update patch for encryption key")
-
-	currentSecret, err := toSecret(currentState)
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	desiredSecret, err := toSecret(desiredState)
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
 	patch := framework.NewPatch()
 
-	if currentSecret == nil && desiredSecret != nil {
-		patch.SetCreateChange(desiredSecret)
+	if create != nil {
+		patch.SetCreateChange(create)
 	}
 
-	r.logger.LogCtx(ctx, "debug", "update patch for encryption key computed")
+	if update != nil {
+		patch.SetUpdateChange(update)
+	}
 
 	return patch, nil
+}
+
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	// for now encryption key should not be updated when one already exists
+	return nil, nil
 }

--- a/service/kvmclusterconfig/v1/resource/encryptionkey/update_test.go
+++ b/service/kvmclusterconfig/v1/resource/encryptionkey/update_test.go
@@ -52,8 +52,7 @@ func Test_newUpdateChange_Does_Not_Return_Change(t *testing.T) {
 
 			secret, err := r.newUpdateChange(context.TODO(), tc.CustomObject, tc.CurrentState, tc.DesiredState)
 			if microerror.Cause(err) != tc.ExpectedError {
-				t.Errorf("Unexpected error returned: %#v, expected %#v", err, tc.ExpectedError)
-				return
+				t.Fatalf("Unexpected error returned: %#v, expected %#v", err, tc.ExpectedError)
 			}
 
 			assertSecret(t, secret, tc.ExpectedSecret)

--- a/service/kvmclusterconfig/v1/resource/encryptionkey/update_test.go
+++ b/service/kvmclusterconfig/v1/resource/encryptionkey/update_test.go
@@ -1,1 +1,82 @@
 package encryptionkey
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/framework"
+	"k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_NewUpdatePatch_Computes_Patch_Correctly(t *testing.T) {
+	testCases := []struct {
+		CustomObject  *v1alpha1.KVMClusterConfig
+		CurrentState  interface{}
+		DesiredState  interface{}
+		ExpectedPatch *framework.Patch
+		ExpectedError error
+	}{
+		// Encryption key secret doesn't exist yet.
+		// Patch should create it.
+		{
+			CustomObject: createCustomObject("cluster-1"),
+			CurrentState: nil,
+			DesiredState: createEncryptionSecret(t, "cluster-1", map[string]string{}),
+			ExpectedPatch: func() *framework.Patch {
+				p := framework.NewPatch()
+				p.SetCreateChange(createEncryptionSecret(t, "cluster-1", map[string]string{}))
+				return p
+			}(),
+			ExpectedError: nil,
+		},
+		// Encryption key secret already exists.
+		// Patch must not create it.
+		{
+			CustomObject:  createCustomObject("cluster-1"),
+			CurrentState:  createEncryptionSecret(t, "cluster-1", map[string]string{}),
+			DesiredState:  createEncryptionSecret(t, "cluster-1", map[string]string{}),
+			ExpectedPatch: framework.NewPatch(),
+			ExpectedError: nil,
+		},
+		// Verify currentState type verification error handling
+		{
+			CustomObject:  createCustomObject("cluster-1"),
+			CurrentState:  &v1.Pod{},
+			DesiredState:  createEncryptionSecret(t, "cluster-1", map[string]string{}),
+			ExpectedPatch: nil,
+			ExpectedError: wrongTypeError,
+		},
+		// Verify desiredState type verification error handling
+		{
+			CustomObject:  createCustomObject("cluster-1"),
+			CurrentState:  nil,
+			DesiredState:  &v1.Pod{},
+			ExpectedPatch: nil,
+			ExpectedError: wrongTypeError,
+		},
+	}
+
+	logger, err := micrologger.New(micrologger.DefaultConfig())
+	if err != nil {
+		t.Fatalf("micrologger.New() failed: %#v", err)
+	}
+
+	for i, tc := range testCases {
+		r, err := New(Config{
+			K8sClient: fake.NewSimpleClientset(),
+			Logger:    logger,
+		})
+
+		patch, err := r.NewUpdatePatch(context.TODO(), tc.CustomObject, tc.CurrentState, tc.DesiredState)
+		if microerror.Cause(err) != tc.ExpectedError {
+			t.Errorf("TestCase %d: Unexpected error returned: %#v, expected %#v", (i + 1), err, tc.ExpectedError)
+			continue
+		}
+
+		assertPatch(t, (i + 1), patch, tc.ExpectedPatch)
+	}
+}

--- a/service/kvmclusterconfig/v1/resource/encryptionkey/update_test.go
+++ b/service/kvmclusterconfig/v1/resource/encryptionkey/update_test.go
@@ -7,56 +7,34 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"github.com/giantswarm/operatorkit/framework"
 	"k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func Test_NewUpdatePatch_Computes_Patch_Correctly(t *testing.T) {
+func Test_newUpdateChange_Does_Not_Return_Change(t *testing.T) {
 	testCases := []struct {
-		CustomObject  *v1alpha1.KVMClusterConfig
-		CurrentState  interface{}
-		DesiredState  interface{}
-		ExpectedPatch *framework.Patch
-		ExpectedError error
+		Description    string
+		CustomObject   *v1alpha1.KVMClusterConfig
+		CurrentState   interface{}
+		DesiredState   interface{}
+		ExpectedSecret *v1.Secret
+		ExpectedError  error
 	}{
-		// Encryption key secret doesn't exist yet.
-		// Patch should create it.
 		{
-			CustomObject: newCustomObject("cluster-1"),
-			CurrentState: nil,
-			DesiredState: newEncryptionSecret(t, "cluster-1", map[string]string{}),
-			ExpectedPatch: func() *framework.Patch {
-				p := framework.NewPatch()
-				p.SetCreateChange(newEncryptionSecret(t, "cluster-1", map[string]string{}))
-				return p
-			}(),
-			ExpectedError: nil,
+			Description:    "encryption key secret doesn't exist yet - no updates must be created",
+			CustomObject:   newCustomObject("cluster-1"),
+			CurrentState:   nil,
+			DesiredState:   newEncryptionSecret(t, "cluster-1", map[string]string{}),
+			ExpectedSecret: nil,
+			ExpectedError:  nil,
 		},
-		// Encryption key secret already exists.
-		// Patch must not create it.
 		{
-			CustomObject:  newCustomObject("cluster-1"),
-			CurrentState:  newEncryptionSecret(t, "cluster-1", map[string]string{}),
-			DesiredState:  newEncryptionSecret(t, "cluster-1", map[string]string{}),
-			ExpectedPatch: framework.NewPatch(),
-			ExpectedError: nil,
-		},
-		// Verify currentState type verification error handling
-		{
-			CustomObject:  newCustomObject("cluster-1"),
-			CurrentState:  &v1.Pod{},
-			DesiredState:  newEncryptionSecret(t, "cluster-1", map[string]string{}),
-			ExpectedPatch: nil,
-			ExpectedError: wrongTypeError,
-		},
-		// Verify desiredState type verification error handling
-		{
-			CustomObject:  newCustomObject("cluster-1"),
-			CurrentState:  nil,
-			DesiredState:  &v1.Pod{},
-			ExpectedPatch: nil,
-			ExpectedError: wrongTypeError,
+			Description:    "encryption key secret already exists - no updates must be created",
+			CustomObject:   newCustomObject("cluster-1"),
+			CurrentState:   newEncryptionSecret(t, "cluster-1", map[string]string{}),
+			DesiredState:   newEncryptionSecret(t, "cluster-1", map[string]string{}),
+			ExpectedSecret: nil,
+			ExpectedError:  nil,
 		},
 	}
 
@@ -65,18 +43,20 @@ func Test_NewUpdatePatch_Computes_Patch_Correctly(t *testing.T) {
 		t.Fatalf("micrologger.New() failed: %#v", err)
 	}
 
-	for i, tc := range testCases {
-		r, err := New(Config{
-			K8sClient: fake.NewSimpleClientset(),
-			Logger:    logger,
+	for _, tc := range testCases {
+		t.Run(tc.Description, func(t *testing.T) {
+			r, err := New(Config{
+				K8sClient: fake.NewSimpleClientset(),
+				Logger:    logger,
+			})
+
+			secret, err := r.newUpdateChange(context.TODO(), tc.CustomObject, tc.CurrentState, tc.DesiredState)
+			if microerror.Cause(err) != tc.ExpectedError {
+				t.Errorf("Unexpected error returned: %#v, expected %#v", err, tc.ExpectedError)
+				return
+			}
+
+			assertSecret(t, secret, tc.ExpectedSecret)
 		})
-
-		patch, err := r.NewUpdatePatch(context.TODO(), tc.CustomObject, tc.CurrentState, tc.DesiredState)
-		if microerror.Cause(err) != tc.ExpectedError {
-			t.Errorf("TestCase %d: Unexpected error returned: %#v, expected %#v", (i + 1), err, tc.ExpectedError)
-			continue
-		}
-
-		assertPatch(t, (i + 1), patch, tc.ExpectedPatch)
 	}
 }

--- a/service/kvmclusterconfig/v1/resource/encryptionkey/update_test.go
+++ b/service/kvmclusterconfig/v1/resource/encryptionkey/update_test.go
@@ -23,12 +23,12 @@ func Test_NewUpdatePatch_Computes_Patch_Correctly(t *testing.T) {
 		// Encryption key secret doesn't exist yet.
 		// Patch should create it.
 		{
-			CustomObject: createCustomObject("cluster-1"),
+			CustomObject: newCustomObject("cluster-1"),
 			CurrentState: nil,
-			DesiredState: createEncryptionSecret(t, "cluster-1", map[string]string{}),
+			DesiredState: newEncryptionSecret(t, "cluster-1", map[string]string{}),
 			ExpectedPatch: func() *framework.Patch {
 				p := framework.NewPatch()
-				p.SetCreateChange(createEncryptionSecret(t, "cluster-1", map[string]string{}))
+				p.SetCreateChange(newEncryptionSecret(t, "cluster-1", map[string]string{}))
 				return p
 			}(),
 			ExpectedError: nil,
@@ -36,23 +36,23 @@ func Test_NewUpdatePatch_Computes_Patch_Correctly(t *testing.T) {
 		// Encryption key secret already exists.
 		// Patch must not create it.
 		{
-			CustomObject:  createCustomObject("cluster-1"),
-			CurrentState:  createEncryptionSecret(t, "cluster-1", map[string]string{}),
-			DesiredState:  createEncryptionSecret(t, "cluster-1", map[string]string{}),
+			CustomObject:  newCustomObject("cluster-1"),
+			CurrentState:  newEncryptionSecret(t, "cluster-1", map[string]string{}),
+			DesiredState:  newEncryptionSecret(t, "cluster-1", map[string]string{}),
 			ExpectedPatch: framework.NewPatch(),
 			ExpectedError: nil,
 		},
 		// Verify currentState type verification error handling
 		{
-			CustomObject:  createCustomObject("cluster-1"),
+			CustomObject:  newCustomObject("cluster-1"),
 			CurrentState:  &v1.Pod{},
-			DesiredState:  createEncryptionSecret(t, "cluster-1", map[string]string{}),
+			DesiredState:  newEncryptionSecret(t, "cluster-1", map[string]string{}),
 			ExpectedPatch: nil,
 			ExpectedError: wrongTypeError,
 		},
 		// Verify desiredState type verification error handling
 		{
-			CustomObject:  createCustomObject("cluster-1"),
+			CustomObject:  newCustomObject("cluster-1"),
 			CurrentState:  nil,
 			DesiredState:  &v1.Pod{},
 			ExpectedPatch: nil,


### PR DESCRIPTION
Basic implementation for encryptionkey NewUpdatePatch(). Refactored
common code from unit tests to common_test.go so it can be shared
between test files.

While there, added missing log line to end of GetDesiredState().