### PR TITLE
Change tests indexing to description and subtest

### DIFF
--- a/service/kvmclusterconfig/v1/key/key_test.go
+++ b/service/kvmclusterconfig/v1/key/key_test.go
@@ -10,18 +10,18 @@ import (
 
 func Test_ClusterID(t *testing.T) {
 	testCases := []struct {
-		Description  string
-		CustomObject v1alpha1.KVMClusterConfig
-		ExpectedID   string
+		description  string
+		customObject v1alpha1.KVMClusterConfig
+		expectedID   string
 	}{
 		{
-			Description:  "empty value KVMClusterConfig produces empty ID",
-			CustomObject: v1alpha1.KVMClusterConfig{},
-			ExpectedID:   "",
+			description:  "empty value KVMClusterConfig produces empty ID",
+			customObject: v1alpha1.KVMClusterConfig{},
+			expectedID:   "",
 		},
 		{
-			Description: "present ID value returned as ClusterID",
-			CustomObject: v1alpha1.KVMClusterConfig{
+			description: "present ID value returned as ClusterID",
+			customObject: v1alpha1.KVMClusterConfig{
 				Spec: v1alpha1.KVMClusterConfigSpec{
 					Guest: v1alpha1.KVMClusterConfigSpecGuest{
 						ClusterGuestConfig: v1alpha1.ClusterGuestConfig{
@@ -30,11 +30,11 @@ func Test_ClusterID(t *testing.T) {
 					},
 				},
 			},
-			ExpectedID: "cluster-1",
+			expectedID: "cluster-1",
 		},
 		{
-			Description: "only present ID value returned as ClusterID",
-			CustomObject: v1alpha1.KVMClusterConfig{
+			description: "only present ID value returned as ClusterID",
+			customObject: v1alpha1.KVMClusterConfig{
 				Spec: v1alpha1.KVMClusterConfigSpec{
 					Guest: v1alpha1.KVMClusterConfigSpecGuest{
 						ClusterGuestConfig: v1alpha1.ClusterGuestConfig{
@@ -44,15 +44,15 @@ func Test_ClusterID(t *testing.T) {
 					},
 				},
 			},
-			ExpectedID: "cluster-123",
+			expectedID: "cluster-123",
 		},
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.Description, func(t *testing.T) {
-			clusterID := ClusterID(tc.CustomObject)
-			if clusterID != tc.ExpectedID {
-				t.Fatalf("ClusterID %s doesn't match. Expected: %s", clusterID, tc.ExpectedID)
+		t.Run(tc.description, func(t *testing.T) {
+			clusterID := ClusterID(tc.customObject)
+			if clusterID != tc.expectedID {
+				t.Fatalf("ClusterID %s doesn't match. expected: %s", clusterID, tc.expectedID)
 			}
 		})
 	}
@@ -60,18 +60,18 @@ func Test_ClusterID(t *testing.T) {
 
 func Test_EncryptionKeySecretName(t *testing.T) {
 	testCases := []struct {
-		Description        string
-		CustomObject       v1alpha1.KVMClusterConfig
-		ExpectedSecretName string
+		description        string
+		customObject       v1alpha1.KVMClusterConfig
+		expectedSecretName string
 	}{
 		{
-			Description:        "empty value KVMClusterConfig returns only static part of secret name",
-			CustomObject:       v1alpha1.KVMClusterConfig{},
-			ExpectedSecretName: "-encryption",
+			description:        "empty value KVMClusterConfig returns only static part of secret name",
+			customObject:       v1alpha1.KVMClusterConfig{},
+			expectedSecretName: "-encryption",
 		},
 		{
-			Description: "composed secret name returned when cluster ID defined in KVMClusterConfig",
-			CustomObject: v1alpha1.KVMClusterConfig{
+			description: "composed secret name returned when cluster ID defined in KVMClusterConfig",
+			customObject: v1alpha1.KVMClusterConfig{
 				Spec: v1alpha1.KVMClusterConfigSpec{
 					Guest: v1alpha1.KVMClusterConfigSpecGuest{
 						ClusterGuestConfig: v1alpha1.ClusterGuestConfig{
@@ -80,11 +80,11 @@ func Test_EncryptionKeySecretName(t *testing.T) {
 					},
 				},
 			},
-			ExpectedSecretName: "cluster-1-encryption",
+			expectedSecretName: "cluster-1-encryption",
 		},
 		{
-			Description: "only cluster ID used to compose secret name",
-			CustomObject: v1alpha1.KVMClusterConfig{
+			description: "only cluster ID used to compose secret name",
+			customObject: v1alpha1.KVMClusterConfig{
 				Spec: v1alpha1.KVMClusterConfigSpec{
 					Guest: v1alpha1.KVMClusterConfigSpecGuest{
 						ClusterGuestConfig: v1alpha1.ClusterGuestConfig{
@@ -94,16 +94,16 @@ func Test_EncryptionKeySecretName(t *testing.T) {
 					},
 				},
 			},
-			ExpectedSecretName: "cluster-123-encryption",
+			expectedSecretName: "cluster-123-encryption",
 		},
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.Description, func(t *testing.T) {
-			encryptionKeySecretName := EncryptionKeySecretName(tc.CustomObject)
-			if encryptionKeySecretName != tc.ExpectedSecretName {
-				t.Fatalf("EncryptionKeySecretName %s doesn't match. Expected: %s",
-					encryptionKeySecretName, tc.ExpectedSecretName)
+		t.Run(tc.description, func(t *testing.T) {
+			encryptionKeySecretName := EncryptionKeySecretName(tc.customObject)
+			if encryptionKeySecretName != tc.expectedSecretName {
+				t.Fatalf("EncryptionKeySecretName %s doesn't match. expected: %s",
+					encryptionKeySecretName, tc.expectedSecretName)
 			}
 		})
 	}
@@ -114,20 +114,20 @@ func Test_ToCustomObject(t *testing.T) {
 	var emptyKVMClusterConfigPtr *v1alpha1.KVMClusterConfig
 
 	testCases := []struct {
-		Description          string
-		InputObject          interface{}
-		ExpectedCustomObject v1alpha1.KVMClusterConfig
-		ExpectedError        error
+		description          string
+		inputObject          interface{}
+		expectedCustomObject v1alpha1.KVMClusterConfig
+		expectedError        error
 	}{
 		{
-			Description:          "reference to empty value KVMClusterConfig returns empty KVMClusterConfig",
-			InputObject:          &v1alpha1.KVMClusterConfig{},
-			ExpectedCustomObject: v1alpha1.KVMClusterConfig{},
-			ExpectedError:        nil,
+			description:          "reference to empty value KVMClusterConfig returns empty KVMClusterConfig",
+			inputObject:          &v1alpha1.KVMClusterConfig{},
+			expectedCustomObject: v1alpha1.KVMClusterConfig{},
+			expectedError:        nil,
 		},
 		{
-			Description: "verify that internal KVMClusterConfig fields are returned as well",
-			InputObject: &v1alpha1.KVMClusterConfig{
+			description: "verify that internal KVMClusterConfig fields are returned as well",
+			inputObject: &v1alpha1.KVMClusterConfig{
 				Spec: v1alpha1.KVMClusterConfigSpec{
 					Guest: v1alpha1.KVMClusterConfigSpecGuest{
 						ClusterGuestConfig: v1alpha1.ClusterGuestConfig{
@@ -137,7 +137,7 @@ func Test_ToCustomObject(t *testing.T) {
 					},
 				},
 			},
-			ExpectedCustomObject: v1alpha1.KVMClusterConfig{
+			expectedCustomObject: v1alpha1.KVMClusterConfig{
 				Spec: v1alpha1.KVMClusterConfigSpec{
 					Guest: v1alpha1.KVMClusterConfigSpecGuest{
 						ClusterGuestConfig: v1alpha1.ClusterGuestConfig{
@@ -147,45 +147,45 @@ func Test_ToCustomObject(t *testing.T) {
 					},
 				},
 			},
-			ExpectedError: nil,
+			expectedError: nil,
 		},
 		{
-			Description:          "nil pointer to KVMClusterConfig must return emptyValueError",
-			InputObject:          emptyKVMClusterConfigPtr,
-			ExpectedCustomObject: v1alpha1.KVMClusterConfig{},
-			ExpectedError:        emptyValueError,
+			description:          "nil pointer to KVMClusterConfig must return emptyValueError",
+			inputObject:          emptyKVMClusterConfigPtr,
+			expectedCustomObject: v1alpha1.KVMClusterConfig{},
+			expectedError:        emptyValueError,
 		},
 		{
-			Description:          "non-pointer value of KVMClusterConfig must return wrontTypeError",
-			InputObject:          v1alpha1.KVMClusterConfig{},
-			ExpectedCustomObject: v1alpha1.KVMClusterConfig{},
-			ExpectedError:        wrongTypeError,
+			description:          "non-pointer value of KVMClusterConfig must return wrontTypeError",
+			inputObject:          v1alpha1.KVMClusterConfig{},
+			expectedCustomObject: v1alpha1.KVMClusterConfig{},
+			expectedError:        wrongTypeError,
 		},
 		{
-			Description:          "wrong type must return wrongTypeError",
-			InputObject:          &v1alpha1.AzureClusterConfig{},
-			ExpectedCustomObject: v1alpha1.KVMClusterConfig{},
-			ExpectedError:        wrongTypeError,
+			description:          "wrong type must return wrongTypeError",
+			inputObject:          &v1alpha1.AzureClusterConfig{},
+			expectedCustomObject: v1alpha1.KVMClusterConfig{},
+			expectedError:        wrongTypeError,
 		},
 		{
-			Description:          "nil interface{} must return wrongTypeError",
-			InputObject:          nil,
-			ExpectedCustomObject: v1alpha1.KVMClusterConfig{},
-			ExpectedError:        wrongTypeError,
+			description:          "nil interface{} must return wrongTypeError",
+			inputObject:          nil,
+			expectedCustomObject: v1alpha1.KVMClusterConfig{},
+			expectedError:        wrongTypeError,
 		},
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.Description, func(t *testing.T) {
-			customObject, err := ToCustomObject(tc.InputObject)
-			if microerror.Cause(err) != tc.ExpectedError {
+		t.Run(tc.description, func(t *testing.T) {
+			customObject, err := ToCustomObject(tc.inputObject)
+			if microerror.Cause(err) != tc.expectedError {
 				t.Errorf("Received error %#v doesn't match expected %#v",
-					err, tc.ExpectedError)
+					err, tc.expectedError)
 			}
 
-			if !reflect.DeepEqual(customObject, tc.ExpectedCustomObject) {
-				t.Fatalf("CustomObject %#v doesn't match expected %#v",
-					customObject, tc.ExpectedCustomObject)
+			if !reflect.DeepEqual(customObject, tc.expectedCustomObject) {
+				t.Fatalf("customObject %#v doesn't match expected %#v",
+					customObject, tc.expectedCustomObject)
 			}
 		})
 	}

--- a/service/kvmclusterconfig/v1/resource/encryptionkey/common_test.go
+++ b/service/kvmclusterconfig/v1/resource/encryptionkey/common_test.go
@@ -51,10 +51,10 @@ func assertSecret(t *testing.T, computedSecret, expectedSecret *v1.Secret) {
 	t.Helper()
 
 	if expectedSecret == nil && computedSecret != nil {
-		t.Errorf("Expected nil secret. Received %#v", computedSecret)
+		t.Errorf("expected nil secret. Received %#v", computedSecret)
 		return
 	} else if expectedSecret != nil && computedSecret == nil {
-		t.Error("Expected non-nil secret. Received nil.")
+		t.Error("expected non-nil secret. Received nil.")
 		return
 	}
 

--- a/service/kvmclusterconfig/v1/resource/encryptionkey/create_test.go
+++ b/service/kvmclusterconfig/v1/resource/encryptionkey/create_test.go
@@ -13,44 +13,44 @@ import (
 
 func Test_newCreateChange(t *testing.T) {
 	testCases := []struct {
-		Description    string
-		CustomObject   *v1alpha1.KVMClusterConfig
-		CurrentState   interface{}
-		DesiredState   interface{}
-		ExpectedSecret *v1.Secret
-		ExpectedError  error
+		description    string
+		customObject   *v1alpha1.KVMClusterConfig
+		currentState   interface{}
+		desiredState   interface{}
+		expectedSecret *v1.Secret
+		expectedError  error
 	}{
 		{
-			Description:    "encryption key secret doesn't exist yet - secret should create it",
-			CustomObject:   newCustomObject("cluster-1"),
-			CurrentState:   nil,
-			DesiredState:   newEncryptionSecret(t, "cluster-1", map[string]string{}),
-			ExpectedSecret: newEncryptionSecret(t, "cluster-1", map[string]string{}),
-			ExpectedError:  nil,
+			description:    "encryption key secret doesn't exist yet - secret should create it",
+			customObject:   newCustomObject("cluster-1"),
+			currentState:   nil,
+			desiredState:   newEncryptionSecret(t, "cluster-1", map[string]string{}),
+			expectedSecret: newEncryptionSecret(t, "cluster-1", map[string]string{}),
+			expectedError:  nil,
 		},
 		{
-			Description:    "encryption key secret already exists - secret must not be created",
-			CustomObject:   newCustomObject("cluster-1"),
-			CurrentState:   newEncryptionSecret(t, "cluster-1", map[string]string{}),
-			DesiredState:   newEncryptionSecret(t, "cluster-1", map[string]string{}),
-			ExpectedSecret: nil,
-			ExpectedError:  nil,
+			description:    "encryption key secret already exists - secret must not be created",
+			customObject:   newCustomObject("cluster-1"),
+			currentState:   newEncryptionSecret(t, "cluster-1", map[string]string{}),
+			desiredState:   newEncryptionSecret(t, "cluster-1", map[string]string{}),
+			expectedSecret: nil,
+			expectedError:  nil,
 		},
 		{
-			Description:    "verify currentState type verification error handling",
-			CustomObject:   newCustomObject("cluster-1"),
-			CurrentState:   &v1.Pod{},
-			DesiredState:   newEncryptionSecret(t, "cluster-1", map[string]string{}),
-			ExpectedSecret: nil,
-			ExpectedError:  wrongTypeError,
+			description:    "verify currentState type verification error handling",
+			customObject:   newCustomObject("cluster-1"),
+			currentState:   &v1.Pod{},
+			desiredState:   newEncryptionSecret(t, "cluster-1", map[string]string{}),
+			expectedSecret: nil,
+			expectedError:  wrongTypeError,
 		},
 		{
-			Description:    "verify desiredState type verification error handling",
-			CustomObject:   newCustomObject("cluster-1"),
-			CurrentState:   nil,
-			DesiredState:   &v1.Pod{},
-			ExpectedSecret: nil,
-			ExpectedError:  wrongTypeError,
+			description:    "verify desiredState type verification error handling",
+			customObject:   newCustomObject("cluster-1"),
+			currentState:   nil,
+			desiredState:   &v1.Pod{},
+			expectedSecret: nil,
+			expectedError:  wrongTypeError,
 		},
 	}
 
@@ -60,18 +60,18 @@ func Test_newCreateChange(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.Description, func(t *testing.T) {
+		t.Run(tc.description, func(t *testing.T) {
 			r, err := New(Config{
 				K8sClient: fake.NewSimpleClientset(),
 				Logger:    logger,
 			})
 
-			secret, err := r.newCreateChange(context.TODO(), tc.CustomObject, tc.CurrentState, tc.DesiredState)
-			if microerror.Cause(err) != tc.ExpectedError {
-				t.Fatalf("Unexpected error returned: %#v, expected %#v", err, tc.ExpectedError)
+			secret, err := r.newCreateChange(context.TODO(), tc.customObject, tc.currentState, tc.desiredState)
+			if microerror.Cause(err) != tc.expectedError {
+				t.Fatalf("Unexpected error returned: %#v, expected %#v", err, tc.expectedError)
 			}
 
-			assertSecret(t, secret, tc.ExpectedSecret)
+			assertSecret(t, secret, tc.expectedSecret)
 		})
 	}
 }

--- a/service/kvmclusterconfig/v1/resource/encryptionkey/current_test.go
+++ b/service/kvmclusterconfig/v1/resource/encryptionkey/current_test.go
@@ -19,15 +19,15 @@ var unknownAPIError = errors.New("Unknown error from k8s API")
 
 func Test_GetCurrentState_Reads_Secrets_For_Relevant_ClusterID(t *testing.T) {
 	testCases := []struct {
+		Description    string
 		CustomObject   *v1alpha1.KVMClusterConfig
 		PresentSecrets []*v1.Secret
 		APIReactors    []k8stesting.Reactor
 		ExpectedSecret *v1.Secret
 		ExpectedError  error
 	}{
-		// Cluster exists: Success case when there are three cluster secrets
-		// present and one of them is correct
 		{
+			Description:  "three clusters exist - return secret for the one where custom object belongs",
 			CustomObject: newCustomObject("cluster-2"),
 			PresentSecrets: []*v1.Secret{
 				newEncryptionSecret(t, "cluster-1", make(map[string]string)),
@@ -38,20 +38,16 @@ func Test_GetCurrentState_Reads_Secrets_For_Relevant_ClusterID(t *testing.T) {
 			ExpectedSecret: newEncryptionSecret(t, "cluster-2", make(map[string]string)),
 			ExpectedError:  nil,
 		},
-
-		// First cluster: Success case when there are no cluster secrets
-		// present but new cluster is about to be created
 		{
+			Description:    "no clusters exist - return empty list of secrets",
 			CustomObject:   newCustomObject("cluster-1"),
 			PresentSecrets: []*v1.Secret{},
 			APIReactors:    []k8stesting.Reactor{},
 			ExpectedSecret: nil,
 			ExpectedError:  nil,
 		},
-
-		// New cluster: Success case when there are three cluster secrets
-		// present but expected secret doesn't exist (yet)
 		{
+			Description:  "three clusters exist - return secrets for them despite custom object referring to new one",
 			CustomObject: newCustomObject("cluster-4"),
 			PresentSecrets: []*v1.Secret{
 				newEncryptionSecret(t, "cluster-1", make(map[string]string)),
@@ -62,9 +58,8 @@ func Test_GetCurrentState_Reads_Secrets_For_Relevant_ClusterID(t *testing.T) {
 			ExpectedSecret: nil,
 			ExpectedError:  nil,
 		},
-
-		// API Error: Kubernetes API client returns unknown error
 		{
+			Description:    "handle unknown error returned from Kubernetes API client",
 			CustomObject:   newCustomObject("cluster-4"),
 			PresentSecrets: []*v1.Secret{},
 			APIReactors: []k8stesting.Reactor{
@@ -80,47 +75,47 @@ func Test_GetCurrentState_Reads_Secrets_For_Relevant_ClusterID(t *testing.T) {
 		t.Fatalf("micrologger.New() failed: %#v", err)
 	}
 
-	for i, tc := range testCases {
-		objs := make([]runtime.Object, 0, len(tc.PresentSecrets))
-		for _, s := range tc.PresentSecrets {
-			objs = append(objs, s)
-		}
+	for _, tc := range testCases {
+		t.Run(tc.Description, func(t *testing.T) {
+			objs := make([]runtime.Object, 0, len(tc.PresentSecrets))
+			for _, s := range tc.PresentSecrets {
+				objs = append(objs, s)
+			}
 
-		client := fake.NewSimpleClientset(objs...)
-		client.ReactionChain = append(tc.APIReactors, client.ReactionChain...)
+			client := fake.NewSimpleClientset(objs...)
+			client.ReactionChain = append(tc.APIReactors, client.ReactionChain...)
 
-		r, err := New(Config{
-			K8sClient: client,
-			Logger:    logger,
+			r, err := New(Config{
+				K8sClient: client,
+				Logger:    logger,
+			})
+
+			if err != nil {
+				t.Fatalf("Resource construction failed: %#v", err)
+			}
+
+			state, err := r.GetCurrentState(context.TODO(), tc.CustomObject)
+			if microerror.Cause(err) != tc.ExpectedError {
+				t.Fatalf("GetCurrentState() returned error %#v - expected: %#v", err, tc.ExpectedError)
+			}
+
+			if state == nil && tc.ExpectedSecret == nil {
+				// Ok
+				return
+			}
+
+			secret, ok := state.(*v1.Secret)
+			if !ok {
+				t.Fatalf("GetCurrentState() returned wrong type %T for current state. Expected %T", state, secret)
+			}
+
+			if tc.ExpectedSecret.Labels[randomkeytpr.ClusterIDLabel] != secret.Labels[randomkeytpr.ClusterIDLabel] {
+				t.Fatalf("Expected secret with cluster ID label %s, found %s",
+					tc.ExpectedSecret.Labels[randomkeytpr.ClusterIDLabel],
+					secret.Labels[randomkeytpr.ClusterIDLabel],
+				)
+			}
 		})
-
-		if err != nil {
-			t.Errorf("TestCase %d: Resource construction failed: %#v", (i + 1), err)
-			continue
-		}
-
-		state, err := r.GetCurrentState(context.TODO(), tc.CustomObject)
-		if microerror.Cause(err) != tc.ExpectedError {
-			t.Errorf("TestCase %d: GetCurrentState() returned error %#v - expected: %#v", (i + 1), err, tc.ExpectedError)
-			continue
-		}
-
-		if state == nil && tc.ExpectedSecret == nil {
-			continue
-		}
-
-		secret, ok := state.(*v1.Secret)
-		if !ok {
-			t.Errorf("TestCase %d: GetCurrentState() returned wrong type %T for current state. Expected %T", (i + 1), state, secret)
-			continue
-		}
-
-		if tc.ExpectedSecret.Labels[randomkeytpr.ClusterIDLabel] != secret.Labels[randomkeytpr.ClusterIDLabel] {
-			t.Errorf("TestCase %d: Expected secret with cluster ID label %s, found %s",
-				(i + 1), tc.ExpectedSecret.Labels[randomkeytpr.ClusterIDLabel],
-				secret.Labels[randomkeytpr.ClusterIDLabel],
-			)
-		}
 	}
 }
 

--- a/service/kvmclusterconfig/v1/resource/encryptionkey/update_test.go
+++ b/service/kvmclusterconfig/v1/resource/encryptionkey/update_test.go
@@ -13,28 +13,28 @@ import (
 
 func Test_newUpdateChange_Does_Not_Return_Change(t *testing.T) {
 	testCases := []struct {
-		Description    string
-		CustomObject   *v1alpha1.KVMClusterConfig
-		CurrentState   interface{}
-		DesiredState   interface{}
-		ExpectedSecret *v1.Secret
-		ExpectedError  error
+		description    string
+		customObject   *v1alpha1.KVMClusterConfig
+		currentState   interface{}
+		desiredState   interface{}
+		expectedSecret *v1.Secret
+		expectedError  error
 	}{
 		{
-			Description:    "encryption key secret doesn't exist yet - no updates must be created",
-			CustomObject:   newCustomObject("cluster-1"),
-			CurrentState:   nil,
-			DesiredState:   newEncryptionSecret(t, "cluster-1", map[string]string{}),
-			ExpectedSecret: nil,
-			ExpectedError:  nil,
+			description:    "encryption key secret doesn't exist yet - no updates must be created",
+			customObject:   newCustomObject("cluster-1"),
+			currentState:   nil,
+			desiredState:   newEncryptionSecret(t, "cluster-1", map[string]string{}),
+			expectedSecret: nil,
+			expectedError:  nil,
 		},
 		{
-			Description:    "encryption key secret already exists - no updates must be created",
-			CustomObject:   newCustomObject("cluster-1"),
-			CurrentState:   newEncryptionSecret(t, "cluster-1", map[string]string{}),
-			DesiredState:   newEncryptionSecret(t, "cluster-1", map[string]string{}),
-			ExpectedSecret: nil,
-			ExpectedError:  nil,
+			description:    "encryption key secret already exists - no updates must be created",
+			customObject:   newCustomObject("cluster-1"),
+			currentState:   newEncryptionSecret(t, "cluster-1", map[string]string{}),
+			desiredState:   newEncryptionSecret(t, "cluster-1", map[string]string{}),
+			expectedSecret: nil,
+			expectedError:  nil,
 		},
 	}
 
@@ -44,18 +44,18 @@ func Test_newUpdateChange_Does_Not_Return_Change(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.Description, func(t *testing.T) {
+		t.Run(tc.description, func(t *testing.T) {
 			r, err := New(Config{
 				K8sClient: fake.NewSimpleClientset(),
 				Logger:    logger,
 			})
 
-			secret, err := r.newUpdateChange(context.TODO(), tc.CustomObject, tc.CurrentState, tc.DesiredState)
-			if microerror.Cause(err) != tc.ExpectedError {
-				t.Fatalf("Unexpected error returned: %#v, expected %#v", err, tc.ExpectedError)
+			secret, err := r.newUpdateChange(context.TODO(), tc.customObject, tc.currentState, tc.desiredState)
+			if microerror.Cause(err) != tc.expectedError {
+				t.Fatalf("Unexpected error returned: %#v, expected %#v", err, tc.expectedError)
 			}
 
-			assertSecret(t, secret, tc.ExpectedSecret)
+			assertSecret(t, secret, tc.expectedSecret)
 		})
 	}
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -10,20 +10,20 @@ import (
 )
 
 func Test_Service_New(t *testing.T) {
-	tests := []struct {
+	testCases := []struct {
+		description          string
 		config               func() Config
 		expectedErrorHandler func(error) bool
 	}{
-		// Test that the default config is invalid.
 		{
+			description: "empty value config must return invalidConfigError",
 			config: func() Config {
 				return Config{}
 			},
 			expectedErrorHandler: IsInvalidConfig,
 		},
-
-		// Test a production-like config is valid.
 		{
+			description: "production-like config must be valid",
 			config: func() Config {
 				config := Config{}
 
@@ -46,16 +46,18 @@ func Test_Service_New(t *testing.T) {
 		},
 	}
 
-	for index, test := range tests {
-		_, err := New(test.config())
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			_, err := New(tc.config())
 
-		if err != nil {
-			if test.expectedErrorHandler == nil {
-				t.Fatalf("%v: unexpected error returned: %#v", index, err)
+			if err != nil {
+				if tc.expectedErrorHandler == nil {
+					t.Fatalf("unexpected error returned: %#v", err)
+				}
+				if !tc.expectedErrorHandler(err) {
+					t.Fatalf("incorrect error returned: %#v", err)
+				}
 			}
-			if !test.expectedErrorHandler(err) {
-				t.Fatalf("%v: incorrect error returned: %#v", index, err)
-			}
-		}
+		})
 	}
 }


### PR DESCRIPTION
As discussed in another PR, this refactoring changes use of sub test case identification from slice index to description field. This version also uses `t.Run(description, func(t *testing.T) { ...testcase.. }` for executing sub-test.

While there, I decided to also change test case struct fields private because I think this is more in line with other projects.