### PR TITLE
Implement deleting chartconfigs

### DIFF
--- a/pkg/v1/resource/chartconfig/current_test.go
+++ b/pkg/v1/resource/chartconfig/current_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/giantswarm/cluster-operator/pkg/cluster"
 )
 
-func Test_GetCurrentState(t *testing.T) {
+func Test_ChartConfig_GetCurrentState(t *testing.T) {
 	testCases := []struct {
 		name                 string
 		obj                  interface{}

--- a/pkg/v1/resource/chartconfig/delete.go
+++ b/pkg/v1/resource/chartconfig/delete.go
@@ -2,14 +2,75 @@ package chartconfig
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/framework"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	clusterGuestConfig, err := r.toClusterGuestConfigFunc(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	chartConfigsToCreate, err := toChartConfigs(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(chartConfigsToCreate) > 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting chartconfigs")
+
+		clusterConfig, err := prepareClusterConfig(r.baseClusterConfig, clusterGuestConfig)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		g8sClient, err := r.guest.NewG8sClient(ctx, clusterConfig.ClusterID, clusterConfig.Domain.API)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		for _, chartConfig := range chartConfigsToCreate {
+			err := g8sClient.CoreV1alpha1().ChartConfigs(metav1.NamespaceSystem).Delete(chartConfig.Name, &metav1.DeleteOptions{})
+			if apierrors.IsNotFound(err) {
+				// fall through
+			} else if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleted chartconfigs")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "no need to delete chartconfigs")
+	}
+
 	return nil
 }
 
 func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
-	return nil, nil
+	delete, err := r.newDeleteChangeForDeletePatch(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := framework.NewPatch()
+	patch.SetDeleteChange(delete)
+
+	return patch, nil
+}
+
+func (r *Resource) newDeleteChangeForDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) ([]*v1alpha1.ChartConfig, error) {
+	currentChartConfigs, err := toChartConfigs(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d chartconfigs that have to be deleted", len(currentChartConfigs)))
+
+	return currentChartConfigs, nil
 }

--- a/pkg/v1/resource/chartconfig/delete_test.go
+++ b/pkg/v1/resource/chartconfig/delete_test.go
@@ -1,0 +1,251 @@
+package chartconfig
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned/fake"
+	"github.com/giantswarm/cluster-operator/pkg/cluster"
+	"github.com/giantswarm/micrologger/microloggertest"
+	clientgofake "k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_ChartConfig_newDeleteChangeForDeletePatch(t *testing.T) {
+	testCases := []struct {
+		description          string
+		obj                  interface{}
+		currentState         interface{}
+		desiredState         interface{}
+		expectedChartConfigs []*v1alpha1.ChartConfig
+		errorMatcher         func(error) bool
+	}{
+		{
+			description:          "case 0: empty current and desired, expected empty",
+			currentState:         []*v1alpha1.ChartConfig{},
+			desiredState:         []*v1alpha1.ChartConfig{},
+			expectedChartConfigs: []*v1alpha1.ChartConfig{},
+			errorMatcher:         nil,
+		},
+		{
+			description: "case 1: non-empty current and empty desired, expected current",
+			currentState: []*v1alpha1.ChartConfig{
+				&v1alpha1.ChartConfig{
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name: "test-chart",
+						},
+					},
+				},
+			},
+			desiredState: []*v1alpha1.ChartConfig{
+				&v1alpha1.ChartConfig{
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name: "test-chart",
+						},
+					},
+				},
+			},
+			expectedChartConfigs: []*v1alpha1.ChartConfig{
+				&v1alpha1.ChartConfig{
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name: "test-chart",
+						},
+					},
+				},
+			},
+			errorMatcher: nil,
+		},
+		{
+			description:  "case 2: empty current and non-empty desired, expected empty",
+			currentState: []*v1alpha1.ChartConfig{},
+			desiredState: []*v1alpha1.ChartConfig{
+				&v1alpha1.ChartConfig{
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name: "test-chart",
+						},
+					},
+				},
+			},
+			expectedChartConfigs: []*v1alpha1.ChartConfig{},
+			errorMatcher:         nil,
+		},
+		{
+			description: "case 3: equal non-empty current and desired, expected current",
+			currentState: []*v1alpha1.ChartConfig{
+				&v1alpha1.ChartConfig{
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name: "test-chart",
+						},
+					},
+				},
+				&v1alpha1.ChartConfig{
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name: "test-chart-2",
+						},
+					},
+				},
+			},
+			desiredState: []*v1alpha1.ChartConfig{
+				&v1alpha1.ChartConfig{
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name: "test-chart",
+						},
+					},
+				},
+				&v1alpha1.ChartConfig{
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name: "test-chart-2",
+						},
+					},
+				},
+			},
+			expectedChartConfigs: []*v1alpha1.ChartConfig{
+				&v1alpha1.ChartConfig{
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name: "test-chart",
+						},
+					},
+				},
+				&v1alpha1.ChartConfig{
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name: "test-chart-2",
+						},
+					},
+				},
+			},
+			errorMatcher: nil,
+		},
+		{
+			description: "case 4: unequal non-empty current and desired, expected current",
+			currentState: []*v1alpha1.ChartConfig{
+				&v1alpha1.ChartConfig{
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name: "test-chart-2",
+						},
+					},
+				},
+				&v1alpha1.ChartConfig{
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name: "test-chart-3",
+						},
+					},
+				},
+				&v1alpha1.ChartConfig{
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name: "test-chart-4",
+						},
+					},
+				},
+			},
+			desiredState: []*v1alpha1.ChartConfig{
+				&v1alpha1.ChartConfig{
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name: "test-chart-1",
+						},
+					},
+				},
+				&v1alpha1.ChartConfig{
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name: "test-chart-2",
+						},
+					},
+				},
+			},
+			expectedChartConfigs: []*v1alpha1.ChartConfig{
+				&v1alpha1.ChartConfig{
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name: "test-chart-2",
+						},
+					},
+				},
+				&v1alpha1.ChartConfig{
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name: "test-chart-3",
+						},
+					},
+				},
+				&v1alpha1.ChartConfig{
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name: "test-chart-4",
+						},
+					},
+				},
+			},
+			errorMatcher: nil,
+		},
+		{
+			description: "case 5: incorrect type for current, expected error",
+			currentState: []v1alpha1.ChartConfig{
+				v1alpha1.ChartConfig{
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name: "test-chart",
+						},
+					},
+				},
+			},
+			desiredState:         []*v1alpha1.ChartConfig{},
+			expectedChartConfigs: []*v1alpha1.ChartConfig{},
+			errorMatcher:         IsWrongType,
+		},
+	}
+
+	c := Config{
+		BaseClusterConfig: cluster.Config{
+			ClusterID: "test-cluster",
+		},
+		G8sClient:   fake.NewSimpleClientset(),
+		Guest:       &guestMock{},
+		K8sClient:   clientgofake.NewSimpleClientset(),
+		Logger:      microloggertest.New(),
+		ProjectName: "cluster-operator",
+		ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
+			return v.(v1alpha1.ClusterGuestConfig), nil
+		},
+	}
+	newResource, err := New(c)
+	if err != nil {
+		t.Fatal("expected", nil, "got", err)
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := newResource.newDeleteChangeForDeletePatch(context.TODO(), tc.obj, tc.currentState, tc.desiredState)
+
+			if err != nil {
+				switch {
+				case err == nil && tc.errorMatcher == nil: // correct; carry on
+				case err != nil && tc.errorMatcher != nil:
+					if !tc.errorMatcher(err) {
+						t.Fatalf("error == %#v, want matching", err)
+					}
+				case err != nil && tc.errorMatcher == nil:
+					t.Fatalf("error == %#v, want nil", err)
+				case err == nil && tc.errorMatcher != nil:
+					t.Fatalf("error == nil, want non-nil")
+				}
+			} else if !reflect.DeepEqual(result, tc.expectedChartConfigs) {
+				t.Fatalf("expected %#v got %#v", tc.expectedChartConfigs, result)
+			}
+		})
+	}
+}

--- a/pkg/v1/resource/chartconfig/desired_test.go
+++ b/pkg/v1/resource/chartconfig/desired_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/giantswarm/cluster-operator/pkg/cluster"
 )
 
-func Test_GetDesiredState(t *testing.T) {
+func Test_ChartConfig_GetDesiredState(t *testing.T) {
 	testCases := []struct {
 		name           string
 		obj            interface{}


### PR DESCRIPTION
Towards giantswarm/giantswarm#1902

Adds delete support. There will be a final PR for the update support and then the chartconfig resource is a wrap.