### PR TITLE
Allow watch for secrets

### DIFF
--- a/helm/cluster-operator-chart/templates/rbac.yaml
+++ b/helm/cluster-operator-chart/templates/rbac.yaml
@@ -11,6 +11,7 @@ rules:
       - create
       - delete
       - get
+      - watch
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
Cluster operator needs secret for guest API access and certs.Searcher
uses watcher for finding them. This requires watch verb on allowed verbs
list for secrets.