### PR TITLE
Add Namespace resource and implement current and desired states

### DIFF
--- a/pkg/v3/key/key.go
+++ b/pkg/v3/key/key.go
@@ -8,6 +8,7 @@ import (
 	"github.com/giantswarm/certs"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/versionbundle"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // APIDomain returns the API server domain for the guest cluster.
@@ -40,6 +41,12 @@ func DNSZone(clusterGuestConfig v1alpha1.ClusterGuestConfig) string {
 // information in given v1alpha1.ClusterGuestConfig.
 func EncryptionKeySecretName(clusterGuestConfig v1alpha1.ClusterGuestConfig) string {
 	return fmt.Sprintf("%s-%s", ClusterID(clusterGuestConfig), "encryption")
+}
+
+// IsDeleted returns true if the Kubernetes resource has been marked for
+// deletion.
+func IsDeleted(objectMeta apismetav1.ObjectMeta) bool {
+	return objectMeta.DeletionTimestamp != nil
 }
 
 // serverDomain returns the guest cluster domain for the provided cluster

--- a/pkg/v3/key/key_test.go
+++ b/pkg/v3/key/key_test.go
@@ -3,9 +3,11 @@ package key
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/certs"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func Test_APIDomain(t *testing.T) {
@@ -206,6 +208,43 @@ func Test_EncryptionKeySecretName(t *testing.T) {
 		})
 	}
 
+}
+
+func Test_IsDeleted(t *testing.T) {
+	testCases := []struct {
+		description    string
+		objectMeta     apismetav1.ObjectMeta
+		expectedResult bool
+	}{
+		{
+			description:    "case 0: false when struct is empty",
+			objectMeta:     apismetav1.ObjectMeta{},
+			expectedResult: false,
+		},
+		{
+			description: "case 1: false when field is nil",
+			objectMeta: apismetav1.ObjectMeta{
+				DeletionTimestamp: nil,
+			},
+			expectedResult: false,
+		},
+		{
+			description: "case 2: true when field is set",
+			objectMeta: apismetav1.ObjectMeta{
+				DeletionTimestamp: &apismetav1.Time{Time: time.Now()},
+			},
+			expectedResult: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result := IsDeleted(tc.objectMeta)
+			if result != tc.expectedResult {
+				t.Fatalf("expected IsDeleted %t, got %t", tc.expectedResult, result)
+			}
+		})
+	}
 }
 
 func Test_ServerDomain(t *testing.T) {

--- a/pkg/v3/resource/namespace/create.go
+++ b/pkg/v3/resource/namespace/create.go
@@ -1,0 +1,9 @@
+package namespace
+
+import (
+	"context"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	return nil
+}

--- a/pkg/v3/resource/namespace/current.go
+++ b/pkg/v3/resource/namespace/current.go
@@ -1,0 +1,48 @@
+package namespace
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	guestK8sClient, err := r.getGuestK8sClient(ctx, obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for the namespace in the guest cluster")
+
+	// Lookup the current state of the namespace.
+	var namespace *apiv1.Namespace
+	{
+		manifest, err := guestK8sClient.CoreV1().Namespaces().Get(namespaceName, apismetav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the namespace in the guest cluster")
+			// fall through
+		} else if err != nil {
+			return nil, microerror.Mask(err)
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "found the namespace in the guest cluster")
+			namespace = manifest
+		}
+	}
+
+	// In case the namespace is already terminating we do not need to do any
+	// further work. Then we cancel the reconciliation to prevent the current and
+	// any further resource from being processed.
+	if namespace != nil && namespace.Status.Phase == "Terminating" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "namespace is in state 'Terminating'")
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return nil, nil
+	}
+
+	return namespace, nil
+}

--- a/pkg/v3/resource/namespace/current.go
+++ b/pkg/v3/resource/namespace/current.go
@@ -3,6 +3,7 @@ package namespace
 import (
 	"context"
 
+	"github.com/giantswarm/cluster-operator/pkg/v3/key"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	apiv1 "k8s.io/api/core/v1"
@@ -11,6 +12,19 @@ import (
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	objectMeta, err := r.toClusterObjectMetaFunc(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	// Guest cluster namespace is not deleted so cancel the reconcilation. The
+	// namespace will be deleted when the guest cluster resources are deleted.
+	if key.IsDeleted(objectMeta) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling namespace deletion: deleted with the guest cluster")
+		resourcecanceledcontext.SetCanceled(ctx)
+		return nil, nil
+	}
+
 	guestK8sClient, err := r.getGuestK8sClient(ctx, obj)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -31,17 +45,6 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 			r.logger.LogCtx(ctx, "level", "debug", "message", "found the namespace in the guest cluster")
 			namespace = manifest
 		}
-	}
-
-	// In case the namespace is already terminating we do not need to do any
-	// further work. Then we cancel the reconciliation to prevent the current and
-	// any further resource from being processed.
-	if namespace != nil && namespace.Status.Phase == "Terminating" {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "namespace is in state 'Terminating'")
-		resourcecanceledcontext.SetCanceled(ctx)
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
-
-		return nil, nil
 	}
 
 	return namespace, nil

