### PR TITLE
Cancel reconciliation when guest cluster is not yet ready

### DIFF
--- a/pkg/v2/resource/chart/current.go
+++ b/pkg/v2/resource/chart/current.go
@@ -22,6 +22,17 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
 
 		return nil, nil
+
+	} else if helmclient.IsGuestAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster is not available")
+
+		// We can't continue without a successful K8s connection. Cluster
+		// may not be up yet. We will retry during the next execution.
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return nil, nil
+
 	} else if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/pkg/v3/resource/chart/current.go
+++ b/pkg/v3/resource/chart/current.go
@@ -31,6 +31,16 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the chart-operator chart in the guest cluster")
 		return nil, nil
 
+	} else if helmclient.IsGuestAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster is not available")
+
+		// We can't continue without a successful K8s connection. Cluster
+		// may not be up yet. We will retry during the next execution.
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return nil, nil
+
 	} else if err != nil {
 		return nil, microerror.Mask(err)
 	}


### PR DESCRIPTION
We also need to check for the guest cluster not being ready in the chart resource. I've backported this to v2 so we clear the alerts.

This should be done now as we have this check in all 3 resources that interact with guest clusters.