### PR TITLE
Change logging to separate level and message

### DIFF
--- a/pkg/resource/v1/certconfig/create.go
+++ b/pkg/resource/v1/certconfig/create.go
@@ -20,7 +20,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 	}
 
 	if len(certConfigsToCreate) > 0 {
-		r.logger.LogCtx(ctx, "debug", "creating certconfigs")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating certconfigs")
 
 		for _, certConfigToCreate := range certConfigsToCreate {
 			_, err = r.g8sClient.CoreV1alpha1().CertConfigs(v1.NamespaceDefault).Create(certConfigToCreate)
@@ -31,9 +31,9 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 			}
 		}
 
-		r.logger.LogCtx(ctx, "debug", "created certconfigs")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "created certconfigs")
 	} else {
-		r.logger.LogCtx(ctx, "debug", "no need to create certconfigs")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "no need to create certconfigs")
 	}
 
 	return nil
@@ -49,7 +49,7 @@ func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desir
 		return nil, microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "debug", "finding out which certconfigs have to be created")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out which certconfigs have to be created")
 
 	var certConfigsToCreate []*v1alpha1.CertConfig
 
@@ -59,7 +59,7 @@ func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desir
 		}
 	}
 
-	r.logger.LogCtx(ctx, "debug", fmt.Sprintf("found %d certconfigs that have to be created", len(certConfigsToCreate)))
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d certconfigs that have to be created", len(certConfigsToCreate)))
 
 	return certConfigsToCreate, nil
 }

--- a/pkg/resource/v1/certconfig/current.go
+++ b/pkg/resource/v1/certconfig/current.go
@@ -21,7 +21,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "debug", "looking for a list of certconfigs in the Kubernetes API")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for a list of certconfigs in the Kubernetes API")
 
 	var certConfigs []*v1alpha1.CertConfig
 	{
@@ -62,7 +62,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		}
 	}
 
-	r.logger.LogCtx(ctx, "debug", fmt.Sprintf("found a list of %d certconfigs in the Kubernetes API", len(certConfigs)))
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found a list of %d certconfigs in the Kubernetes API", len(certConfigs)))
 
 	return certConfigs, nil
 }

--- a/pkg/resource/v1/certconfig/delete.go
+++ b/pkg/resource/v1/certconfig/delete.go
@@ -36,9 +36,9 @@ func (r *Resource) newDeleteChangeForDeletePatch(ctx context.Context, obj, curre
 		return nil, microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "debug", "finding out which certconfigs have to be deleted")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out which certconfigs have to be deleted")
 
-	r.logger.LogCtx(ctx, "debug", fmt.Sprintf("found %d certconfigs that have to be deleted", len(currentCertConfigs)))
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d certconfigs that have to be deleted", len(currentCertConfigs)))
 
 	return currentCertConfigs, nil
 }
@@ -53,7 +53,7 @@ func (r *Resource) newDeleteChangeForUpdatePatch(ctx context.Context, obj, curre
 		return nil, microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "debug", "finding out which certconfigs have to be deleted")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out which certconfigs have to be deleted")
 
 	var certConfigsToDelete []*v1alpha1.CertConfig
 	for _, currentCertConfig := range currentCertConfigs {
@@ -64,7 +64,7 @@ func (r *Resource) newDeleteChangeForUpdatePatch(ctx context.Context, obj, curre
 		}
 	}
 
-	r.logger.LogCtx(ctx, "debug", fmt.Sprintf("found %d certconfigs that have to be deleted", len(certConfigsToDelete)))
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d certconfigs that have to be deleted", len(certConfigsToDelete)))
 
 	return certConfigsToDelete, nil
 }

--- a/pkg/resource/v1/certconfig/update.go
+++ b/pkg/resource/v1/certconfig/update.go
@@ -47,7 +47,7 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 		return nil, microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "debug", "finding out which certconfigs have to be updated")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out which certconfigs have to be updated")
 
 	var certConfigsToUpdate []*v1alpha1.CertConfig
 	for _, currentCertConfig := range currentCertConfigs {
@@ -60,10 +60,10 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 		}
 
 		if isCertConfigModified(desiredCertConfig, currentCertConfig) {
-			r.logger.LogCtx(ctx, "debug", fmt.Sprintf("found certconfig '%s' that has to be updated", desiredCertConfig.GetName()))
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found certconfig '%s' that has to be updated", desiredCertConfig.GetName()))
 			certConfigsToUpdate = append(certConfigsToUpdate, desiredCertConfig)
 		} else {
-			r.logger.LogCtx(ctx, "debug", fmt.Sprintf("not updating certconfig '%s': no changes found", currentCertConfig.GetName()))
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not updating certconfig '%s': no changes found", currentCertConfig.GetName()))
 		}
 	}
 

