### PR TITLE
Reduce resync

### DIFF
--- a/pkg/v3/resource/chart/current.go
+++ b/pkg/v3/resource/chart/current.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/giantswarm/helmclient"
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
 
 	"github.com/giantswarm/cluster-operator/pkg/v3/guestcluster"
 )
@@ -36,8 +36,8 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 
 		// We can't continue without a successful K8s connection. Cluster
 		// may not be up yet. We will retry during the next execution.
-		resourcecanceledcontext.SetCanceled(ctx)
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation for custom object")
 
 		return nil, nil
 

--- a/pkg/v3/resource/chart/current.go
+++ b/pkg/v3/resource/chart/current.go
@@ -18,8 +18,8 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 
 		// We can't continue without a Helm client. We will retry during the
 		// next execution.
-		resourcecanceledcontext.SetCanceled(ctx)
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation for custom object")
 
 		return nil, nil
 	} else if err != nil {

--- a/pkg/v3/resource/namespace/current.go
+++ b/pkg/v3/resource/namespace/current.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -33,8 +34,8 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 
 		// We can't continue without a K8s client. We will retry during the
 		// next execution.
-		resourcecanceledcontext.SetCanceled(ctx)
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation for custom object")
 
 		return nil, nil
 	} else if err != nil {

--- a/pkg/v3/resource/namespace/current.go
+++ b/pkg/v3/resource/namespace/current.go
@@ -55,8 +55,8 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 
 			// We can't continue without a successful K8s connection. Cluster
 			// may not be up yet. We will retry during the next execution.
-			resourcecanceledcontext.SetCanceled(ctx)
-			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+			reconciliationcanceledcontext.SetCanceled(ctx)
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation for custom object")
 
 			return nil, nil
 

--- a/service/controller/aws/cluster.go
+++ b/service/controller/aws/cluster.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"time"
+
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/apprclient"
@@ -63,8 +65,12 @@ func NewCluster(config ClusterConfig) (*Cluster, error) {
 	var newInformer *informer.Informer
 	{
 		c := informer.Config{
-			Logger:  config.Logger,
-			Watcher: config.G8sClient.CoreV1alpha1().AWSClusterConfigs(""),
+			Logger: config.Logger,
+			// ResyncPeriod is 1 minute because some resources access guest
+			// clusters. So we need to wait until they become available. When
+			// a guest cluster is not available we cancel the reconciliation.
+			ResyncPeriod: 1 * time.Minute,
+			Watcher:      config.G8sClient.CoreV1alpha1().AWSClusterConfigs(""),
 		}
 
 		newInformer, err = informer.New(c)


### PR DESCRIPTION
Towards giantswarm/giantswarm#1902

Reduces resync period from 5 mins to 1 min.  Also cancels whole reconciliation when the guest cluster is not up yet and there are following resources that access it.

This is to speed up how quickly we can install chartconfigs so chart-operator can do its thing. The problem is when the chartconfig CRD becomes available. The chart resource installs chart-operator but the CRD is only created when the operator boots.

So we need to wait up until 5 mins for the next resync before the chartconfig resource can create CRs.


