### PR TITLE
Simplify getting g8s client in chartconfig resource

### DIFF
--- a/pkg/v3/resource/chartconfig/create.go
+++ b/pkg/v3/resource/chartconfig/create.go
@@ -11,11 +11,6 @@ import (
 )
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
-	clusterGuestConfig, err := r.toClusterGuestConfigFunc(obj)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
 	chartConfigsToCreate, err := toChartConfigs(createChange)
 	if err != nil {
 		return microerror.Mask(err)
@@ -24,18 +19,13 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 	if len(chartConfigsToCreate) > 0 {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "creating chartconfigs")
 
-		clusterConfig, err := prepareClusterConfig(r.baseClusterConfig, clusterGuestConfig)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		g8sClient, err := r.guest.NewG8sClient(ctx, clusterConfig.ClusterID, clusterConfig.Domain.API)
+		guestG8sClient, err := r.getGuestG8sClient(ctx, obj)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
 		for _, chartConfigToCreate := range chartConfigsToCreate {
-			_, err := g8sClient.CoreV1alpha1().ChartConfigs(metav1.NamespaceSystem).Create(chartConfigToCreate)
+			_, err := guestG8sClient.CoreV1alpha1().ChartConfigs(metav1.NamespaceSystem).Create(chartConfigToCreate)
 			if apierrors.IsAlreadyExists(err) {
 				// fall through
 			} else if err != nil {

--- a/pkg/v3/resource/chartconfig/current.go
+++ b/pkg/v3/resource/chartconfig/current.go
@@ -16,19 +16,10 @@ import (
 // GetCurrentState returns the ChartConfig resources present in the guest
 // cluster.
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
-	clusterGuestConfig, err := r.toClusterGuestConfigFunc(obj)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for chartconfigs in the guest cluster")
 
-	clusterConfig, err := prepareClusterConfig(r.baseClusterConfig, clusterGuestConfig)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	g8sClient, err := r.guest.NewG8sClient(ctx, clusterConfig.ClusterID, clusterConfig.Domain.API)
+	guestG8sClient, err := r.getGuestG8sClient(ctx, obj)
 	if guestcluster.IsNotFound(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the cluster-operator api cert in the Kubernetes API")
 
@@ -43,7 +34,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
-	chartConfigList, err := g8sClient.CoreV1alpha1().ChartConfigs(metav1.NamespaceSystem).List(metav1.ListOptions{})
+	chartConfigList, err := guestG8sClient.CoreV1alpha1().ChartConfigs(metav1.NamespaceSystem).List(metav1.ListOptions{})
 	if apierrors.IsNotFound(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the chartconfig CRD in the guest cluster")
 

--- a/pkg/v3/resource/chartconfig/resource.go
+++ b/pkg/v3/resource/chartconfig/resource.go
@@ -1,6 +1,7 @@
 package chartconfig
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
@@ -100,6 +101,30 @@ func prepareClusterConfig(baseClusterConfig cluster.Config, clusterGuestConfig v
 	clusterConfig.Organization = clusterGuestConfig.Owner
 
 	return clusterConfig, nil
+}
+
+func (r *Resource) getGuestG8sClient(ctx context.Context, obj interface{}) (versioned.Interface, error) {
+	clusterGuestConfig, err := r.toClusterGuestConfigFunc(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	clusterConfig, err := prepareClusterConfig(r.baseClusterConfig, clusterGuestConfig)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	guestAPIDomain, err := key.APIDomain(clusterGuestConfig)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	guestG8sClient, err := r.guest.NewG8sClient(ctx, clusterConfig.ClusterID, guestAPIDomain)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return guestG8sClient, nil
 }
 
 func containsChartConfig(list []*v1alpha1.ChartConfig, item *v1alpha1.ChartConfig) bool {


### PR DESCRIPTION
Some cleanup to simplify how we get the g8s client for the guest cluster. Updates it to match the namespace and chart resources.