### PR TITLE
add status to desired state

### DIFF
--- a/pkg/v3/resource/chart/desired.go
+++ b/pkg/v3/resource/chart/desired.go
@@ -18,6 +18,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		ChartName:      chartOperatorChart,
 		ReleaseName:    chartOperatorRelease,
 		ReleaseVersion: releaseVersion,
+		ReleaseStatus:  chartOperatorDesiredStatus,
 	}
 
 	return chartState, nil

--- a/pkg/v3/resource/chart/desired_test.go
+++ b/pkg/v3/resource/chart/desired_test.go
@@ -32,6 +32,7 @@ func Test_Chart_GetDesiredState(t *testing.T) {
 				ChartName:      "chart-operator-chart",
 				ReleaseName:    "chart-operator",
 				ReleaseVersion: "0.1.2",
+				ReleaseStatus:  "DEPLOYED",
 			},
 		},
 	}

--- a/pkg/v3/resource/chart/resource.go
+++ b/pkg/v3/resource/chart/resource.go
@@ -22,10 +22,11 @@ const (
 	// Name is the identifier of the resource.
 	Name = "chartv3"
 
-	chartOperatorChart     = "chart-operator-chart"
-	chartOperatorChannel   = "0-1-stable"
-	chartOperatorRelease   = "chart-operator"
-	chartOperatorNamespace = "kube-system"
+	chartOperatorChart         = "chart-operator-chart"
+	chartOperatorChannel       = "0-1-stable"
+	chartOperatorRelease       = "chart-operator"
+	chartOperatorNamespace     = "kube-system"
+	chartOperatorDesiredStatus = "DEPLOYED"
 )
 
 // Config represents the configuration used to create a new chart config resource.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3093

Adds the missing `ReleaseStatus` to the desired state so that updates are not continuously triggered (status is included in current state and we are comparing both states for deciding to trigger updates).