### PR TITLE
Cancel resource reconciliation on Tiller install error

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -246,7 +246,7 @@
   branch = "master"
   name = "github.com/giantswarm/helmclient"
   packages = ["."]
-  revision = "189a0a77fc506fec0143ac32f99a9ac7a9e9bb56"
+  revision = "821154e798258995c76fdfa8072a952a016ef061"
 
 [[projects]]
   branch = "master"

--- a/pkg/v3/resource/chart/create.go
+++ b/pkg/v3/resource/chart/create.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/giantswarm/helmclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	"k8s.io/helm/pkg/helm"
@@ -26,6 +27,15 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		// the current guest cluster was not found. We can't continue without a Helm
 		// client. We will retry during the next execution, when the certificate
 		// might be available.
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return nil
+	} else if helmclient.IsTillerInstallationFailed(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "Tiller installation failed")
+
+		// Tiller installation can fail during guest cluster setup. We will retry
+		// on next reconciliation loop.
 		resourcecanceledcontext.SetCanceled(ctx)
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
 

--- a/pkg/v3/resource/chart/delete.go
+++ b/pkg/v3/resource/chart/delete.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 
 	"github.com/giantswarm/cluster-operator/pkg/v3/guestcluster"
+	"github.com/giantswarm/helmclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
@@ -25,6 +26,15 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 		// the current guest cluster was not found. We can't continue without a Helm
 		// client. We will retry during the next execution, when the certificate
 		// might be available.
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return nil
+	} else if helmclient.IsTillerInstallationFailed(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "Tiller installation failed")
+
+		// Tiller installation can fail during guest cluster setup. We will retry
+		// on next reconciliation loop.
 		resourcecanceledcontext.SetCanceled(ctx)
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
 

--- a/pkg/v3/resource/chart/update.go
+++ b/pkg/v3/resource/chart/update.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/giantswarm/helmclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
@@ -22,6 +23,15 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 		// the current guest cluster was not found. We can't continue without a Helm
 		// client. We will retry during the next execution, when the certificate
 		// might be available.
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return nil
+	} else if helmclient.IsTillerInstallationFailed(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "Tiller installation failed")
+
+		// Tiller installation can fail during guest cluster setup. We will retry
+		// on next reconciliation loop.
 		resourcecanceledcontext.SetCanceled(ctx)
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
 

--- a/vendor/github.com/giantswarm/helmclient/error.go
+++ b/vendor/github.com/giantswarm/helmclient/error.go
@@ -103,6 +103,13 @@ func IsReleaseNotFound(err error) bool {
 	return false
 }
 
+var tillerInstallationFailedError = microerror.New("Tiller installation failed")
+
+// IsTillerInstallationFailed asserts tillerInstallationFailedError.
+func IsTillerInstallationFailed(err error) bool {
+	return microerror.Cause(err) == tillerInstallationFailedError
+}
+
 var tooManyResultsError = microerror.New("too many results")
 
 // IsTooManyResults asserts tooManyResultsError.

--- a/vendor/github.com/giantswarm/helmclient/helmclient.go
+++ b/vendor/github.com/giantswarm/helmclient/helmclient.go
@@ -231,7 +231,7 @@ func (c *Client) EnsureTillerInstalled() error {
 
 		err := backoff.RetryNotify(o, b, n)
 		if err != nil {
-			return microerror.Mask(err)
+			return microerror.Maskf(tillerInstallationFailedError, err.Error())
 		}
 
 		c.logger.Log("level", "debug", "message", "succeeded pinging tiller")


### PR DESCRIPTION
Towards https://github.com/giantswarm/cluster-operator/issues/103

Checks for Tiller installation error and cancels resource reconciliation if found instead of letting the error to bubble up.