### PR TITLE
Use value instead of pointer for cluster config passing

### DIFF
--- a/pkg/resource/v1/certconfig/common_test.go
+++ b/pkg/resource/v1/certconfig/common_test.go
@@ -2,6 +2,7 @@ package certconfig
 
 import (
 	"errors"
+	"net"
 	"testing"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
@@ -12,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	k8stesting "k8s.io/client-go/testing"
 
+	"github.com/giantswarm/cluster-operator/pkg/cluster"
 	"github.com/giantswarm/cluster-operator/pkg/label"
 	"github.com/giantswarm/cluster-operator/pkg/resource/v1/key"
 )
@@ -55,6 +57,15 @@ func newCertConfigWithVersion(clusterID string, cert certs.Cert, version string)
 			VersionBundle: v1alpha1.CertConfigSpecVersionBundle{
 				Version: version,
 			},
+		},
+	}
+}
+
+func newClusterConfig() cluster.Config {
+	return cluster.Config{
+		CertTTL: "",
+		IP: cluster.IP{
+			Range: net.IPv4(172, 31, 0, 0),
 		},
 	}
 }

--- a/pkg/resource/v1/certconfig/create_test.go
+++ b/pkg/resource/v1/certconfig/create_test.go
@@ -13,7 +13,6 @@ import (
 	clientgofake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 
-	"github.com/giantswarm/cluster-operator/pkg/cluster"
 	"github.com/giantswarm/cluster-operator/pkg/resource/v1/key"
 )
 
@@ -47,13 +46,13 @@ func Test_ApplyCreateChange_Creates_createChange(t *testing.T) {
 	}, client.ReactionChain...)
 
 	r, err := New(Config{
-		BaseClusterConfig: &cluster.Config{},
+		BaseClusterConfig: newClusterConfig(),
 		G8sClient:         client,
 		K8sClient:         clientgofake.NewSimpleClientset(),
 		Logger:            logger,
 		ProjectName:       "cluster-operator",
-		ToClusterGuestConfigFunc: func(v interface{}) (*v1alpha1.ClusterGuestConfig, error) {
-			return v.(*v1alpha1.ClusterGuestConfig), nil
+		ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
+			return v.(v1alpha1.ClusterGuestConfig), nil
 		},
 	})
 
@@ -93,13 +92,13 @@ func Test_ApplyCreateChange_Does_Not_Make_API_Call_With_Empty_CreateChange(t *te
 	}, client.ReactionChain...)
 
 	r, err := New(Config{
-		BaseClusterConfig: &cluster.Config{},
+		BaseClusterConfig: newClusterConfig(),
 		G8sClient:         client,
 		K8sClient:         clientgofake.NewSimpleClientset(),
 		Logger:            logger,
 		ProjectName:       "cluster-operator",
-		ToClusterGuestConfigFunc: func(v interface{}) (*v1alpha1.ClusterGuestConfig, error) {
-			return v.(*v1alpha1.ClusterGuestConfig), nil
+		ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
+			return v.(v1alpha1.ClusterGuestConfig), nil
 		},
 	})
 
@@ -133,13 +132,13 @@ func Test_ApplyCreateChange_Handles_K8S_API_Error(t *testing.T) {
 	}, client.ReactionChain...)
 
 	r, err := New(Config{
-		BaseClusterConfig: &cluster.Config{},
+		BaseClusterConfig: newClusterConfig(),
 		G8sClient:         client,
 		K8sClient:         clientgofake.NewSimpleClientset(),
 		Logger:            logger,
 		ProjectName:       "cluster-operator",
-		ToClusterGuestConfigFunc: func(v interface{}) (*v1alpha1.ClusterGuestConfig, error) {
-			return v.(*v1alpha1.ClusterGuestConfig), nil
+		ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
+			return v.(v1alpha1.ClusterGuestConfig), nil
 		},
 	})
 
