### PR TITLE
Remove e2e tests when deploying

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,3 @@ workflows:
           filters:
             branches:
               only: master
-          requires:
-          - e2eTestCurrentMaster
-          - e2eTestWIPMaster


### PR DESCRIPTION
Currently, we don't deploy on merges to master until the e2e tests have passed. This was OK until we needed to spin up AWS guest clusters for the tests. Now they take about 25 mins before the deploy happens.

I think we should do the same as aws-operator and deploy once the build step has completed.