--- a/pkg/v3/resource/namespace/delete.go
+++ b/pkg/v3/resource/namespace/delete.go
@@ -10,6 +10,8 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 	return nil
 }
 
+// NewDeletePatch is a no-op because the namespace in the guest cluster is
+// deleted with the guest cluster resources.
 func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
 	return nil, nil
 }

--- a/pkg/v3/resource/namespace/delete.go
+++ b/pkg/v3/resource/namespace/delete.go
@@ -6,6 +6,8 @@ import (
 	"github.com/giantswarm/operatorkit/controller"
 )
 
+// ApplyDeleteChange is a no-op because the namespace in the guest cluster is
+// deleted with the guest cluster resources.
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
 	return nil
 }

--- a/pkg/v3/resource/namespace/delete.go
+++ b/pkg/v3/resource/namespace/delete.go
@@ -1,0 +1,15 @@
+package namespace
+
+import (
+	"context"
+
+	"github.com/giantswarm/operatorkit/controller"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	return nil, nil
+}

--- a/pkg/v3/resource/namespace/desired.go
+++ b/pkg/v3/resource/namespace/desired.go
@@ -1,0 +1,42 @@
+package namespace
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/cluster-operator/pkg/label"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	clusterGuestConfig, err := r.toClusterGuestConfigFunc(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	clusterConfig, err := prepareClusterConfig(r.baseClusterConfig, clusterGuestConfig)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	// Compute the desired state of the namespace to have a reference of how
+	// the data should be.
+	namespace := &apiv1.Namespace{
+		TypeMeta: apismetav1.TypeMeta{
+			Kind:       "Namespace",
+			APIVersion: "v1",
+		},
+		ObjectMeta: apismetav1.ObjectMeta{
+			Name: namespaceName,
+			Labels: map[string]string{
+				label.Cluster:      clusterConfig.ClusterID,
+				label.ManagedBy:    r.projectName,
+				label.Organization: clusterConfig.Organization,
+			},
+		},
+	}
+
+	return namespace, nil
+}

--- a/pkg/v3/resource/namespace/desired_test.go
+++ b/pkg/v3/resource/namespace/desired_test.go
@@ -1,0 +1,72 @@
+package namespace
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+
+	"github.com/giantswarm/cluster-operator/pkg/cluster"
+)
+
+func Test_Resource_Namespace_GetDesiredState(t *testing.T) {
+	testCases := []struct {
+		name           string
+		obj            interface{}
+		expectedName   string
+		expectedLabels map[string]string
+	}{
+		{
+			name: "case 0: basic match",
+			obj: v1alpha1.ClusterGuestConfig{
+				DNSZone: "5xchu.aws.giantswarm.io",
+				ID:      "5xchu",
+				Owner:   "giantswarm",
+			},
+			expectedName: "giantswarm",
+			expectedLabels: map[string]string{
+				"giantswarm.io/cluster":      "5xchu",
+				"giantswarm.io/managed-by":   "cluster-operator",
+				"giantswarm.io/organization": "giantswarm",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := Config{
+				BaseClusterConfig: cluster.Config{
+					ClusterID: "test-cluster",
+				},
+				Guest:       &guestMock{},
+				Logger:      microloggertest.New(),
+				ProjectName: "cluster-operator",
+				ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
+					return v.(v1alpha1.ClusterGuestConfig), nil
+				},
+			}
+			newResource, err := New(c)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+
+			result, err := newResource.GetDesiredState(context.TODO(), tc.obj)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+
+			name := result.(*apiv1.Namespace).Name
+			if tc.expectedName != name {
+				t.Fatalf("expected %q got %q", tc.expectedName, name)
+			}
+
+			labels := result.(*apiv1.Namespace).Labels
+			if !reflect.DeepEqual(tc.expectedLabels, labels) {
+				t.Fatalf("expected %#v got %#v", tc.expectedLabels, labels)
+			}
+		})
+	}
+}

