### PR TITLE
Cancel reconciliation on guest API not ready

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -246,7 +246,7 @@
   branch = "master"
   name = "github.com/giantswarm/helmclient"
   packages = ["."]
-  revision = "821154e798258995c76fdfa8072a952a016ef061"
+  revision = "0393af05514494472c2d0b5cb34bfe9c97ecb975"
 
 [[projects]]
   branch = "master"

--- a/pkg/v3/resource/chart/create.go
+++ b/pkg/v3/resource/chart/create.go
@@ -40,6 +40,15 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
 
 		return nil
+	} else if helmclient.IsGuestAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "Guest API not available.")
+
+		// We should not hammer guest API if it is not available, the guest cluster
+		// might be initializing. We will retry on next reconciliation loop.
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return nil
 	} else if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/v3/resource/chart/delete.go
+++ b/pkg/v3/resource/chart/delete.go
@@ -39,6 +39,15 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
 
 		return nil
+	} else if helmclient.IsGuestAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "Guest API not available.")
+
+		// We should not hammer guest API if it is not available, the guest cluster
+		// might be initializing. We will retry on next reconciliation loop.
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return nil
 	} else if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/v3/resource/chart/update.go
+++ b/pkg/v3/resource/chart/update.go
@@ -36,6 +36,15 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
 
 		return nil
+	} else if helmclient.IsGuestAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "Guest API not available.")
+
+		// We should not hammer guest API if it is not available, the guest cluster
+		// might be initializing. We will retry on next reconciliation loop.
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return nil
 	} else if err != nil {
 		return microerror.Mask(err)
 	}

--- a/vendor/github.com/giantswarm/helmclient/error.go
+++ b/vendor/github.com/giantswarm/helmclient/error.go
@@ -1,6 +1,7 @@
 package helmclient
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/giantswarm/microerror"
@@ -35,6 +36,38 @@ var executionFailedError = microerror.New("execution failed")
 // IsExecutionFailed asserts executionFailedError.
 func IsExecutionFailed(err error) bool {
 	return microerror.Cause(err) == executionFailedError
+}
+
+var guestAPINotAvailableError = microerror.New("Guest API not available")
+var guestNamespaceCreationErrorSuffix = "namespaces/kube-system/serviceaccounts: EOF"
+
+// match example https://play.golang.org/p/ipBkwqlc4Td
+var guestDNSNotReadyPattern = "dial tcp: lookup .* on .*:53: no such host"
+
+// IsGuestAPINotAvailable asserts guestAPINotAvailableError.
+func IsGuestAPINotAvailable(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	c := microerror.Cause(err)
+
+	if strings.HasSuffix(c.Error(), guestNamespaceCreationErrorSuffix) {
+		return true
+	}
+	matched, matchErr := regexp.MatchString(guestDNSNotReadyPattern, c.Error())
+	if matchErr != nil {
+		return false
+	}
+	if matched {
+		return true
+	}
+
+	if c == guestAPINotAvailableError {
+		return true
+	}
+
+	return false
 }
 
 var invalidConfigError = microerror.New("invalid config")

--- a/vendor/github.com/giantswarm/helmclient/helmclient.go
+++ b/vendor/github.com/giantswarm/helmclient/helmclient.go
@@ -141,6 +141,8 @@ func (c *Client) EnsureTillerInstalled() error {
 		if errors.IsAlreadyExists(err) {
 			c.logger.Log("level", "debug", "message", fmt.Sprintf("serviceaccount %s creation failed", tillerPodName), "stack", fmt.Sprintf("%#v", err))
 			// fall through
+		} else if IsGuestAPINotAvailable(err) {
+			return microerror.Maskf(guestAPINotAvailableError, err.Error())
 		} else if err != nil {
 			return microerror.Mask(err)
 		}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3197

Uses `helmclient.IsGuestAPINotAvailable` to cancel reconciliation if guest cluster API is not yet available.