### PR TITLE
Add API cert for cluster-operator

### DIFF
--- a/pkg/v1/resource/certconfig/desired.go
+++ b/pkg/v1/resource/certconfig/desired.go
@@ -180,11 +180,9 @@ func newCalicoCertConfig(clusterConfig cluster.Config, cert certs.Cert, projectN
 		ObjectMeta: apimetav1.ObjectMeta{
 			Name: key.CertConfigName(clusterConfig.ClusterID, cert),
 			Labels: map[string]string{
-				label.Cluster:         clusterConfig.ClusterID,
-				label.LegacyClusterID: clusterConfig.ClusterID,
-				label.LegacyComponent: certName,
-				label.ManagedBy:       projectName,
-				label.Organization:    clusterConfig.Organization,
+				label.Cluster:      clusterConfig.ClusterID,
+				label.ManagedBy:    projectName,
+				label.Organization: clusterConfig.Organization,
 			},
 		},
 		Spec: v1alpha1.CertConfigSpec{

--- a/pkg/v1/resource/certconfig/desired.go
+++ b/pkg/v1/resource/certconfig/desired.go
@@ -180,9 +180,11 @@ func newCalicoCertConfig(clusterConfig cluster.Config, cert certs.Cert, projectN
 		ObjectMeta: apimetav1.ObjectMeta{
 			Name: key.CertConfigName(clusterConfig.ClusterID, cert),
 			Labels: map[string]string{
-				label.Cluster:      clusterConfig.ClusterID,
-				label.ManagedBy:    projectName,
-				label.Organization: clusterConfig.Organization,
+				label.Cluster:         clusterConfig.ClusterID,
+				label.LegacyClusterID: clusterConfig.ClusterID,
+				label.LegacyComponent: certName,
+				label.ManagedBy:       projectName,
+				label.Organization:    clusterConfig.Organization,
 			},
 		},
 		Spec: v1alpha1.CertConfigSpec{
@@ -211,11 +213,9 @@ func newClusterOperatorAPICertConfig(clusterConfig cluster.Config, cert certs.Ce
 		ObjectMeta: apimetav1.ObjectMeta{
 			Name: key.CertConfigName(clusterConfig.ClusterID, cert),
 			Labels: map[string]string{
-				label.Cluster:         clusterConfig.ClusterID,
-				label.LegacyClusterID: clusterConfig.ClusterID,
-				label.LegacyComponent: certName,
-				label.ManagedBy:       projectName,
-				label.Organization:    clusterConfig.Organization,
+				label.Cluster:      clusterConfig.ClusterID,
+				label.ManagedBy:    projectName,
+				label.Organization: clusterConfig.Organization,
 			},
 		},
 		Spec: v1alpha1.CertConfigSpec{

--- a/pkg/v1/resource/certconfig/desired.go
+++ b/pkg/v1/resource/certconfig/desired.go
@@ -57,6 +57,10 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		desiredCertConfigs = append(desiredCertConfigs, certConfig)
 	}
 	{
+		certConfig := newClusterOperatorAPICertConfig(clusterConfig, certs.ClusterOperatorAPICert, r.projectName)
+		desiredCertConfigs = append(desiredCertConfigs, certConfig)
+	}
+	{
 		certConfig := newEtcdCertConfig(clusterConfig, certs.EtcdCert, r.projectName)
 		desiredCertConfigs = append(desiredCertConfigs, certConfig)
 	}
@@ -189,6 +193,39 @@ func newCalicoCertConfig(clusterConfig cluster.Config, cert certs.Cert, projectN
 				ClusterComponent:    certName,
 				ClusterID:           clusterConfig.ClusterID,
 				CommonName:          clusterConfig.Domain.Calico,
+				DisableRegeneration: false,
+				TTL:                 clusterConfig.CertTTL,
+			},
+			VersionBundle: v1alpha1.CertConfigSpecVersionBundle{
+				Version: clusterConfig.VersionBundleVersion,
+			},
+		},
+	}
+}
+
+func newClusterOperatorAPICertConfig(clusterConfig cluster.Config, cert certs.Cert, projectName string) *v1alpha1.CertConfig {
+	certName := string(cert)
+	return &v1alpha1.CertConfig{
+		TypeMeta: apimetav1.TypeMeta{
+			Kind:       certKind,
+			APIVersion: certAPIVersion,
+		},
+		ObjectMeta: apimetav1.ObjectMeta{
+			Name: key.CertConfigName(clusterConfig.ClusterID, cert),
+			Labels: map[string]string{
+				label.Cluster:         clusterConfig.ClusterID,
+				label.LegacyClusterID: clusterConfig.ClusterID,
+				label.LegacyComponent: certName,
+				label.ManagedBy:       projectName,
+				label.Organization:    clusterConfig.Organization,
+			},
+		},
+		Spec: v1alpha1.CertConfigSpec{
+			Cert: v1alpha1.CertConfigSpecCert{
+				AllowBareDomains:    false,
+				ClusterComponent:    certName,
+				ClusterID:           clusterConfig.ClusterID,
+				CommonName:          clusterConfig.Domain.API,
 				DisableRegeneration: false,
 				TTL:                 clusterConfig.CertTTL,
 			},

--- a/pkg/v1/resource/certconfig/desired_test.go
+++ b/pkg/v1/resource/certconfig/desired_test.go
@@ -19,6 +19,7 @@ func Test_GetDesiredState_Returns_CertConfig_For_All_Managed_Certs(t *testing.T)
 	managedCertificates := []certs.Cert{
 		certs.APICert,
 		certs.CalicoCert,
+		certs.ClusterOperatorAPICert,
 		certs.EtcdCert,
 		certs.NodeOperatorCert,
 		certs.PrometheusCert,


### PR DESCRIPTION
Towards giantswarm/giantswarm#1902

Adds the cluster-operator cert so it can connect to the API server in guest clusters. This is for installing chart-operator and managing chartconfig CRs.