### PR TITLE
Allow cluster-operator to create/delete secrets

### DIFF
--- a/helm/cluster-operator-chart/templates/rbac.yaml
+++ b/helm/cluster-operator-chart/templates/rbac.yaml
@@ -7,9 +7,9 @@ rules:
       - ""
     resources:
       - secrets
-    resourceNames:
-      - cluster-operator-pull-secret
     verbs:
+      - create
+      - delete
       - get
   - apiGroups:
       - ""


### PR DESCRIPTION
In order to manage encryptionkey secrets, create/read verbs must be
allowed for secrets. This wasn't catched earlier due to testing on
geckon (no RBAC enforcing).