### PR TITLE
Reduce certs searcher timeout

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -135,7 +135,7 @@ func New(config Config) (*Service, error) {
 			K8sClient: k8sClient,
 			Logger:    config.Logger,
 
-			WatchTimeout: 2 * time.Minute,
+			WatchTimeout: 5 * time.Second,
 		}
 
 		certSearcher, err = certs.NewSearcher(c)


### PR DESCRIPTION
Reduces the searcher timeout so we fail faster if we can't get the cert. The resource reconciliation will be canceled and we can retry on the next resync.