### PR TITLE
Write changelog messages & remove component reference

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -316,7 +316,7 @@
   branch = "master"
   name = "github.com/giantswarm/versionbundle"
   packages = ["."]
-  revision = "d9e6f0b682c63fc5a070aacaa48001ded44b16dc"
+  revision = "94e7abbcdd8662cf87bb046f612fa4016277b30a"
 
 [[projects]]
   name = "github.com/go-ini/ini"

--- a/service/controller/aws/v1/version_bundle.go
+++ b/service/controller/aws/v1/version_bundle.go
@@ -10,7 +10,7 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "Cluster Operator",
+				Component:   "cluster-operator",
 				Description: "Initial version for AWS",
 				Kind:        versionbundle.KindAdded,
 			},

--- a/service/controller/aws/v2/version_bundle.go
+++ b/service/controller/aws/v2/version_bundle.go
@@ -11,7 +11,7 @@ func VersionBundle() versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "cluster-operator",
-				Description: "Chart resource enabled.",
+				Description: "Install chart-operator in kube-system namespace.",
 				Kind:        versionbundle.KindChanged,
 			},
 			{

--- a/service/controller/aws/v2/version_bundle.go
+++ b/service/controller/aws/v2/version_bundle.go
@@ -11,12 +11,12 @@ func VersionBundle() versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "cluster-operator",
-				Description: "Install chart-operator in kube-system namespace.",
+				Description: "Installed chart-operator in kube-system namespace.",
 				Kind:        versionbundle.KindChanged,
 			},
 			{
 				Component:   "cluster-operator",
-				Description: "Misleading component reference to aws-operator removed.",
+				Description: "Removed misleading component reference to aws-operator.",
 				Kind:        versionbundle.KindFixed,
 			},
 		},

--- a/service/controller/aws/v2/version_bundle.go
+++ b/service/controller/aws/v2/version_bundle.go
@@ -10,17 +10,17 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "Cluster Operator",
-				Description: "TODO",
+				Component:   "cluster-operator",
+				Description: "Chart resource enabled.",
 				Kind:        versionbundle.KindChanged,
 			},
-		},
-		Components: []versionbundle.Component{
 			{
-				Name:    "aws-operator",
-				Version: "1.0.0",
+				Component:   "cluster-operator",
+				Description: "Misleading component reference to aws-operator removed.",
+				Kind:        versionbundle.KindFixed,
 			},
 		},
+		Components:   []versionbundle.Component{},
 		Dependencies: []versionbundle.Dependency{},
 		Deprecated:   false,
 		Name:         "cluster-operator",

--- a/service/controller/azure/v1/version_bundle.go
+++ b/service/controller/azure/v1/version_bundle.go
@@ -10,7 +10,7 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "Cluster Operator",
+				Component:   "cluster-operator",
 				Description: "Initial version for Azure",
 				Kind:        versionbundle.KindAdded,
 			},

--- a/service/controller/azure/v2/version_bundle.go
+++ b/service/controller/azure/v2/version_bundle.go
@@ -10,17 +10,17 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "Cluster Operator",
-				Description: "TODO",
+				Component:   "cluster-operator",
+				Description: "Chart resource enabled.",
 				Kind:        versionbundle.KindChanged,
 			},
-		},
-		Components: []versionbundle.Component{
 			{
-				Name:    "azure-operator",
-				Version: "1.0.0",
+				Component:   "cluster-operator",
+				Description: "Misleading component reference to azure-operator removed.",
+				Kind:        versionbundle.KindFixed,
 			},
 		},
+		Components:   []versionbundle.Component{},
 		Dependencies: []versionbundle.Dependency{},
 		Deprecated:   false,
 		Name:         "cluster-operator",

--- a/service/controller/azure/v2/version_bundle.go
+++ b/service/controller/azure/v2/version_bundle.go
@@ -11,7 +11,7 @@ func VersionBundle() versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "cluster-operator",
-				Description: "Chart resource enabled.",
+				Description: "Install chart-operator in kube-system namespace.",
 				Kind:        versionbundle.KindChanged,
 			},
 			{

--- a/service/controller/azure/v2/version_bundle.go
+++ b/service/controller/azure/v2/version_bundle.go
@@ -11,12 +11,12 @@ func VersionBundle() versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "cluster-operator",
-				Description: "Install chart-operator in kube-system namespace.",
+				Description: "Installed chart-operator in kube-system namespace.",
 				Kind:        versionbundle.KindChanged,
 			},
 			{
 				Component:   "cluster-operator",
-				Description: "Misleading component reference to azure-operator removed.",
+				Description: "Removed misleading component reference to azure-operator.",
 				Kind:        versionbundle.KindFixed,
 			},
 		},

--- a/service/controller/kvm/v1/version_bundle.go
+++ b/service/controller/kvm/v1/version_bundle.go
@@ -10,7 +10,7 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "Cluster Operator",
+				Component:   "cluster-operator",
 				Description: "Initial version for KVM",
 				Kind:        versionbundle.KindAdded,
 			},

--- a/service/controller/kvm/v2/version_bundle.go
+++ b/service/controller/kvm/v2/version_bundle.go
@@ -10,17 +10,17 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "Cluster Operator",
-				Description: "TODO",
+				Component:   "cluster-operator",
+				Description: "Chart resource enabled.",
 				Kind:        versionbundle.KindChanged,
 			},
