### PR TITLE
Add chartconfig resource

### DIFF
--- a/pkg/resource/v1/chartconfig/create.go
+++ b/pkg/resource/v1/chartconfig/create.go
@@ -1,0 +1,9 @@
+package chartconfig
+
+import (
+	"context"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	return nil
+}

--- a/pkg/resource/v1/chartconfig/current.go
+++ b/pkg/resource/v1/chartconfig/current.go
@@ -1,0 +1,9 @@
+package chartconfig
+
+import (
+	"context"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/pkg/resource/v1/chartconfig/delete.go
+++ b/pkg/resource/v1/chartconfig/delete.go
@@ -1,0 +1,15 @@
+package chartconfig
+
+import (
+	"context"
+
+	"github.com/giantswarm/operatorkit/framework"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
+	return nil, nil
+}

--- a/pkg/resource/v1/chartconfig/desired.go
+++ b/pkg/resource/v1/chartconfig/desired.go
@@ -1,0 +1,9 @@
+package chartconfig
+
+import (
+	"context"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/pkg/resource/v1/chartconfig/error.go
+++ b/pkg/resource/v1/chartconfig/error.go
@@ -1,0 +1,10 @@
+package chartconfig
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/pkg/resource/v1/chartconfig/resource.go
+++ b/pkg/resource/v1/chartconfig/resource.go
@@ -1,0 +1,66 @@
+package chartconfig
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/cluster-operator/pkg/cluster"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "chartconfigv1"
+)
+
+// Config represents the configuration used to create a new chart config resource.
+type Config struct {
+	BaseClusterConfig *cluster.Config
+	G8sClient         versioned.Interface
+	K8sClient         kubernetes.Interface
+	Logger            micrologger.Logger
+	ProjectName       string
+}
+
+// Resource implements the chart config resource.
+type Resource struct {
+	baseClusterConfig *cluster.Config
+	g8sClient         versioned.Interface
+	k8sClient         kubernetes.Interface
+	logger            micrologger.Logger
+	projectName       string
+}
+
+// New creates a new configured chart config resource.
+func New(config Config) (*Resource, error) {
+	if config.BaseClusterConfig == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.BaseClusterConfig must not be empty")
+	}
+	if config.G8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
+	}
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.ProjectName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ProjectName must not be empty", config)
+	}
+
+	newResource := &Resource{
+		baseClusterConfig: config.BaseClusterConfig,
+		g8sClient:         config.G8sClient,
+		k8sClient:         config.K8sClient,
+		logger:            config.Logger,
+		projectName:       config.ProjectName,
+	}
+
+	return newResource, nil
+}
+
+// Name returns name of the Resource.
+func (r *Resource) Name() string {
+	return Name
+}

--- a/pkg/resource/v1/chartconfig/resource.go
+++ b/pkg/resource/v1/chartconfig/resource.go
@@ -2,7 +2,6 @@ package chartconfig
 
 import (
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
-	"github.com/giantswarm/cluster-operator/pkg/cluster"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"k8s.io/client-go/kubernetes"
@@ -15,27 +14,22 @@ const (
 
 // Config represents the configuration used to create a new chart config resource.
 type Config struct {
-	BaseClusterConfig *cluster.Config
-	G8sClient         versioned.Interface
-	K8sClient         kubernetes.Interface
-	Logger            micrologger.Logger
-	ProjectName       string
+	G8sClient   versioned.Interface
+	K8sClient   kubernetes.Interface
+	Logger      micrologger.Logger
+	ProjectName string
 }
 
 // Resource implements the chart config resource.
 type Resource struct {
-	baseClusterConfig *cluster.Config
-	g8sClient         versioned.Interface
-	k8sClient         kubernetes.Interface
-	logger            micrologger.Logger
-	projectName       string
+	g8sClient   versioned.Interface
+	k8sClient   kubernetes.Interface
+	logger      micrologger.Logger
+	projectName string
 }
 
 // New creates a new configured chart config resource.
 func New(config Config) (*Resource, error) {
-	if config.BaseClusterConfig == nil {
-		return nil, microerror.Maskf(invalidConfigError, "config.BaseClusterConfig must not be empty")
-	}
 	if config.G8sClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
 	}
@@ -50,11 +44,10 @@ func New(config Config) (*Resource, error) {
 	}
 
 	newResource := &Resource{
-		baseClusterConfig: config.BaseClusterConfig,
-		g8sClient:         config.G8sClient,
-		k8sClient:         config.K8sClient,
-		logger:            config.Logger,
-		projectName:       config.ProjectName,
+		g8sClient:   config.G8sClient,
+		k8sClient:   config.K8sClient,
+		logger:      config.Logger,
+		projectName: config.ProjectName,
 	}
 
 	return newResource, nil

--- a/pkg/resource/v1/chartconfig/update.go
+++ b/pkg/resource/v1/chartconfig/update.go
@@ -1,0 +1,15 @@
+package chartconfig
+
+import (
+	"context"
+
+	"github.com/giantswarm/operatorkit/framework"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
+	return nil, nil
+}


### PR DESCRIPTION
Towards giantswarm/giantswarm#1902

Nothing fancy just adds the `chartconfig` resource structure. This will be used to create the chartconfig CR for chart-operator in the guest cluster. Later we will add more chartconfig CRs as we migrate components from k8scloudconfig.