### PR TITLE
Remove chart resource from AWS v2

### DIFF
--- a/service/controller/aws/v2/version_bundle.go
+++ b/service/controller/aws/v2/version_bundle.go
@@ -17,6 +17,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Removed misleading component reference to aws-operator.",
 				Kind:        versionbundle.KindFixed,
 			},
+			{
+				Component:   "cluster-operator",
+				Description: "Removed chart resource so Tiller is not installed in the kube-system namespace.",
+				Kind:        versionbundle.KindRemoved,
+			},
 		},
 		Components: []versionbundle.Component{},
 		Name:       "cluster-operator",


### PR DESCRIPTION
Removes the chart resource from v2 because it installed Tiller in kube-system and this conflicts with customer workloads. This is OK as no chartconfigs are installed in v2 and all resources are still managed via k8scloudconfig.

In v3 Tiller is installed in the giantswarm namespace which prevents conflicts with customer workloads.