-		},
-		Components: []versionbundle.Component{
 			{
-				Name:    "kvm-operator",
-				Version: "1.0.0",
+				Component:   "cluster-operator",
+				Description: "Misleading component reference to kvm-operator removed.",
+				Kind:        versionbundle.KindFixed,
 			},
 		},
+		Components:   []versionbundle.Component{},
 		Dependencies: []versionbundle.Dependency{},
 		Deprecated:   false,
 		Name:         "cluster-operator",

--- a/service/controller/kvm/v2/version_bundle.go
+++ b/service/controller/kvm/v2/version_bundle.go
@@ -11,7 +11,7 @@ func VersionBundle() versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "cluster-operator",
-				Description: "Chart resource enabled.",
+				Description: "Install chart-operator in kube-system namespace.",
 				Kind:        versionbundle.KindChanged,
 			},
 			{

--- a/service/controller/kvm/v2/version_bundle.go
+++ b/service/controller/kvm/v2/version_bundle.go
@@ -11,12 +11,12 @@ func VersionBundle() versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "cluster-operator",
-				Description: "Install chart-operator in kube-system namespace.",
+				Description: "Installed chart-operator in kube-system namespace.",
 				Kind:        versionbundle.KindChanged,
 			},
 			{
 				Component:   "cluster-operator",
-				Description: "Misleading component reference to kvm-operator removed.",
+				Description: "Removed misleading component reference to kvm-operator.",
 				Kind:        versionbundle.KindFixed,
 			},
 		},

--- a/vendor/github.com/giantswarm/versionbundle/bundle.go
+++ b/vendor/github.com/giantswarm/versionbundle/bundle.go
@@ -171,9 +171,6 @@ func (b Bundle) Validate() error {
 		}
 	}
 
-	if len(b.Components) == 0 {
-		return microerror.Maskf(invalidBundleError, "components must not be empty")
-	}
 	for _, c := range b.Components {
 		err := c.Validate()
 		if err != nil {

--- a/vendor/github.com/giantswarm/versionbundle/release.go
+++ b/vendor/github.com/giantswarm/versionbundle/release.go
@@ -9,6 +9,8 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
+const releaseTimestampFormat = "2006-01-02T15:04:05.000000Z"
+
 type ReleaseConfig struct {
 	Bundles []Bundle
 }
@@ -169,7 +171,7 @@ func aggregateReleaseTimestamp(bundles []Bundle) (string, error) {
 		}
 	}
 
-	return t.Format("2006-01-02T15:04:05.000000Z"), nil
+	return t.Format(releaseTimestampFormat), nil
 }
 
 func aggregateReleaseVersion(bundles []Bundle) (string, error) {

--- a/vendor/github.com/giantswarm/versionbundle/releases.go
+++ b/vendor/github.com/giantswarm/versionbundle/releases.go
@@ -1,0 +1,37 @@
+package versionbundle
+
+import "sort"
+
+// CanonicalizeReleases canonicalizes representation of multiple releases. It
+// makes sure there are no duplicate versions.
+func CanonicalizeReleases(releases []Release) []Release {
+	releases = deduplicateReleases(releases)
+	// TODO: Add changelog deduplication here.
+
+	return releases
+}
+
+func deduplicateReleases(releases []Release) []Release {
+	if len(releases) < 2 {
+		return releases
+	}
+
+	sort.Sort(SortReleasesByTimestamp(releases))
+	sort.Stable(SortReleasesByVersion(releases))
+
+	for i := 0; i < len(releases)-1; i++ {
+		if releases[i].Version() == releases[i+1].Version() {
+			// NOTE: This will remove newer version of two duplicates to
+			// maintain active version available.
+			if !releases[i].Active() {
+				releases = append(releases[:i], releases[i+1:]...)
+				i--
+			} else {
+				releases = append(releases[:i+1], releases[i+2:]...)
+				i--
+			}
+		}
+	}
+
+	return releases
+}

--- a/vendor/github.com/giantswarm/versionbundle/releases_sort.go
+++ b/vendor/github.com/giantswarm/versionbundle/releases_sort.go
@@ -1,7 +1,27 @@
 package versionbundle
 
+import "time"
+
 type SortReleasesByVersion []Release
 
 func (r SortReleasesByVersion) Len() int           { return len(r) }
 func (r SortReleasesByVersion) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
 func (r SortReleasesByVersion) Less(i, j int) bool { return r[i].Version() < r[j].Version() }
+
+type SortReleasesByTimestamp []Release
+
+func (r SortReleasesByTimestamp) Len() int      { return len(r) }
+func (r SortReleasesByTimestamp) Swap(i, j int) { r[i], r[j] = r[j], r[i] }
+func (r SortReleasesByTimestamp) Less(i, j int) bool {
+	iTime, err := time.Parse(releaseTimestampFormat, r[i].Timestamp())
+	if err != nil {
+		panic(err)
+	}
+
+	jTime, err := time.Parse(releaseTimestampFormat, r[j].Timestamp())
+	if err != nil {
+		panic(err)
+	}
+
+	return iTime.UnixNano() < jTime.UnixNano()
+}


### PR DESCRIPTION
Component reference in version bundle caused misunderstandings among SEs
and customers. SIG Operator decided to remove it. To make this
effective, prepare for new release by writing appropriate changelog
messages.