--- a/pkg/v3/resource/namespace/desired_test.go
+++ b/pkg/v3/resource/namespace/desired_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/micrologger/microloggertest"
 	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/cluster-operator/pkg/cluster"
 )
@@ -46,6 +47,9 @@ func Test_Resource_Namespace_GetDesiredState(t *testing.T) {
 				ProjectName: "cluster-operator",
 				ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
 					return v.(v1alpha1.ClusterGuestConfig), nil
+				},
+				ToClusterObjectMetaFunc: func(v interface{}) (apismetav1.ObjectMeta, error) {
+					return v.(apismetav1.ObjectMeta), nil
 				},
 			}
 			newResource, err := New(c)

--- a/pkg/v3/resource/namespace/error.go
+++ b/pkg/v3/resource/namespace/error.go
@@ -1,0 +1,10 @@
+package namespace
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/pkg/v3/resource/namespace/mock_test.go
+++ b/pkg/v3/resource/namespace/mock_test.go
@@ -1,0 +1,25 @@
+package namespace
+
+import (
+	"context"
+
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/helmclient"
+	"k8s.io/client-go/kubernetes"
+)
+
+type guestMock struct {
+	fakeGuestG8sClient  versioned.Interface
+	fakeGuestHelmClient helmclient.Interface
+	fakeGuestK8sClient  kubernetes.Interface
+}
+
+func (g *guestMock) NewG8sClient(ctx context.Context, clusterID, apiDomain string) (versioned.Interface, error) {
+	return g.fakeGuestG8sClient, nil
+}
+func (g *guestMock) NewHelmClient(ctx context.Context, clusterID, apiDomain string) (helmclient.Interface, error) {
+	return g.fakeGuestHelmClient, nil
+}
+func (g *guestMock) NewK8sClient(ctx context.Context, clusterID, apiDomain string) (kubernetes.Interface, error) {
+	return g.fakeGuestK8sClient, nil
+}

--- a/pkg/v3/resource/namespace/resource.go
+++ b/pkg/v3/resource/namespace/resource.go
@@ -7,6 +7,7 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/giantswarm/cluster-operator/pkg/cluster"
@@ -28,6 +29,7 @@ type Config struct {
 	Logger                   micrologger.Logger
 	ProjectName              string
 	ToClusterGuestConfigFunc func(obj interface{}) (v1alpha1.ClusterGuestConfig, error)
+	ToClusterObjectMetaFunc  func(obj interface{}) (apismetav1.ObjectMeta, error)
 }
 
 // Resource implements the namespace resource.
@@ -37,6 +39,7 @@ type Resource struct {
 	logger                   micrologger.Logger
 	projectName              string
 	toClusterGuestConfigFunc func(obj interface{}) (v1alpha1.ClusterGuestConfig, error)
+	toClusterObjectMetaFunc  func(obj interface{}) (apismetav1.ObjectMeta, error)
 }
 
 // New creates a new configured namespace resource.
@@ -56,6 +59,9 @@ func New(config Config) (*Resource, error) {
 	if config.ToClusterGuestConfigFunc == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ToClusterGuestConfigFunc must not be empty", config)
 	}
+	if config.ToClusterObjectMetaFunc == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ToClusterObjectMetaFunc must not be empty", config)
+	}
 
 	newResource := &Resource{
 		baseClusterConfig:        config.BaseClusterConfig,
@@ -63,6 +69,7 @@ func New(config Config) (*Resource, error) {
 		logger:                   config.Logger,
 		projectName:              config.ProjectName,
 		toClusterGuestConfigFunc: config.ToClusterGuestConfigFunc,
+		toClusterObjectMetaFunc:  config.ToClusterObjectMetaFunc,
 	}
 
 	return newResource, nil

--- a/pkg/v3/resource/namespace/update.go
+++ b/pkg/v3/resource/namespace/update.go
@@ -1,0 +1,15 @@
+package namespace
+
+import (
+	"context"
+
+	"github.com/giantswarm/operatorkit/controller"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	return nil, nil
+}


### PR DESCRIPTION
Towards giantswarm/giantswarm#1902

Adds the namespace resource which creates a `giantswarm` namespace in the guest cluster. This will be used for Tiller and chart-operator instead of using kube-system.

This is to avoid conflicting with customers using Tiller in kube-system.