### PR TITLE
Add newDeleteChangeForUpdatePatch() for resource cleanup

### DIFF
--- a/pkg/resource/v1/certconfig/delete.go
+++ b/pkg/resource/v1/certconfig/delete.go
@@ -19,7 +19,7 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 // analyses the current and desired state and returns the patch to be applied by
 // Create, Update and Delete functions.
 func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
-	delete, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	delete, err := r.newDeleteChangeForDeletePatch(ctx, obj, currentState, desiredState)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -30,7 +30,7 @@ func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desire
 	return patch, nil
 }
 
-func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) ([]*v1alpha1.CertConfig, error) {
+func (r *Resource) newDeleteChangeForDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) ([]*v1alpha1.CertConfig, error) {
 	currentCertConfigs, err := toCertConfigs(currentState)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -41,4 +41,30 @@ func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desir
 	r.logger.LogCtx(ctx, "debug", fmt.Sprintf("found %d certconfigs that have to be deleted", len(currentCertConfigs)))
 
 	return currentCertConfigs, nil
+}
+
+func (r *Resource) newDeleteChangeForUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) ([]*v1alpha1.CertConfig, error) {
+	currentCertConfigs, err := toCertConfigs(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredCertConfigs, err := toCertConfigs(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "debug", "finding out which certconfigs have to be deleted")
+
+	var certConfigsToDelete []*v1alpha1.CertConfig
+	for _, currentCertConfig := range currentCertConfigs {
+		_, err := getCertConfigByName(desiredCertConfigs, currentCertConfig.Name)
+		// Existing CertConfig is not desired anymore so it should be deleted.
+		if IsNotFound(err) {
+			certConfigsToDelete = append(certConfigsToDelete, currentCertConfig)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "debug", fmt.Sprintf("found %d certconfigs that have to be deleted", len(certConfigsToDelete)))
+
+	return certConfigsToDelete, nil
 }

--- a/pkg/resource/v1/certconfig/delete_test.go
+++ b/pkg/resource/v1/certconfig/delete_test.go
@@ -12,7 +12,7 @@ import (
 	clientgofake "k8s.io/client-go/kubernetes/fake"
 )
 
-func Test_newDeleteChange_Deletes_Existing_CertConfigs(t *testing.T) {
+func Test_newDeleteChangeForDeletePatch_Deletes_Existing_CertConfigs(t *testing.T) {
 	testCases := []struct {
 		name                string
 		clusterGuestConfig  *v1alpha1.ClusterGuestConfig
@@ -50,7 +50,7 @@ func Test_newDeleteChange_Deletes_Existing_CertConfigs(t *testing.T) {
 			errorMatcher: nil,
 		},
 		{
-			name: "case 2: Some of desired certconfigs but not all",
+			name: "case 2: Some of desired certconfigs exist but not all",
 			clusterGuestConfig: &v1alpha1.ClusterGuestConfig{
 				ID: "cluster-1",
 			},
@@ -117,7 +117,7 @@ func Test_newDeleteChange_Deletes_Existing_CertConfigs(t *testing.T) {
 				t.Fatalf("Resource construction failed: %#v", err)
 			}
 
-			certConfigs, err := r.newDeleteChange(context.TODO(), tt.clusterGuestConfig, tt.currentState, tt.desiredState)
+			certConfigs, err := r.newDeleteChangeForDeletePatch(context.TODO(), tt.clusterGuestConfig, tt.currentState, tt.desiredState)
 
 			switch {
 			case err == nil && tt.errorMatcher == nil: // correct; carry on
@@ -139,9 +139,9 @@ func Test_newDeleteChange_Deletes_Existing_CertConfigs(t *testing.T) {
 				for i := 0; i < len(certConfigs); i++ {
 					if reflect.DeepEqual(certConfigs[i], c) {
 						// When matching certconfig is found, remove from list
-						// returned by newDeleteChange(). When all expected
-						// certconfigs are iterated, returned list must be
-						// empty.
+						// returned by newDeleteChangeForDeletePatch(). When
+						// all expected certconfigs are iterated, returned list
+						// must be empty.
 						certConfigs = append(certConfigs[:i], certConfigs[i+1:]...)
 						found = true
 						break
@@ -149,7 +149,179 @@ func Test_newDeleteChange_Deletes_Existing_CertConfigs(t *testing.T) {
 				}
 
 				if !found {
-					t.Fatalf("%#v not found in certConfigs returned by newDeleteChange", c)
+					t.Fatalf("%#v not found in certConfigs returned by newDeleteChangeForDeletePatch", c)
+				}
+			}
+
+			// Verify that there aren't any unexpected extra certconfigs going
+			// to be deleted.
+			if len(certConfigs) > 0 {
+				for _, c := range certConfigs {
+					t.Errorf("unwanted certconfig present: %#v", c)
+				}
+			}
+		})
+	}
+}
+
+func Test_newDeleteChangeForUpdatePatch_Deletes_Existing_CertConfigs_That_Are_Not_Desired(t *testing.T) {
+	testCases := []struct {
+		name                string
+		clusterGuestConfig  *v1alpha1.ClusterGuestConfig
+		currentState        interface{}
+		desiredState        interface{}
+		expectedCertConfigs []*v1alpha1.CertConfig
+		errorMatcher        func(error) bool
+	}{
+		{
+			name: "case 0: No certconfigs exist, single certconfig desired",
+			clusterGuestConfig: &v1alpha1.ClusterGuestConfig{
+				ID: "cluster-1",
+			},
+			currentState: nil,
+			desiredState: []*v1alpha1.CertConfig{
+				newCertConfig("cluster-1", certs.APICert),
+			},
+			expectedCertConfigs: []*v1alpha1.CertConfig{},
+			errorMatcher:        nil,
+		},
+		{
+			name: "case 1: One certconfig exists and it's the same as desired one",
+			clusterGuestConfig: &v1alpha1.ClusterGuestConfig{
+				ID: "cluster-1",
+			},
+			currentState: []*v1alpha1.CertConfig{
+				newCertConfig("cluster-1", certs.APICert),
+			},
+			desiredState: []*v1alpha1.CertConfig{
+				newCertConfig("cluster-1", certs.APICert),
+			},
+			expectedCertConfigs: []*v1alpha1.CertConfig{},
+			errorMatcher:        nil,
+		},
+		{
+			name: "case 2: Some of desired certconfigs exist but not all, there are also some leftovers from earlier implementation",
+			clusterGuestConfig: &v1alpha1.ClusterGuestConfig{
+				ID: "cluster-1",
+			},
+			currentState: []*v1alpha1.CertConfig{
+				newCertConfig("cluster-1", certs.APICert),
+				newCertConfig("cluster-1", certs.CalicoCert),
+				newCertConfig("cluster-1", certs.EtcdCert),
+				newCertConfig("cluster-1", "legacy-cert-1"),
+				newCertConfig("cluster-1", "legacy-cert-2"),
+				newCertConfig("cluster-1", "not needed anymore"),
+				newCertConfig("cluster-1", certs.FlanneldCert),
+			},
+			desiredState: []*v1alpha1.CertConfig{
+				newCertConfig("cluster-1", certs.APICert),
+				newCertConfig("cluster-1", certs.CalicoCert),
+				newCertConfig("cluster-1", certs.EtcdCert),
+				newCertConfig("cluster-1", certs.FlanneldCert),
+				newCertConfig("cluster-1", certs.NodeOperatorCert),
+				newCertConfig("cluster-1", certs.PrometheusCert),
+				newCertConfig("cluster-1", certs.ServiceAccountCert),
+				newCertConfig("cluster-1", certs.WorkerCert),
+			},
+			expectedCertConfigs: []*v1alpha1.CertConfig{
+				newCertConfig("cluster-1", "legacy-cert-1"),
+				newCertConfig("cluster-1", "legacy-cert-2"),
+				newCertConfig("cluster-1", "not needed anymore"),
+			},
+			errorMatcher: nil,
+		},
+		{
+			name: "case 3: currentState is wrong type",
+			clusterGuestConfig: &v1alpha1.ClusterGuestConfig{
+				ID: "cluster-1",
+			},
+			currentState: []string{
+				"foo",
+				"bar",
+				"baz",
+			},
+			desiredState: []*v1alpha1.CertConfig{
+				newCertConfig("cluster-1", certs.APICert),
+				newCertConfig("cluster-1", certs.CalicoCert),
+				newCertConfig("cluster-1", certs.EtcdCert),
+			},
+			expectedCertConfigs: []*v1alpha1.CertConfig{},
+			errorMatcher:        IsWrongType,
+		},
+		{
+			name: "case 4: desiredState is wrong type",
+			clusterGuestConfig: &v1alpha1.ClusterGuestConfig{
+				ID: "cluster-1",
+			},
+			currentState: []*v1alpha1.CertConfig{
+				newCertConfig("cluster-1", certs.APICert),
+				newCertConfig("cluster-1", certs.CalicoCert),
+				newCertConfig("cluster-1", certs.EtcdCert),
+			},
+			desiredState: []string{
+				"foo",
+				"bar",
+				"baz",
+			},
+			expectedCertConfigs: []*v1alpha1.CertConfig{},
+			errorMatcher:        IsWrongType,
+		},
+	}
+
+	logger, err := micrologger.New(micrologger.DefaultConfig())
+	if err != nil {
+		t.Fatalf("micrologger.New() failed: %#v", err)
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			r, err := New(Config{
+				G8sClient:   fake.NewSimpleClientset(),
+				K8sClient:   clientgofake.NewSimpleClientset(),
+				Logger:      logger,
+				ProjectName: "cluster-operator",
+				ToClusterGuestConfigFunc: func(v interface{}) (*v1alpha1.ClusterGuestConfig, error) {
+					return v.(*v1alpha1.ClusterGuestConfig), nil
+				},
+			})
+
+			if err != nil {
+				t.Fatalf("Resource construction failed: %#v", err)
+			}
+
+			certConfigs, err := r.newDeleteChangeForUpdatePatch(context.TODO(), tt.clusterGuestConfig, tt.currentState, tt.desiredState)
+
+			switch {
+			case err == nil && tt.errorMatcher == nil: // correct; carry on
+			case err != nil && tt.errorMatcher != nil:
+				if !tt.errorMatcher(err) {
+					t.Fatalf("error == %#v, want matching", err)
+				}
+			case err != nil && tt.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tt.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			}
+
+			// Verify that certconfigs that are expected to be deleted, are the
+			// only ones in the returned list of certconfigs that are to be
+			// updated.  Order doesn't matter here.
+			for _, c := range tt.expectedCertConfigs {
+				found := false
+				for i := 0; i < len(certConfigs); i++ {
+					if reflect.DeepEqual(certConfigs[i], c) {
+						// When matching certconfig is found, remove from list
+						// returned by newDeleteChangeForUpdatePatch(). When
+						// all expected certconfigs are iterated, returned list
+						// must be empty.
+						certConfigs = append(certConfigs[:i], certConfigs[i+1:]...)
+						found = true
+						break
+					}
+				}
+
+				if !found {
+					t.Fatalf("%#v not found in certConfigs returned by newDeleteChangeForUpdatePatch", c)
 				}
 			}
 


### PR DESCRIPTION
When there are changes in GetDesiredState(), it is possible that there
are resources in existing environments that are not desired anymore.
Undesired resources should be delete so that they don't cause
distraction for engineers when investigating system state.