### PR TITLE
use version bundles info from authorities

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -232,7 +232,7 @@
     "pkg/framework",
     "pkg/harness"
   ]
-  revision = "54be9f9ff435305dcbe09ee26fc94361ac57a330"
+  revision = "614e2f621998114f38515088a7c274316bddeec3"
 
 [[projects]]
   branch = "master"

--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -105,42 +105,33 @@ func WrapTestMain(g *framework.Guest, h *framework.Host, helmClient *helmclient.
 	token := os.Getenv("GITHUB_BOT_TOKEN")
 	vType := os.Getenv("TESTED_VERSION")
 	params := &framework.VBVParams{
-		Component: "cluster-operator",
-		Provider:  "aws",
-		Token:     token,
-		VType:     vType,
+		Provider: "aws",
+		Token:    token,
+		VType:    vType,
 	}
-	vbv, err := framework.GetVersionBundleVersion(params)
-	if err != nil {
-		log.Printf("%#v\n", err)
-		v = 1
-		return
-	}
+	authorities, err = framework.GetAuthorities(params)
 	// do not fail on missing WIP.
-	if vbv == "" && os.Getenv("TESTED_VERSION") == "wip" {
+	if os.Getenv("TESTED_VERSION") == "wip" && framework.IsNotFound(err) {
 		log.Printf("WIP version not present, exiting.\n")
 		os.Exit(0)
 	}
-	os.Setenv("CLOP_VERSION_BUNDLE_VERSION", vbv)
-
-	params = &framework.VBVParams{
-		Component: "aws-operator",
-		Provider:  "aws",
-		Token:     token,
-		VType:     "current",
-	}
-
-	vbv, err = framework.GetVersionBundleVersion(params)
 	if err != nil {
 		log.Printf("%#v\n", err)
 		v = 1
 		return
 	}
-	if vbv == "" {
-		log.Fatalf("Could not get aws-operator current version.\n")
-		os.Exit(0)
+	for _, authority := range authorities {
+		switch authority.Name {
+		case "aws-operator":
+			os.Setenv("AWSOP_VERSION_BUNDLE_VERSION", authority.Version)
+			// next env var is required by aws-operator templates.
+			os.Setenv("VERSION_BUNDLE_VERSION", authority.Version)
+		case "cluster-operator":
+			os.Setenv("CLOP_VERSION_BUNDLE_VERSION", authority.Version)
+		case "cert-operator":
+			os.Setenv("CERTOP_VERSION_BUNDLE_VERSION", authority.Version)
+		}
 	}
-	os.Setenv("VERSION_BUNDLE_VERSION", vbv)
 
 	clusterName := fmt.Sprintf("ci-clop-%s-%s", os.Getenv("TESTED_VERSION"), os.Getenv("CIRCLE_SHA1")[0:5])
 	os.Setenv("CLUSTER_NAME", clusterName)

--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -109,7 +109,7 @@ func WrapTestMain(g *framework.Guest, h *framework.Host, helmClient *helmclient.
 		Token:    token,
 		VType:    vType,
 	}
-	authorities, err = framework.GetAuthorities(params)
+	authorities, err := framework.GetAuthorities(params)
 	// do not fail on missing WIP.
 	if os.Getenv("TESTED_VERSION") == "wip" && framework.IsNotFound(err) {
 		log.Printf("WIP version not present, exiting.\n")

--- a/integration/template/cluster_operator_resource_chart_values.go
+++ b/integration/template/cluster_operator_resource_chart_values.go
@@ -7,6 +7,13 @@ const ClusterOperatorResourceChartValues = `guest:
   dnsZone: "${CLUSTER_NAME}.k8s.${COMMON_DOMAIN}"
   id: "${CLUSTER_NAME}"
   owner: "giantswarm"
+  versionBundles:
+  - name: aws-operator
+    version: ${AWSOP_VERSION_BUNDLE_VERSION}
+  - name: cert-operator
+    version: ${CERTOP_VERSION_BUNDLE_VERSION}
+  - name: cluster-operator
+    version: ${CLOP_VERSION_BUNDLE_VERSION}
 versionBundle:
   version: "${CLOP_VERSION_BUNDLE_VERSION}"
 `

--- a/vendor/github.com/giantswarm/e2e-harness/pkg/framework/version_bundle.go
+++ b/vendor/github.com/giantswarm/e2e-harness/pkg/framework/version_bundle.go
@@ -3,10 +3,10 @@ package framework
 import (
 	"context"
 	"fmt"
-	"log"
 	"sort"
 
 	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/versionbundle"
 	"github.com/google/go-github/github"
 	"golang.org/x/oauth2"
@@ -25,12 +25,18 @@ type VBVParams struct {
 	VType     string
 }
 
+var logger micrologger.Logger
+
+func init() {
+	logger, _ = micrologger.New(micrologger.Config{})
+}
+
 func GetVersionBundleVersion(params *VBVParams) (string, error) {
 	err := checkType(params.VType)
 	if err != nil {
 		return "", microerror.Mask(err)
 	}
-	log.Printf("Tested version %q", params.VType)
+	logger.Log("level", "debug", "message", fmt.Sprintf("Tested version %q", params.VType))
 
 	content, err := getContent(params.Provider, params.Token)
 	if err != nil {
@@ -42,8 +48,27 @@ func GetVersionBundleVersion(params *VBVParams) (string, error) {
 		return "", microerror.Mask(err)
 	}
 
-	log.Printf("Version Bundle Version %q", output)
+	logger.Log("level", "debug", fmt.Sprintf("Version Bundle Version %q", output))
 	return output, nil
+}
+
+func GetAuthorities(params *VBVParams) ([]versionbundle.Authority, error) {
+	err := checkType(params.VType)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	logger.Log("level", "debug", "message", fmt.Sprintf("Tested version %q", params.VType))
+
+	content, err := getContent(params.Provider, params.Token)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	authorities, err := extractAuthorities(content, params.VType)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	return authorities, nil
 }
 
 func getContent(provider, token string) (string, error) {
@@ -89,23 +114,33 @@ func checkType(vType string) error {
 }
 
 func extractReleaseVersion(content, vType, component string) (string, error) {
+	authorities, err := extractAuthorities(content, vType)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	for _, a := range authorities {
+		if a.Name == component {
+			return a.Version, nil
+		}
+	}
+	return "", microerror.Mask(notFoundError)
+}
+
+func extractAuthorities(content, vType string) ([]versionbundle.Authority, error) {
 	var indexReleases []versionbundle.IndexRelease
 
 	err := yaml.Unmarshal([]byte(content), &indexReleases)
 	if err != nil {
-		return "", microerror.Mask(err)
+		return nil, microerror.Mask(err)
 	}
 
 	sortedReleases := versionbundle.SortIndexReleasesByVersion(indexReleases)
 	sort.Sort(sort.Reverse(sortedReleases))
 	for _, ir := range sortedReleases {
 		if vType == "wip" && !ir.Active || vType == "current" && ir.Active {
-			for _, a := range ir.Authorities {
-				if a.Name == component {
-					return a.Version, nil
-				}
-			}
+			return ir.Authorities, nil
 		}
 	}
-	return "", nil
+	return nil, microerror.Mask(notFoundError)
 }


### PR DESCRIPTION
Uses `framework.GetAuthorities` from e2e-harness to inject the component's version bundle versions into clusterconfig template values.