### PR TITLE
WIP: Configure chartconfig resource for aws

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -78,7 +78,7 @@
   branch = "master"
   name = "github.com/giantswarm/certs"
   packages = ["."]
-  revision = "162a1130d27d6bbe1ab101059afab985707e46b0"
+  revision = "25f23b0e8cccf531f2f88554d498a9d54d29ca03"
 
 [[projects]]
   branch = "master"

--- a/pkg/v1/guestcluster/error.go
+++ b/pkg/v1/guestcluster/error.go
@@ -10,3 +10,10 @@ var invalidConfigError = microerror.New("invalid config")
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
+
+var notFoundError = microerror.New("not found")
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}

--- a/pkg/v1/guestcluster/guestcluster.go
+++ b/pkg/v1/guestcluster/guestcluster.go
@@ -44,7 +44,9 @@ func (s *Service) NewG8sClient(ctx context.Context, clusterID, apiDomain string)
 	s.logger.LogCtx(ctx, "level", "debug", "message", "looking for certificate to connect to the guest cluster")
 
 	operatorCerts, err := s.certsSearcher.SearchClusterOperator(clusterID)
-	if err != nil {
+	if certs.IsTimeout(err) {
+		return nil, microerror.Maskf(notFoundError, "cluster-operator cert not found for cluster")
+	} else if err != nil {
 		return nil, microerror.Mask(err)
 	}
 

--- a/pkg/v1/resource/chartconfig/current.go
+++ b/pkg/v1/resource/chartconfig/current.go
@@ -6,7 +6,10 @@ import (
 
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/framework/context/resourcecanceledcontext"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/cluster-operator/pkg/v1/guestcluster"
 )
 
 // GetCurrentState returns the ChartConfig resources present in the guest
@@ -25,7 +28,13 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	}
 
 	g8sClient, err := r.guest.NewG8sClient(ctx, clusterConfig.ClusterID, clusterConfig.Domain.API)
-	if err != nil {
+	if guestcluster.IsNotFound(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the cluster-operator cert in the Kubernetes API")
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+		return nil, nil
+
+	} else if err != nil {
 		return nil, microerror.Mask(err)
 	}
 

--- a/pkg/v1/resource/chartconfig/current.go
+++ b/pkg/v1/resource/chartconfig/current.go
@@ -7,6 +7,7 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/framework/context/resourcecanceledcontext"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/cluster-operator/pkg/v1/guestcluster"
@@ -30,8 +31,12 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	g8sClient, err := r.guest.NewG8sClient(ctx, clusterConfig.ClusterID, clusterConfig.Domain.API)
 	if guestcluster.IsNotFound(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the cluster-operator cert in the Kubernetes API")
+
+		// We can't continue without the cert. We will retry during the next
+		// execution.
 		resourcecanceledcontext.SetCanceled(ctx)
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
 		return nil, nil
 
 	} else if err != nil {
@@ -39,7 +44,17 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	}
 
 	chartConfigList, err := g8sClient.CoreV1alpha1().ChartConfigs(metav1.NamespaceSystem).List(metav1.ListOptions{})
-	if err != nil {
+	if apierrors.IsNotFound(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the chartconfig CRD in the guest cluster")
+
+		// CRD is created by chart-operator which may not be running yet in the
+		// guest cluster. We will retry during the next execution.
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return nil, nil
+
+	} else if err != nil {
 		return nil, microerror.Mask(err)
 	}
 

--- a/service/service.go
+++ b/service/service.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/certs"
@@ -101,6 +102,8 @@ func New(config Config) (*Service, error) {
 		c := certs.Config{
 			K8sClient: k8sClient,
 			Logger:    config.Logger,
+
+			WatchTimeout: 5 * time.Second,
 		}
 
 		certsSearcher, err = certs.NewSearcher(c)

--- a/vendor/github.com/giantswarm/certs/error.go
+++ b/vendor/github.com/giantswarm/certs/error.go
@@ -4,7 +4,7 @@ import "github.com/giantswarm/microerror"
 
 var executionError = microerror.New("execution error")
 
-func IsExecutionError(err error) bool {
+func IsExecution(err error) bool {
 	return microerror.Cause(err) == executionError
 }
 
@@ -22,12 +22,12 @@ func IsInvalidSecret(err error) bool {
 
 var timeoutError = microerror.New("timeout")
 
-func IsTimeoutError(err error) bool {
+func IsTimeout(err error) bool {
 	return microerror.Cause(err) == timeoutError
 }
 
 var wrongTypeError = microerror.New("wrong type")
 
-func IsWrongTypeError(err error) bool {
+func IsWrongType(err error) bool {
 	return microerror.Cause(err) == wrongTypeError
 }


### PR DESCRIPTION
Towards giantswarm/giantswarm#1902

This PR enables the chartconfig resource for AWS. It also cancels the resource reconciliation if the cluster-operator cert doesn't exist in the host cluster. Or if the chartconfig CRD hasn't been created in the guest cluster yet.

This was tested with a locally launched AWS cluster. I still need to add the cluster-operator cert to kubernetesd and cluster-operator before this can be merged.
