### PR TITLE
Remove operator component from old releases

### DIFF
--- a/service/controller/aws/v1/version_bundle.go
+++ b/service/controller/aws/v1/version_bundle.go
@@ -15,12 +15,7 @@ func VersionBundle() versionbundle.Bundle {
 				Kind:        versionbundle.KindAdded,
 			},
 		},
-		Components: []versionbundle.Component{
-			{
-				Name:    "aws-operator",
-				Version: "1.0.0",
-			},
-		},
+		Components:   []versionbundle.Component{},
 		Dependencies: []versionbundle.Dependency{},
 		Deprecated:   true,
 		Name:         "cluster-operator",

--- a/service/controller/azure/v1/version_bundle.go
+++ b/service/controller/azure/v1/version_bundle.go
@@ -15,12 +15,7 @@ func VersionBundle() versionbundle.Bundle {
 				Kind:        versionbundle.KindAdded,
 			},
 		},
-		Components: []versionbundle.Component{
-			{
-				Name:    "azure-operator",
-				Version: "1.0.0",
-			},
-		},
+		Components:   []versionbundle.Component{},
 		Dependencies: []versionbundle.Dependency{},
 		Deprecated:   true,
 		Name:         "cluster-operator",

--- a/service/controller/kvm/v1/version_bundle.go
+++ b/service/controller/kvm/v1/version_bundle.go
@@ -15,12 +15,7 @@ func VersionBundle() versionbundle.Bundle {
 				Kind:        versionbundle.KindAdded,
 			},
 		},
-		Components: []versionbundle.Component{
-			{
-				Name:    "kvm-operator",
-				Version: "1.0.0",
-			},
-		},
+		Components:   []versionbundle.Component{},
 		Dependencies: []versionbundle.Dependency{},
 		Deprecated:   false,
 		Name:         "cluster-operator",


### PR DESCRIPTION
Due to continuing confusion of presence of aws-operator:1.0.0 in older
releases, remove operator component from old releases.

This only changes version bundle metadata, not any functionality.

This should have done like this in the beginning, but I thought that it's
"more right" to create new release and use that. Appears I was wrong.
This is still haunting us so lets remove it for good now.