### PR TITLE
Add encryptionkey resource to Azure Cluster Config framework

### DIFF
--- a/service/azureclusterconfig/v1/key/key.go
+++ b/service/azureclusterconfig/v1/key/key.go
@@ -5,6 +5,11 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
+// ToClusterGuestConfig extracts ClusterGuestConfig from AzureClusterConfig.
+func ToClusterGuestConfig(azureClusterConfig v1alpha1.AzureClusterConfig) v1alpha1.ClusterGuestConfig {
+	return azureClusterConfig.Spec.Guest.ClusterGuestConfig
+}
+
 // ToCustomObject converts value to v1alpha1.AzureClusterConfig and returns it or
 // error if type does not match.
 func ToCustomObject(v interface{}) (v1alpha1.AzureClusterConfig, error) {


### PR DESCRIPTION
This enables guest cluster encryption key management in Azure by
cluster-operator. This is a requirement for kubernetesd ->
cluster-operator migration.