### PR TITLE
Cancel chartconfig resource if cluster-operator cert or chartconfig CRD do not exist

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -78,7 +78,7 @@
   branch = "master"
   name = "github.com/giantswarm/certs"
   packages = ["."]
-  revision = "162a1130d27d6bbe1ab101059afab985707e46b0"
+  revision = "25f23b0e8cccf531f2f88554d498a9d54d29ca03"
 
 [[projects]]
   branch = "master"
@@ -715,6 +715,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b85a0fa6031afd71b9a6505c96c44eafe763888631dedf2187609043940675e7"
+  inputs-digest = "dacf9ef4ae7054d04c764d9138bcc303b6440aafb1ad0c93b7c4ea575fcd2f61"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/v1/guestcluster/error.go
+++ b/pkg/v1/guestcluster/error.go
@@ -10,3 +10,10 @@ var invalidConfigError = microerror.New("invalid config")
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
+
+var notFoundError = microerror.New("not found")
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}

--- a/pkg/v1/guestcluster/guestcluster.go
+++ b/pkg/v1/guestcluster/guestcluster.go
@@ -83,7 +83,9 @@ func (s *Service) newKubernetesRestConfig(ctx context.Context, clusterID, apiDom
 	s.logger.LogCtx(ctx, "level", "debug", "message", "looking for certificate to connect to the guest cluster")
 
 	operatorCerts, err := s.certsSearcher.SearchClusterOperator(clusterID)
-	if err != nil {
+	if certs.IsTimeout(err) {
+		return nil, microerror.Maskf(notFoundError, "cluster-operator cert not found for cluster")
+	} else if err != nil {
 		return nil, microerror.Mask(err)
 	}
 

--- a/pkg/v1/resource/chartconfig/current.go
+++ b/pkg/v1/resource/chartconfig/current.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
-	"github.com/giantswarm/cluster-operator/pkg/v1/guestcluster"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/framework/context/resourcecanceledcontext"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/cluster-operator/pkg/v1/guestcluster"
 )
 
 // GetCurrentState returns the ChartConfig resources present in the guest

--- a/pkg/v1/resource/chartconfig/current.go
+++ b/pkg/v1/resource/chartconfig/current.go
@@ -8,6 +8,7 @@ import (
 	"github.com/giantswarm/cluster-operator/pkg/v1/guestcluster"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/framework/context/resourcecanceledcontext"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -42,7 +43,18 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	}
 
 	chartConfigList, err := g8sClient.CoreV1alpha1().ChartConfigs(metav1.NamespaceSystem).List(metav1.ListOptions{})
-	if err != nil {
+	if apierrors.IsNotFound(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the chartconfig CRD in the guest cluster")
+
+		// ChartConfig CRD is created by chart-operator which may not be
+		// running yet in the guest cluster. We will retry during the next
+		// execution.
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return nil, nil
+
+	} else if err != nil {
 		return nil, microerror.Mask(err)
 	}
 

--- a/vendor/github.com/giantswarm/certs/error.go
+++ b/vendor/github.com/giantswarm/certs/error.go
@@ -4,7 +4,7 @@ import "github.com/giantswarm/microerror"
 
 var executionError = microerror.New("execution error")
 
-func IsExecutionError(err error) bool {
+func IsExecution(err error) bool {
 	return microerror.Cause(err) == executionError
 }
 
@@ -22,12 +22,12 @@ func IsInvalidSecret(err error) bool {
 
 var timeoutError = microerror.New("timeout")
 
-func IsTimeoutError(err error) bool {
+func IsTimeout(err error) bool {
 	return microerror.Cause(err) == timeoutError
 }
 
 var wrongTypeError = microerror.New("wrong type")
 
-func IsWrongTypeError(err error) bool {
+func IsWrongType(err error) bool {
 	return microerror.Cause(err) == wrongTypeError
 }


### PR DESCRIPTION
Towards giantswarm/giantswarm#1902

Cancel reconciliation of chartconfig resource if the cluster-operator API cert is not found. Or if the chartconfig CRD is not found in the guest cluster.

In both cases we cancel as we can't continue and will retry in the next execution. For the chartconfig CRD there will be a delay until chart-operator is running in the guest cluster since it creates the CRD.