### PR TITLE
e2e: teardown host peer VPC stack on CI

### DIFF
--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -73,9 +73,15 @@ func WrapTestMain(g *framework.Guest, h *framework.Host, helmClient *helmclient.
 			logEntry := "deleted the guest cluster main stack"
 			h.DeleteGuestCluster(name, customResource, logEntry)
 
+			err := teardown.HostPeerVPC(c)
+			if err != nil {
+				log.Printf("%#v\n", err)
+				v = 1
+			}
+
 			// only do full teardown when not on CI
 			if os.Getenv("CIRCLECI") != "true" {
-				err := teardown.Teardown(c, h, helmClient)
+				err := teardown.Resources(c, h, helmClient)
 				if err != nil {
 					log.Printf("%#v\n", err)
 					v = 1

--- a/integration/teardown/teardown.go
+++ b/integration/teardown/teardown.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/helm/pkg/helm"
 )
 
-func Teardown(c *awsclient.Client, f *framework.Host, helmClient *helmclient.Client) error {
+func Resources(c *awsclient.Client, f *framework.Host, helmClient *helmclient.Client) error {
 	items := []string{
 		"cluster-operator",
 		"cluster-operator-resource",
@@ -33,15 +33,10 @@ func Teardown(c *awsclient.Client, f *framework.Host, helmClient *helmclient.Cli
 		}
 	}
 
-	err := hostPeerVPC(c)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
 	return nil
 }
 
-func hostPeerVPC(c *awsclient.Client) error {
+func HostPeerVPC(c *awsclient.Client) error {
 	log.Printf("Deleting Host Peer VPC stack")
 
 	_, err := c.CloudFormation.DeleteStack(&cloudformation.DeleteStackInput{


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3181

After errors on CI we are not cleaning up host peer VPC stack, with this changes we make sure that stack is always removed.