@@ -156,7 +155,7 @@ func Test_ApplyCreateChange_Handles_K8S_API_Error(t *testing.T) {
 func Test_newCreateChange(t *testing.T) {
 	testCases := []struct {
 		name                string
-		clusterGuestConfig  *v1alpha1.ClusterGuestConfig
+		clusterGuestConfig  v1alpha1.ClusterGuestConfig
 		currentState        interface{}
 		desiredState        interface{}
 		expectedCertConfigs []*v1alpha1.CertConfig
@@ -164,7 +163,7 @@ func Test_newCreateChange(t *testing.T) {
 	}{
 		{
 			name: "case 0: No certconfigs exist, single certconfig desired",
-			clusterGuestConfig: &v1alpha1.ClusterGuestConfig{
+			clusterGuestConfig: v1alpha1.ClusterGuestConfig{
 				ID: "cluster-1",
 			},
 			currentState: nil,
@@ -178,7 +177,7 @@ func Test_newCreateChange(t *testing.T) {
 		},
 		{
 			name: "case 1: One certconfig exists and it's the desired one",
-			clusterGuestConfig: &v1alpha1.ClusterGuestConfig{
+			clusterGuestConfig: v1alpha1.ClusterGuestConfig{
 				ID: "cluster-1",
 			},
 			currentState: []*v1alpha1.CertConfig{
@@ -192,7 +191,7 @@ func Test_newCreateChange(t *testing.T) {
 		},
 		{
 			name: "case 2: Some of desired certconfigs exist",
-			clusterGuestConfig: &v1alpha1.ClusterGuestConfig{
+			clusterGuestConfig: v1alpha1.ClusterGuestConfig{
 				ID: "cluster-1",
 			},
 			currentState: []*v1alpha1.CertConfig{
@@ -221,7 +220,7 @@ func Test_newCreateChange(t *testing.T) {
 		},
 		{
 			name: "case 3: desiredState is wrong type",
-			clusterGuestConfig: &v1alpha1.ClusterGuestConfig{
+			clusterGuestConfig: v1alpha1.ClusterGuestConfig{
 				ID: "cluster-1",
 			},
 			currentState: []*v1alpha1.CertConfig{
@@ -239,7 +238,7 @@ func Test_newCreateChange(t *testing.T) {
 		},
 		{
 			name: "case 4: currentState is wrong type",
-			clusterGuestConfig: &v1alpha1.ClusterGuestConfig{
+			clusterGuestConfig: v1alpha1.ClusterGuestConfig{
 				ID: "cluster-1",
 			},
 			currentState: []string{
@@ -265,13 +264,13 @@ func Test_newCreateChange(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			r, err := New(Config{
-				BaseClusterConfig: &cluster.Config{},
+				BaseClusterConfig: newClusterConfig(),
 				G8sClient:         fake.NewSimpleClientset(),
 				K8sClient:         clientgofake.NewSimpleClientset(),
 				Logger:            logger,
 				ProjectName:       "cluster-operator",
-				ToClusterGuestConfigFunc: func(v interface{}) (*v1alpha1.ClusterGuestConfig, error) {
-					return v.(*v1alpha1.ClusterGuestConfig), nil
+				ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
+					return v.(v1alpha1.ClusterGuestConfig), nil
 				},
 			})
 

--- a/pkg/resource/v1/certconfig/current.go
+++ b/pkg/resource/v1/certconfig/current.go
@@ -27,7 +27,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	var certConfigs []*v1alpha1.CertConfig
 	{
 		labelSelector := &metav1.LabelSelector{}
-		labelSelector = metav1.AddLabelToSelector(labelSelector, label.LegacyClusterID, key.ClusterID(*clusterGuestConfig))
+		labelSelector = metav1.AddLabelToSelector(labelSelector, label.LegacyClusterID, key.ClusterID(clusterGuestConfig))
 
 		selector, err := metav1.LabelSelectorAsSelector(labelSelector)
 		if err != nil {

--- a/pkg/resource/v1/certconfig/current_test.go
+++ b/pkg/resource/v1/certconfig/current_test.go
@@ -13,14 +13,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgofake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
-
-	"github.com/giantswarm/cluster-operator/pkg/cluster"
 )
 
 func Test_GetCurrentState(t *testing.T) {
 	testCases := []struct {
 		description         string
-		clusterGuestConfig  *v1alpha1.ClusterGuestConfig
+		clusterGuestConfig  v1alpha1.ClusterGuestConfig
 		presentCertConfigs  []*v1alpha1.CertConfig
 		apiReactors         []k8stesting.Reactor
 		expectedCertConfigs []*v1alpha1.CertConfig
@@ -28,7 +26,7 @@ func Test_GetCurrentState(t *testing.T) {
 	}{
 		{
 			description: "return correct certconfigs from group of certconfigs for different clusters",
-			clusterGuestConfig: &v1alpha1.ClusterGuestConfig{
+			clusterGuestConfig: v1alpha1.ClusterGuestConfig{
 				ID: "cluster-1",
 			},
 			presentCertConfigs: []*v1alpha1.CertConfig{
@@ -46,7 +44,7 @@ func Test_GetCurrentState(t *testing.T) {
 		},
 		{
 			description: "return empty list as state when there are no certconfigs present",
-			clusterGuestConfig: &v1alpha1.ClusterGuestConfig{
+			clusterGuestConfig: v1alpha1.ClusterGuestConfig{
 				ID: "cluster-1",
 			},
 			presentCertConfigs:  []*v1alpha1.CertConfig{},
@@ -56,7 +54,7 @@ func Test_GetCurrentState(t *testing.T) {
 		},
 		{
 			description: "return all certconfigs that match clusterID despite of having uknonwn Cert name",
-			clusterGuestConfig: &v1alpha1.ClusterGuestConfig{
+			clusterGuestConfig: v1alpha1.ClusterGuestConfig{
 				ID: "cluster-1",
 			},
 			presentCertConfigs: []*v1alpha1.CertConfig{
@@ -76,7 +74,7 @@ func Test_GetCurrentState(t *testing.T) {
 		},
 		{
 			description: "handle unknown error from k8s API",
-			clusterGuestConfig: &v1alpha1.ClusterGuestConfig{
+			clusterGuestConfig: v1alpha1.ClusterGuestConfig{
 				ID: "cluster-1",
 			},
 			presentCertConfigs:  []*v1alpha1.CertConfig{},
@@ -102,13 +100,13 @@ func Test_GetCurrentState(t *testing.T) {
 			client.ReactionChain = append(tc.apiReactors, client.ReactionChain...)
 
 			r, err := New(Config{
-				BaseClusterConfig: &cluster.Config{},
+				BaseClusterConfig: newClusterConfig(),
 				G8sClient:         client,
 				K8sClient:         clientgofake.NewSimpleClientset(),
 				Logger:            logger,
 				ProjectName:       "cluster-operator",
-				ToClusterGuestConfigFunc: func(v interface{}) (*v1alpha1.ClusterGuestConfig, error) {
-					return v.(*v1alpha1.ClusterGuestConfig), nil
+				ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
+					return v.(v1alpha1.ClusterGuestConfig), nil
 				},
 			})
 

--- a/pkg/resource/v1/certconfig/delete_test.go
+++ b/pkg/resource/v1/certconfig/delete_test.go
@@ -13,7 +13,6 @@ import (
 	clientgofake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 
-	"github.com/giantswarm/cluster-operator/pkg/cluster"
 	"github.com/giantswarm/cluster-operator/pkg/resource/v1/key"
 )
 
@@ -47,13 +46,13 @@ func Test_ApplyDeleteChange_Deletes_deleteChange(t *testing.T) {
 	}, client.ReactionChain...)
 
 	r, err := New(Config{
-		BaseClusterConfig: &cluster.Config{},
+		BaseClusterConfig: newClusterConfig(),
 		G8sClient:         client,
 		K8sClient:         clientgofake.NewSimpleClientset(),
 		Logger:            logger,
 		ProjectName:       "cluster-operator",
-		ToClusterGuestConfigFunc: func(v interface{}) (*v1alpha1.ClusterGuestConfig, error) {
-			return v.(*v1alpha1.ClusterGuestConfig), nil
+		ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
+			return v.(v1alpha1.ClusterGuestConfig), nil
 		},
 	})
 
@@ -93,13 +92,13 @@ func Test_ApplyDeleteChange_Does_Not_Make_API_Call_With_Empty_deleteChange(t *te
 	}, client.ReactionChain...)
 
 	r, err := New(Config{
-		BaseClusterConfig: &cluster.Config{},
+		BaseClusterConfig: newClusterConfig(),
 		G8sClient:         client,
 		K8sClient:         clientgofake.NewSimpleClientset(),
 		Logger:            logger,
 		ProjectName:       "cluster-operator",
-		ToClusterGuestConfigFunc: func(v interface{}) (*v1alpha1.ClusterGuestConfig, error) {
-			return v.(*v1alpha1.ClusterGuestConfig), nil
+		ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
+			return v.(v1alpha1.ClusterGuestConfig), nil
 		},
 	})
 
@@ -133,13 +132,13 @@ func Test_ApplyDeleteChange_Handles_K8S_API_Error(t *testing.T) {
 	}, client.ReactionChain...)
 
 	r, err := New(Config{
-		BaseClusterConfig: &cluster.Config{},
+		BaseClusterConfig: newClusterConfig(),
 		G8sClient:         client,
 		K8sClient:         clientgofake.NewSimpleClientset(),
 		Logger:            logger,
 		ProjectName:       "cluster-operator",
-		ToClusterGuestConfigFunc: func(v interface{}) (*v1alpha1.ClusterGuestConfig, error) {
-			return v.(*v1alpha1.ClusterGuestConfig), nil
+		ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
+			return v.(v1alpha1.ClusterGuestConfig), nil
 		},
 	})
 
@@ -156,7 +155,7 @@ func Test_ApplyDeleteChange_Handles_K8S_API_Error(t *testing.T) {
 func Test_newDeleteChangeForDeletePatch_Deletes_Existing_CertConfigs(t *testing.T) {
 	testCases := []struct {
 		name                string
-		clusterGuestConfig  *v1alpha1.ClusterGuestConfig
+		clusterGuestConfig  v1alpha1.ClusterGuestConfig
 		currentState        interface{}
 		desiredState        interface{}
 		expectedCertConfigs []*v1alpha1.CertConfig
@@ -164,7 +163,7 @@ func Test_newDeleteChangeForDeletePatch_Deletes_Existing_CertConfigs(t *testing.
 	}{
 		{
 			name: "case 0: No certconfigs exist, single certconfig desired",
-			clusterGuestConfig: &v1alpha1.ClusterGuestConfig{
+			clusterGuestConfig: v1alpha1.ClusterGuestConfig{
 				ID: "cluster-1",
 			},
 			currentState: nil,
@@ -176,7 +175,7 @@ func Test_newDeleteChangeForDeletePatch_Deletes_Existing_CertConfigs(t *testing.
 		},
 		{
 			name: "case 1: One certconfig exists and it's the same as desired one",
-			clusterGuestConfig: &v1alpha1.ClusterGuestConfig{
+			clusterGuestConfig: v1alpha1.ClusterGuestConfig{
 				ID: "cluster-1",
 			},
 			currentState: []*v1alpha1.CertConfig{
@@ -192,7 +191,7 @@ func Test_newDeleteChangeForDeletePatch_Deletes_Existing_CertConfigs(t *testing.
 		},
 		{
 			name: "case 2: Some of desired certconfigs exist but not all",
-			clusterGuestConfig: &v1alpha1.ClusterGuestConfig{
+			clusterGuestConfig: v1alpha1.ClusterGuestConfig{
 				ID: "cluster-1",
 			},
 			currentState: []*v1alpha1.CertConfig{
@@ -219,7 +218,7 @@ func Test_newDeleteChangeForDeletePatch_Deletes_Existing_CertConfigs(t *testing.
 		},
 		{
 			name: "case 3: currentState is wrong type",
-			clusterGuestConfig: &v1alpha1.ClusterGuestConfig{
+			clusterGuestConfig: v1alpha1.ClusterGuestConfig{
 				ID: "cluster-1",
 			},
 			currentState: []string{
@@ -245,13 +244,13 @@ func Test_newDeleteChangeForDeletePatch_Deletes_Existing_CertConfigs(t *testing.
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			r, err := New(Config{
-				BaseClusterConfig: &cluster.Config{},
+				BaseClusterConfig: newClusterConfig(),
 				G8sClient:         fake.NewSimpleClientset(),
 				K8sClient:         clientgofake.NewSimpleClientset(),
 				Logger:            logger,
 				ProjectName:       "cluster-operator",
-				ToClusterGuestConfigFunc: func(v interface{}) (*v1alpha1.ClusterGuestConfig, error) {
-					return v.(*v1alpha1.ClusterGuestConfig), nil
+				ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
+					return v.(v1alpha1.ClusterGuestConfig), nil
 				},
 			})
 
@@ -309,7 +308,7 @@ func Test_newDeleteChangeForDeletePatch_Deletes_Existing_CertConfigs(t *testing.
 func Test_newDeleteChangeForUpdatePatch_Deletes_Existing_CertConfigs_That_Are_Not_Desired(t *testing.T) {
 	testCases := []struct {
 		name                string
-		clusterGuestConfig  *v1alpha1.ClusterGuestConfig
+		clusterGuestConfig  v1alpha1.ClusterGuestConfig
 		currentState        interface{}
 		desiredState        interface{}
 		expectedCertConfigs []*v1alpha1.CertConfig
@@ -317,7 +316,7 @@ func Test_newDeleteChangeForUpdatePatch_Deletes_Existing_CertConfigs_That_Are_No
 	}{
 		{
 			name: "case 0: No certconfigs exist, single certconfig desired",
-			clusterGuestConfig: &v1alpha1.ClusterGuestConfig{
+			clusterGuestConfig: v1alpha1.ClusterGuestConfig{
 				ID: "cluster-1",
 			},
 			currentState: nil,
@@ -329,7 +328,7 @@ func Test_newDeleteChangeForUpdatePatch_Deletes_Existing_CertConfigs_That_Are_No
 		},
 		{
 			name: "case 1: One certconfig exists and it's the same as desired one",
-			clusterGuestConfig: &v1alpha1.ClusterGuestConfig{
+			clusterGuestConfig: v1alpha1.ClusterGuestConfig{
 				ID: "cluster-1",
 			},
 			currentState: []*v1alpha1.CertConfig{
@@ -343,7 +342,7 @@ func Test_newDeleteChangeForUpdatePatch_Deletes_Existing_CertConfigs_That_Are_No
 		},
 		{
 			name: "case 2: Some of desired certconfigs exist but not all, there are also some leftovers from earlier implementation",
-			clusterGuestConfig: &v1alpha1.ClusterGuestConfig{
+			clusterGuestConfig: v1alpha1.ClusterGuestConfig{
 				ID: "cluster-1",
 			},
 			currentState: []*v1alpha1.CertConfig{
@@ -374,7 +373,7 @@ func Test_newDeleteChangeForUpdatePatch_Deletes_Existing_CertConfigs_That_Are_No
 		},
 		{
 			name: "case 3: currentState is wrong type",
-			clusterGuestConfig: &v1alpha1.ClusterGuestConfig{
+			clusterGuestConfig: v1alpha1.ClusterGuestConfig{
 				ID: "cluster-1",
 			},
 			currentState: []string{
@@ -392,7 +391,7 @@ func Test_newDeleteChangeForUpdatePatch_Deletes_Existing_CertConfigs_That_Are_No
 		},
 		{
 			name: "case 4: desiredState is wrong type",
-			clusterGuestConfig: &v1alpha1.ClusterGuestConfig{
+			clusterGuestConfig: v1alpha1.ClusterGuestConfig{
 				ID: "cluster-1",
 			},
 			currentState: []*v1alpha1.CertConfig{
@@ -418,13 +417,13 @@ func Test_newDeleteChangeForUpdatePatch_Deletes_Existing_CertConfigs_That_Are_No
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			r, err := New(Config{
-				BaseClusterConfig: &cluster.Config{},
+				BaseClusterConfig: newClusterConfig(),
 				G8sClient:         fake.NewSimpleClientset(),
 				K8sClient:         clientgofake.NewSimpleClientset(),
 				Logger:            logger,
 				ProjectName:       "cluster-operator",
-				ToClusterGuestConfigFunc: func(v interface{}) (*v1alpha1.ClusterGuestConfig, error) {
-					return v.(*v1alpha1.ClusterGuestConfig), nil
+				ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
+					return v.(v1alpha1.ClusterGuestConfig), nil
 				},
 			})
 

--- a/pkg/resource/v1/certconfig/desired.go
+++ b/pkg/resource/v1/certconfig/desired.go
@@ -42,7 +42,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
-	clusterConfig, err := prepareClusterConfig(*r.baseClusterConfig, *clusterGuestConfig)
+	clusterConfig, err := prepareClusterConfig(r.baseClusterConfig, clusterGuestConfig)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -80,50 +80,49 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	return desiredCertConfigs, nil
 }
 
-func prepareClusterConfig(baseClusterConfig cluster.Config, clusterGuestConfig v1alpha1.ClusterGuestConfig) (*cluster.Config, error) {
+func prepareClusterConfig(baseClusterConfig cluster.Config, clusterGuestConfig v1alpha1.ClusterGuestConfig) (cluster.Config, error) {
 	var err error
 
 	// Copy baseClusterConfig as basis and supplement it with information from
 	// clusterGuestConfig.
-	clusterConfig := new(cluster.Config)
-	*clusterConfig = baseClusterConfig
+	clusterConfig := baseClusterConfig
 
 	clusterConfig.ClusterID = key.ClusterID(clusterGuestConfig)
 
 	clusterConfig.Domain.API, err = newServerDomain(key.DNSZone(clusterGuestConfig), certs.APICert)
 	if err != nil {
-		return nil, microerror.Mask(err)
+		return cluster.Config{}, microerror.Mask(err)
 	}
 	clusterConfig.Domain.Calico, err = newServerDomain(key.DNSZone(clusterGuestConfig), certs.CalicoCert)
 	if err != nil {
-		return nil, microerror.Mask(err)
+		return cluster.Config{}, microerror.Mask(err)
 	}
 	clusterConfig.Domain.Etcd, err = newServerDomain(key.DNSZone(clusterGuestConfig), certs.EtcdCert)
 	if err != nil {
-		return nil, microerror.Mask(err)
+		return cluster.Config{}, microerror.Mask(err)
 	}
 	clusterConfig.Domain.NodeOperator, err = newServerDomain(key.DNSZone(clusterGuestConfig), certs.NodeOperatorCert)
 	if err != nil {
-		return nil, microerror.Mask(err)
+		return cluster.Config{}, microerror.Mask(err)
 	}
 	clusterConfig.Domain.Prometheus, err = newServerDomain(key.DNSZone(clusterGuestConfig), certs.PrometheusCert)
 	if err != nil {
-		return nil, microerror.Mask(err)
+		return cluster.Config{}, microerror.Mask(err)
 	}
 	clusterConfig.Domain.ServiceAccount, err = newServerDomain(key.DNSZone(clusterGuestConfig), certs.ServiceAccountCert)
 	if err != nil {
-		return nil, microerror.Mask(err)
+		return cluster.Config{}, microerror.Mask(err)
 	}
 	clusterConfig.Domain.Worker, err = newServerDomain(key.DNSZone(clusterGuestConfig), certs.WorkerCert)
 	if err != nil {
-		return nil, microerror.Mask(err)
+		return cluster.Config{}, microerror.Mask(err)
 	}
 
 	clusterConfig.Organization = clusterGuestConfig.Owner
 
 	versionBundle, err := versionbundle.GetBundleByName(key.VersionBundles(clusterGuestConfig), certOperatorID)
 	if err != nil {
-		return nil, microerror.Mask(err)
+		return cluster.Config{}, microerror.Mask(err)
 	}
 
 	clusterConfig.VersionBundleVersion = versionBundle.Version
@@ -131,7 +130,7 @@ func prepareClusterConfig(baseClusterConfig cluster.Config, clusterGuestConfig v
 	return clusterConfig, nil
 }
 
-func newAPICertConfig(clusterConfig *cluster.Config, cert certs.Cert, projectName string) *v1alpha1.CertConfig {
+func newAPICertConfig(clusterConfig cluster.Config, cert certs.Cert, projectName string) *v1alpha1.CertConfig {
 	certName := string(cert)
 	return &v1alpha1.CertConfig{
 		TypeMeta: apimetav1.TypeMeta{
@@ -167,7 +166,7 @@ func newAPICertConfig(clusterConfig *cluster.Config, cert certs.Cert, projectNam
 	}
 }
 
-func newCalicoCertConfig(clusterConfig *cluster.Config, cert certs.Cert, projectName string) *v1alpha1.CertConfig {
+func newCalicoCertConfig(clusterConfig cluster.Config, cert certs.Cert, projectName string) *v1alpha1.CertConfig {
 	certName := string(cert)
 	return &v1alpha1.CertConfig{
 		TypeMeta: apimetav1.TypeMeta{
@@ -200,7 +199,7 @@ func newCalicoCertConfig(clusterConfig *cluster.Config, cert certs.Cert, project
 	}
 }
 
-func newEtcdCertConfig(clusterConfig *cluster.Config, cert certs.Cert, projectName string) *v1alpha1.CertConfig {
+func newEtcdCertConfig(clusterConfig cluster.Config, cert certs.Cert, projectName string) *v1alpha1.CertConfig {
 	certName := string(cert)
 	return &v1alpha1.CertConfig{
 		TypeMeta: apimetav1.TypeMeta{
@@ -234,7 +233,7 @@ func newEtcdCertConfig(clusterConfig *cluster.Config, cert certs.Cert, projectNa
 	}
 }
 
-func newNodeOperatorCertConfig(clusterConfig *cluster.Config, cert certs.Cert, projectName string) *v1alpha1.CertConfig {
+func newNodeOperatorCertConfig(clusterConfig cluster.Config, cert certs.Cert, projectName string) *v1alpha1.CertConfig {
 	certName := string(cert)
 	return &v1alpha1.CertConfig{
 		TypeMeta: apimetav1.TypeMeta{
@@ -267,7 +266,7 @@ func newNodeOperatorCertConfig(clusterConfig *cluster.Config, cert certs.Cert, p
 	}
 }
 
-func newPrometheusCertConfig(clusterConfig *cluster.Config, cert certs.Cert, projectName string) *v1alpha1.CertConfig {
+func newPrometheusCertConfig(clusterConfig cluster.Config, cert certs.Cert, projectName string) *v1alpha1.CertConfig {
 	certName := string(cert)
 	return &v1alpha1.CertConfig{
 		TypeMeta: apimetav1.TypeMeta{
@@ -300,7 +299,7 @@ func newPrometheusCertConfig(clusterConfig *cluster.Config, cert certs.Cert, pro
 	}
 }
 
-func newServiceAccountCertConfig(clusterConfig *cluster.Config, cert certs.Cert, projectName string) *v1alpha1.CertConfig {
+func newServiceAccountCertConfig(clusterConfig cluster.Config, cert certs.Cert, projectName string) *v1alpha1.CertConfig {
 	certName := string(cert)
 	return &v1alpha1.CertConfig{
 		TypeMeta: apimetav1.TypeMeta{
@@ -333,7 +332,7 @@ func newServiceAccountCertConfig(clusterConfig *cluster.Config, cert certs.Cert,
 	}
 }
 
-func newWorkerCertConfig(clusterConfig *cluster.Config, cert certs.Cert, projectName string) *v1alpha1.CertConfig {
+func newWorkerCertConfig(clusterConfig cluster.Config, cert certs.Cert, projectName string) *v1alpha1.CertConfig {
 	certName := string(cert)
 	return &v1alpha1.CertConfig{
 		TypeMeta: apimetav1.TypeMeta{

--- a/pkg/resource/v1/certconfig/desired_test.go
+++ b/pkg/resource/v1/certconfig/desired_test.go
@@ -43,7 +43,7 @@ func Test_GetDesiredState_Returns_CertConfig_For_All_Managed_Certs(t *testing.T)
 	}
 
 	r, err := New(Config{
-		BaseClusterConfig: &cluster.Config{
+		BaseClusterConfig: cluster.Config{
 			ClusterID: "cluster-1",
 			CertTTL:   "720h",
 			IP: cluster.IP{
@@ -54,8 +54,8 @@ func Test_GetDesiredState_Returns_CertConfig_For_All_Managed_Certs(t *testing.T)
 		K8sClient:   clientgofake.NewSimpleClientset(),
 		Logger:      microloggertest.New(),
 		ProjectName: "cluster-operator",
-		ToClusterGuestConfigFunc: func(v interface{}) (*v1alpha1.ClusterGuestConfig, error) {
-			return v.(*v1alpha1.ClusterGuestConfig), nil
+		ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
+			return v.(v1alpha1.ClusterGuestConfig), nil
 		},
 	})
 
@@ -63,7 +63,7 @@ func Test_GetDesiredState_Returns_CertConfig_For_All_Managed_Certs(t *testing.T)
 		t.Fatalf("Resource construction failed: %#v", err)
 	}
 
-	desiredState, err := r.GetDesiredState(context.TODO(), &clusterGuestConfig)
+	desiredState, err := r.GetDesiredState(context.TODO(), clusterGuestConfig)
 	if err != nil {
 		t.Fatalf("GetDesiredState() == %#v, want nil error", err)
 	}

--- a/pkg/resource/v1/certconfig/resource.go
+++ b/pkg/resource/v1/certconfig/resource.go
@@ -1,6 +1,8 @@
 package certconfig
 
 import (
+	"reflect"
+
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/microerror"
@@ -23,27 +25,27 @@ const (
 
 // Config represents the configuration used to create a new cloud config resource.
 type Config struct {
-	BaseClusterConfig        *cluster.Config
+	BaseClusterConfig        cluster.Config
 	G8sClient                versioned.Interface
 	K8sClient                kubernetes.Interface
 	Logger                   micrologger.Logger
 	ProjectName              string
-	ToClusterGuestConfigFunc func(obj interface{}) (*v1alpha1.ClusterGuestConfig, error)
+	ToClusterGuestConfigFunc func(obj interface{}) (v1alpha1.ClusterGuestConfig, error)
 }
 
 // Resource implements the cloud config resource.
 type Resource struct {
-	baseClusterConfig        *cluster.Config
+	baseClusterConfig        cluster.Config
 	g8sClient                versioned.Interface
 	k8sClient                kubernetes.Interface
 	logger                   micrologger.Logger
 	projectName              string
-	toClusterGuestConfigFunc func(obj interface{}) (*v1alpha1.ClusterGuestConfig, error)
+	toClusterGuestConfigFunc func(obj interface{}) (v1alpha1.ClusterGuestConfig, error)
 }
 
 // New creates a new configured cloud config resource.
 func New(config Config) (*Resource, error) {
-	if config.BaseClusterConfig == nil {
+	if reflect.DeepEqual(config.BaseClusterConfig, cluster.Config{}) {
 		return nil, microerror.Maskf(invalidConfigError, "config.BaseClusterConfig must not be empty")
 	}
 	if config.G8sClient == nil {

--- a/pkg/resource/v1/certconfig/update_test.go
+++ b/pkg/resource/v1/certconfig/update_test.go
@@ -13,7 +13,6 @@ import (
 	clientgofake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 
-	"github.com/giantswarm/cluster-operator/pkg/cluster"
 	"github.com/giantswarm/cluster-operator/pkg/resource/v1/key"
 )
 
@@ -47,13 +46,13 @@ func Test_ApplyUpdateChange_Updates_updateChange(t *testing.T) {
 	}, client.ReactionChain...)
 
 	r, err := New(Config{
-		BaseClusterConfig: &cluster.Config{},
+		BaseClusterConfig: newClusterConfig(),
 		G8sClient:         client,
 		K8sClient:         clientgofake.NewSimpleClientset(),
 		Logger:            logger,
 		ProjectName:       "cluster-operator",
-		ToClusterGuestConfigFunc: func(v interface{}) (*v1alpha1.ClusterGuestConfig, error) {
-			return v.(*v1alpha1.ClusterGuestConfig), nil
+		ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
+			return v.(v1alpha1.ClusterGuestConfig), nil
 		},
 	})
 
@@ -93,13 +92,13 @@ func Test_ApplyUpdateChange_Does_Not_Make_API_Call_With_Empty_UpdateChange(t *te
 	}, client.ReactionChain...)
 
 	r, err := New(Config{
-		BaseClusterConfig: &cluster.Config{},
+		BaseClusterConfig: newClusterConfig(),
 		G8sClient:         client,
 		K8sClient:         clientgofake.NewSimpleClientset(),
 		Logger:            logger,
 		ProjectName:       "cluster-operator",
-		ToClusterGuestConfigFunc: func(v interface{}) (*v1alpha1.ClusterGuestConfig, error) {
-			return v.(*v1alpha1.ClusterGuestConfig), nil
+		ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
+			return v.(v1alpha1.ClusterGuestConfig), nil
 		},
 	})
 
@@ -133,13 +132,13 @@ func Test_ApplyUpdateChange_Handles_K8S_API_Error(t *testing.T) {
 	}, client.ReactionChain...)
 
 	r, err := New(Config{
-		BaseClusterConfig: &cluster.Config{},
+		BaseClusterConfig: newClusterConfig(),
 		G8sClient:         client,
 		K8sClient:         clientgofake.NewSimpleClientset(),
 		Logger:            logger,
 		ProjectName:       "cluster-operator",
-		ToClusterGuestConfigFunc: func(v interface{}) (*v1alpha1.ClusterGuestConfig, error) {
-			return v.(*v1alpha1.ClusterGuestConfig), nil
+		ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
+			return v.(v1alpha1.ClusterGuestConfig), nil
 		},
 	})
 
@@ -284,13 +283,13 @@ func Test_newUpdateChange_Updates_VersionBundle(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			r, err := New(Config{
-				BaseClusterConfig: &cluster.Config{},
+				BaseClusterConfig: newClusterConfig(),
 				G8sClient:         fake.NewSimpleClientset(),
 				K8sClient:         clientgofake.NewSimpleClientset(),
 				Logger:            logger,
 				ProjectName:       "cluster-operator",
-				ToClusterGuestConfigFunc: func(v interface{}) (*v1alpha1.ClusterGuestConfig, error) {
-					return v.(*v1alpha1.ClusterGuestConfig), nil
+				ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
+					return v.(v1alpha1.ClusterGuestConfig), nil
 				},
 			})
 

--- a/pkg/resource/v1/encryptionkey/common_test.go
+++ b/pkg/resource/v1/encryptionkey/common_test.go
@@ -30,8 +30,8 @@ var (
 
 type apiReactorFactory func(t *testing.T) k8stesting.Reactor
 
-func newClusterGuestConfig(clusterID string) *v1alpha1.ClusterGuestConfig {
-	return &v1alpha1.ClusterGuestConfig{
+func newClusterGuestConfig(clusterID string) v1alpha1.ClusterGuestConfig {
+	return v1alpha1.ClusterGuestConfig{
 		ID: clusterID,
 	}
 }
@@ -44,7 +44,7 @@ func newEncryptionSecret(t *testing.T, clusterID string, data map[string]string)
 	}, data)
 }
 
-func newSecret(t *testing.T, clusterGuestConfig *v1alpha1.ClusterGuestConfig, labels, data map[string]string) *v1.Secret {
+func newSecret(t *testing.T, clusterGuestConfig v1alpha1.ClusterGuestConfig, labels, data map[string]string) *v1.Secret {
 	t.Helper()
 	return &v1.Secret{
 		TypeMeta: apismetav1.TypeMeta{
@@ -52,7 +52,7 @@ func newSecret(t *testing.T, clusterGuestConfig *v1alpha1.ClusterGuestConfig, la
 			APIVersion: "v1",
 		},
 		ObjectMeta: apismetav1.ObjectMeta{
-			Name:      key.EncryptionKeySecretName(*clusterGuestConfig),
+			Name:      key.EncryptionKeySecretName(clusterGuestConfig),
 			Namespace: v1.NamespaceDefault,
 			Labels:    labels,
 		},

--- a/pkg/resource/v1/encryptionkey/create_test.go
+++ b/pkg/resource/v1/encryptionkey/create_test.go
@@ -15,7 +15,7 @@ import (
 func Test_ApplyCreateChange(t *testing.T) {
 	testCases := []struct {
 		description         string
-		clusterGuestConfig  *v1alpha1.ClusterGuestConfig
+		clusterGuestConfig  v1alpha1.ClusterGuestConfig
 		createChange        interface{}
 		apiReactorFactories []apiReactorFactory
 		expectedError       error
@@ -87,8 +87,8 @@ func Test_ApplyCreateChange(t *testing.T) {
 				K8sClient:   client,
 				Logger:      logger,
 				ProjectName: "cluster-operator",
-				ToClusterGuestConfigFunc: func(v interface{}) (*v1alpha1.ClusterGuestConfig, error) {
-					return v.(*v1alpha1.ClusterGuestConfig), nil
+				ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
+					return v.(v1alpha1.ClusterGuestConfig), nil
 				},
 			})
 
@@ -111,7 +111,7 @@ func Test_ApplyCreateChange(t *testing.T) {
 func Test_newCreateChange(t *testing.T) {
 	testCases := []struct {
 		description        string
-		clusterGuestConfig *v1alpha1.ClusterGuestConfig
+		clusterGuestConfig v1alpha1.ClusterGuestConfig
 		currentState       interface{}
 		desiredState       interface{}
 		expectedSecret     *v1.Secret
@@ -162,8 +162,8 @@ func Test_newCreateChange(t *testing.T) {
 				K8sClient:   fake.NewSimpleClientset(),
 				Logger:      logger,
 				ProjectName: "cluster-operator",
-				ToClusterGuestConfigFunc: func(v interface{}) (*v1alpha1.ClusterGuestConfig, error) {
-					return v.(*v1alpha1.ClusterGuestConfig), nil
+				ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
+					return v.(v1alpha1.ClusterGuestConfig), nil
 				},
 			})
 

--- a/pkg/resource/v1/encryptionkey/current.go
+++ b/pkg/resource/v1/encryptionkey/current.go
@@ -20,7 +20,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
-	secretName := key.EncryptionKeySecretName(*clusterGuestConfig)
+	secretName := key.EncryptionKeySecretName(clusterGuestConfig)
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for encryptionkey secret in the Kubernetes API", "secretName", secretName)
 

--- a/pkg/resource/v1/encryptionkey/current_test.go
+++ b/pkg/resource/v1/encryptionkey/current_test.go
@@ -17,7 +17,7 @@ import (
 func Test_GetCurrentState_Reads_Secrets_For_Relevant_ClusterID(t *testing.T) {
 	testCases := []struct {
 		description        string
-		clusterGuestConfig *v1alpha1.ClusterGuestConfig
+		clusterGuestConfig v1alpha1.ClusterGuestConfig
 		presentSecrets     []*v1.Secret
 		apiReactors        []k8stesting.Reactor
 		expectedSecret     *v1.Secret
@@ -86,8 +86,8 @@ func Test_GetCurrentState_Reads_Secrets_For_Relevant_ClusterID(t *testing.T) {
 				K8sClient:   client,
 				Logger:      logger,
 				ProjectName: "cluster-operator",
-				ToClusterGuestConfigFunc: func(v interface{}) (*v1alpha1.ClusterGuestConfig, error) {
-					return v.(*v1alpha1.ClusterGuestConfig), nil
+				ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
+					return v.(v1alpha1.ClusterGuestConfig), nil
 				},
 			})
 

--- a/pkg/resource/v1/encryptionkey/delete_test.go
+++ b/pkg/resource/v1/encryptionkey/delete_test.go
@@ -15,7 +15,7 @@ import (
 func Test_ApplyDeleteChange(t *testing.T) {
 	testCases := []struct {
 		description         string
-		clusterGuestConfig  *v1alpha1.ClusterGuestConfig
+		clusterGuestConfig  v1alpha1.ClusterGuestConfig
 		deleteChange        interface{}
 		apiReactorFactories []apiReactorFactory
 		expectedError       error
@@ -87,8 +87,8 @@ func Test_ApplyDeleteChange(t *testing.T) {
 				K8sClient:   client,
 				Logger:      logger,
 				ProjectName: "cluster-operator",
-				ToClusterGuestConfigFunc: func(v interface{}) (*v1alpha1.ClusterGuestConfig, error) {
-					return v.(*v1alpha1.ClusterGuestConfig), nil
+				ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
+					return v.(v1alpha1.ClusterGuestConfig), nil
 				},
 			})
 

--- a/pkg/resource/v1/encryptionkey/desired.go
+++ b/pkg/resource/v1/encryptionkey/desired.go
@@ -28,7 +28,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	}
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", "computing desired encryption key secret")
-	secretName := key.EncryptionKeySecretName(*clusterGuestConfig)
+	secretName := key.EncryptionKeySecretName(clusterGuestConfig)
 
 	keyBytes, err := newRandomKey(AESCBCKeyLength)
 	if err != nil {
@@ -40,8 +40,8 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 			Name:      secretName,
 			Namespace: v1.NamespaceDefault,
 			Labels: map[string]string{
-				label.Cluster:          key.ClusterID(*clusterGuestConfig),
-				label.LegacyClusterID:  key.ClusterID(*clusterGuestConfig),
+				label.Cluster:          key.ClusterID(clusterGuestConfig),
+				label.LegacyClusterID:  key.ClusterID(clusterGuestConfig),
 				label.LegacyClusterKey: label.RandomKeyTypeEncryption,
 				label.ManagedBy:        r.projectName,
 				label.RandomKey:        label.RandomKeyTypeEncryption,

--- a/pkg/resource/v1/encryptionkey/desired_test.go
+++ b/pkg/resource/v1/encryptionkey/desired_test.go
@@ -27,8 +27,8 @@ func Test_GetDesiredState_Secret_Properties(t *testing.T) {
 		K8sClient:   fake.NewSimpleClientset(),
 		Logger:      logger,
 		ProjectName: "cluster-operator",
-		ToClusterGuestConfigFunc: func(v interface{}) (*v1alpha1.ClusterGuestConfig, error) {
-			return v.(*v1alpha1.ClusterGuestConfig), nil
+		ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
+			return v.(v1alpha1.ClusterGuestConfig), nil
 		},
 	})
 
@@ -36,7 +36,7 @@ func Test_GetDesiredState_Secret_Properties(t *testing.T) {
 		t.Errorf("Resource construction failed: %#v", err)
 	}
 
-	clusterGuestConfig := &v1alpha1.ClusterGuestConfig{
+	clusterGuestConfig := v1alpha1.ClusterGuestConfig{
 		ID: "cluster-1",
 	}
 
@@ -91,8 +91,8 @@ func Test_GetDesiredState_Rand_Error_Handling(t *testing.T) {
 		K8sClient:   fake.NewSimpleClientset(),
 		Logger:      logger,
 		ProjectName: "cluster-operator",
-		ToClusterGuestConfigFunc: func(v interface{}) (*v1alpha1.ClusterGuestConfig, error) {
-			return v.(*v1alpha1.ClusterGuestConfig), nil
+		ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
+			return v.(v1alpha1.ClusterGuestConfig), nil
 		},
 	})
 
@@ -100,7 +100,7 @@ func Test_GetDesiredState_Rand_Error_Handling(t *testing.T) {
 		t.Errorf("Resource construction failed: %#v", err)
 	}
 
-	clusterGuestConfig := &v1alpha1.ClusterGuestConfig{
+	clusterGuestConfig := v1alpha1.ClusterGuestConfig{
 		ID: "cluster-1",
 	}
 

--- a/pkg/resource/v1/encryptionkey/resource.go
+++ b/pkg/resource/v1/encryptionkey/resource.go
@@ -18,7 +18,7 @@ type Config struct {
 	K8sClient                kubernetes.Interface
 	Logger                   micrologger.Logger
 	ProjectName              string
-	ToClusterGuestConfigFunc func(obj interface{}) (*v1alpha1.ClusterGuestConfig, error)
+	ToClusterGuestConfigFunc func(obj interface{}) (v1alpha1.ClusterGuestConfig, error)
 }
 
 // Resource implements the cloud config resource.
@@ -26,7 +26,7 @@ type Resource struct {
 	k8sClient                kubernetes.Interface
 	logger                   micrologger.Logger
 	projectName              string
-	toClusterGuestConfigFunc func(obj interface{}) (*v1alpha1.ClusterGuestConfig, error)
+	toClusterGuestConfigFunc func(obj interface{}) (v1alpha1.ClusterGuestConfig, error)
 }
 
 // New creates a new configured cloud config resource.

--- a/pkg/resource/v1/encryptionkey/update_test.go
+++ b/pkg/resource/v1/encryptionkey/update_test.go
@@ -14,7 +14,7 @@ import (
 func Test_newUpdateChange_Does_Not_Return_Change(t *testing.T) {
 	testCases := []struct {
 		description        string
-		clusterGuestConfig *v1alpha1.ClusterGuestConfig
+		clusterGuestConfig v1alpha1.ClusterGuestConfig
 		currentState       interface{}
 		desiredState       interface{}
 		expectedSecret     *v1.Secret
@@ -49,8 +49,8 @@ func Test_newUpdateChange_Does_Not_Return_Change(t *testing.T) {
 				K8sClient:   fake.NewSimpleClientset(),
 				Logger:      logger,
 				ProjectName: "cluster-operator",
-				ToClusterGuestConfigFunc: func(v interface{}) (*v1alpha1.ClusterGuestConfig, error) {
-					return v.(*v1alpha1.ClusterGuestConfig), nil
+				ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
+					return v.(v1alpha1.ClusterGuestConfig), nil
 				},
 			})
 

--- a/service/awsclusterconfig/v1/key/key.go
+++ b/service/awsclusterconfig/v1/key/key.go
@@ -5,6 +5,11 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
+// ToClusterGuestConfig extracts ClusterGuestConfig from AWSClusterConfig
+func ToClusterGuestConfig(awsClusterConfig v1alpha1.AWSClusterConfig) v1alpha1.ClusterGuestConfig {
+	return awsClusterConfig.Spec.Guest.Config
+}
+
 // ToCustomObject converts value to v1alpha1.AWSClusterConfig and returns it or
 // error if type does not match.
 func ToCustomObject(v interface{}) (v1alpha1.AWSClusterConfig, error) {
@@ -20,6 +25,7 @@ func ToCustomObject(v interface{}) (v1alpha1.AWSClusterConfig, error) {
 	return *customObjectPointer, nil
 }
 
+// VersionBundleVersion extracts version bundle version from AWSClusterConfig
 func VersionBundleVersion(awsClusterConfig v1alpha1.AWSClusterConfig) string {
 	return awsClusterConfig.Spec.VersionBundle.Version
 }

--- a/service/awsclusterconfig/v1/key/key.go
+++ b/service/awsclusterconfig/v1/key/key.go
@@ -5,7 +5,7 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
-// ToClusterGuestConfig extracts ClusterGuestConfig from AWSClusterConfig
+// ToClusterGuestConfig extracts ClusterGuestConfig from AWSClusterConfig.
 func ToClusterGuestConfig(awsClusterConfig v1alpha1.AWSClusterConfig) v1alpha1.ClusterGuestConfig {
 	return awsClusterConfig.Spec.Guest.Config
 }
@@ -25,7 +25,7 @@ func ToCustomObject(v interface{}) (v1alpha1.AWSClusterConfig, error) {
 	return *customObjectPointer, nil
 }
 
-// VersionBundleVersion extracts version bundle version from AWSClusterConfig
+// VersionBundleVersion extracts version bundle version from AWSClusterConfig.
 func VersionBundleVersion(awsClusterConfig v1alpha1.AWSClusterConfig) string {
 	return awsClusterConfig.Spec.VersionBundle.Version
 }

--- a/service/kvmclusterconfig/v1/key/key.go
+++ b/service/kvmclusterconfig/v1/key/key.go
@@ -10,7 +10,7 @@ func ClusterID(customObject v1alpha1.KVMClusterConfig) string {
 	return customObject.Spec.Guest.Config.ID
 }
 
-// ToClusterGuestConfig extracts ClusterGuestConfig from KVMClusterConfig
+// ToClusterGuestConfig extracts ClusterGuestConfig from KVMClusterConfig.
 func ToClusterGuestConfig(kvmClusterConfig v1alpha1.KVMClusterConfig) v1alpha1.ClusterGuestConfig {
 	return kvmClusterConfig.Spec.Guest.Config
 }
@@ -31,6 +31,7 @@ func ToCustomObject(v interface{}) (v1alpha1.KVMClusterConfig, error) {
 	return *customObjectPointer, nil
 }
 
+// VersionBundleVersion extracts version bundle version from KVMClusterConfig.
 func VersionBundleVersion(kvmClusterConfig v1alpha1.KVMClusterConfig) string {
 	return kvmClusterConfig.Spec.VersionBundle.Version
 }

--- a/service/kvmclusterconfig/v1/key/key.go
+++ b/service/kvmclusterconfig/v1/key/key.go
@@ -10,6 +10,11 @@ func ClusterID(customObject v1alpha1.KVMClusterConfig) string {
 	return customObject.Spec.Guest.Config.ID
 }
 
+// ToClusterGuestConfig extracts ClusterGuestConfig from KVMClusterConfig
+func ToClusterGuestConfig(kvmClusterConfig v1alpha1.KVMClusterConfig) v1alpha1.ClusterGuestConfig {
+	return kvmClusterConfig.Spec.Guest.Config
+}
+
 // ToCustomObject converts value to v1alpha1.KVMClusterConfig and returns it or
 // error if type does not match.
 func ToCustomObject(v interface{}) (v1alpha1.KVMClusterConfig, error) {

--- a/service/kvmclusterconfig/v1/resource_set.go
+++ b/service/kvmclusterconfig/v1/resource_set.go
@@ -147,19 +147,13 @@ func NewResourceSet(config ResourceSetConfig) (*framework.ResourceSet, error) {
 	return resourceSet, nil
 }
 
-func toClusterGuestConfig(obj interface{}) (*v1alpha1.ClusterGuestConfig, error) {
-	var clusterGuestConfig *v1alpha1.ClusterGuestConfig
-	if obj == nil {
-		return nil, microerror.Maskf(wrongTypeError, "got nil interface{}, expected %T", clusterGuestConfig)
+func toClusterGuestConfig(obj interface{}) (v1alpha1.ClusterGuestConfig, error) {
+	kvmClusterConfig, err := key.ToCustomObject(obj)
+	if err != nil {
+		return v1alpha1.ClusterGuestConfig{}, microerror.Mask(err)
 	}
 
-	var ok bool
-	clusterGuestConfig, ok = obj.(*v1alpha1.ClusterGuestConfig)
-	if !ok {
-		return nil, microerror.Maskf(wrongTypeError, "got %T, expected %T", obj, clusterGuestConfig)
-	}
-
-	return clusterGuestConfig, nil
+	return key.ToClusterGuestConfig(kvmClusterConfig), nil
 }
 
 func toCRUDResource(logger micrologger.Logger, ops framework.CRUDResourceOps) (*framework.CRUDResource, error) {


### PR DESCRIPTION
Both ClusterGuestConfig and cluster.Config were passed by pointer. To
make intention of its use more clear (those must be copies instead of
references), use value instead of pointer.