--- a/service/kvmclusterconfig/v1/resource/encryptionkey/create.go
+++ b/service/kvmclusterconfig/v1/resource/encryptionkey/create.go
@@ -16,7 +16,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		return microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "debug", "creating encryptionkey secret")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "creating encryptionkey secret")
 
 	if secret != nil {
 		_, err = r.k8sClient.Core().Secrets(v1.NamespaceDefault).Create(secret)
@@ -24,9 +24,9 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 			err = microerror.Mask(err)
 		}
 
-		r.logger.LogCtx(ctx, "debug", "creating encryptionkey secret: created")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating encryptionkey secret: created")
 	} else {
-		r.logger.LogCtx(ctx, "debug", "creating encryptionkey secret: already created")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating encryptionkey secret: already created")
 	}
 
 	return err
@@ -42,14 +42,14 @@ func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desir
 		return nil, microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "debug", "finding out if the secret has to be created")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the secret has to be created")
 
 	var secretToCreate *v1.Secret
 	if currentSecret == nil {
 		secretToCreate = desiredSecret
 	}
 
-	r.logger.LogCtx(ctx, "debug", "found out if the secret has to be created")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "found out if the secret has to be created")
 
 	return secretToCreate, nil
 }

--- a/service/kvmclusterconfig/v1/resource/encryptionkey/current.go
+++ b/service/kvmclusterconfig/v1/resource/encryptionkey/current.go
@@ -22,18 +22,18 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 
 	secretName := key.EncryptionKeySecretName(customObject)
 
-	r.logger.LogCtx(ctx, "debug", "looking for encryptionkey secret in the Kubernetes API", "secretName", secretName)
+	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for encryptionkey secret in the Kubernetes API", "secretName", secretName)
 
 	secret, err := r.k8sClient.Core().Secrets(v1.NamespaceDefault).Get(secretName, apismetav1.GetOptions{})
 
 	if apierrors.IsNotFound(err) {
-		r.logger.LogCtx(ctx, "debug", "did not find a secret for encryptionkey in the Kubernetes API", "secretName", secretName)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "did not find a secret for encryptionkey in the Kubernetes API", "secretName", secretName)
 		return nil, nil
 	} else if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "debug", "found a secret for encryptionkey in the Kubernetes API", "secretName", secretName)
+	r.logger.LogCtx(ctx, "level", "debug", "message", "found a secret for encryptionkey in the Kubernetes API", "secretName", secretName)
 
 	return secret, nil
 }

--- a/service/kvmclusterconfig/v1/resource/encryptionkey/delete.go
+++ b/service/kvmclusterconfig/v1/resource/encryptionkey/delete.go
@@ -18,7 +18,7 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 		return microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "debug", "deleting encryptionkey secret")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "deleting encryptionkey secret")
 
 	if secret != nil {
 		err = r.k8sClient.Core().Secrets(v1.NamespaceDefault).Delete(secret.Name, &metav1.DeleteOptions{})
@@ -26,9 +26,9 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 			err = microerror.Mask(err)
 		}
 
-		r.logger.LogCtx(ctx, "debug", "deleting encryptionkey secret: deleted")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting encryptionkey secret: deleted")
 	} else {
-		r.logger.LogCtx(ctx, "debug", "deleting encryptionkey secret: already deleted")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting encryptionkey secret: already deleted")
 	}
 
 	return err

--- a/service/kvmclusterconfig/v1/resource/encryptionkey/desired.go
+++ b/service/kvmclusterconfig/v1/resource/encryptionkey/desired.go
@@ -26,7 +26,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "debug", "computing desired encryption key secret")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "computing desired encryption key secret")
 	secretName := key.EncryptionKeySecretName(customObject)
 
 	keyBytes, err := newRandomKey(AESCBCKeyLength)
@@ -48,7 +48,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		},
 	}
 
-	r.logger.LogCtx(ctx, "debug", "computed desired encryption key secret")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "computed desired encryption key secret")
 
 	return secret, nil
 }

--- a/service/service.go
+++ b/service/service.go
@@ -37,7 +37,7 @@ func New(config Config) (*Service, error) {
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
 	}
-	config.Logger.Log("debug", fmt.Sprintf("creating cluster-operator gitCommit:%s", config.GitCommit))
+	config.Logger.Log("level", "debug", "message", fmt.Sprintf("creating cluster-operator gitCommit:%s", config.GitCommit))
 
 	if config.Flag == nil {
 		return nil, microerror.Maskf(invalidConfigError, "config.Flag must not be empty")


### PR DESCRIPTION
Earlier logging key-pair was (level, msg). This change separates these
to be e.g. [("level", "debug"), ("message", "This is an example
message.")]. This makes it easier to filter based on logging level or
message.