### PR TITLE
Optimize resource ordering to execute encryptionKeyResource first

### DIFF
--- a/service/awsclusterconfig/v1/resource_set.go
+++ b/service/awsclusterconfig/v1/resource_set.go
@@ -87,8 +87,11 @@ func NewResourceSet(config ResourceSetConfig) (*framework.ResourceSet, error) {
 	}
 
 	resources := []framework.Resource{
-		awsConfigResource,
+		// Put encryptionKeyResource first because it executes faster than
+		// awsConfigResource and could introduce dependency during cluster
+		// creation.
 		encryptionKeyResource,
+		awsConfigResource,
 	}
 
 	// Wrap resources with retry and metrics.

--- a/service/azureclusterconfig/v1/resource_set.go
+++ b/service/azureclusterconfig/v1/resource_set.go
@@ -87,8 +87,11 @@ func NewResourceSet(config ResourceSetConfig) (*framework.ResourceSet, error) {
 	}
 
 	resources := []framework.Resource{
-		azureConfigResource,
+		// Put encryptionKeyResource first because it executes faster than
+		// azureConfigResource and could introduce dependency during cluster
+		// creation.
 		encryptionKeyResource,
+		azureConfigResource,
 	}
 
 	// Wrap resources with retry and metrics.

--- a/service/kvmclusterconfig/v1/resource_set.go
+++ b/service/kvmclusterconfig/v1/resource_set.go
@@ -86,6 +86,9 @@ func NewResourceSet(config ResourceSetConfig) (*framework.ResourceSet, error) {
 	}
 
 	resources := []framework.Resource{
+		// Put encryptionKeyResource first because it executes faster than
+		// kvmConfigResource and could introduce dependency during cluster
+		// creation.
 		encryptionKeyResource,
 		kvmConfigResource,
 	}


### PR DESCRIPTION
Optimize resource ordering so encryptionkey secret is created before
provider specific resource starts creating the whole cluster. This
should speed up cluster creation and remove possible dependency issues.