### PR TITLE
Add external DNS chart for Azure

### DIFF
--- a/pkg/v4/resource/chartconfig/desired_test.go
+++ b/pkg/v4/resource/chartconfig/desired_test.go
@@ -47,7 +47,7 @@ func Test_ChartConfig_GetDesiredState(t *testing.T) {
 			},
 		},
 		{
-			name: "azure also has ingress controller chartconfig",
+			name: "azure also has provider specific chartconfigs",
 			obj: v1alpha1.ClusterGuestConfig{
 				DNSZone: "5xchu.azure.giantswarm.io",
 				ID:      "5xchu",
@@ -58,6 +58,7 @@ func Test_ChartConfig_GetDesiredState(t *testing.T) {
 				"kubernetes-node-exporter-chart",
 				"kubernetes-kube-state-metrics-chart",
 				"kubernetes-nginx-ingress-controller-chart",
+				"kubernetes-external-dns-chart",
 			},
 		},
 	}

--- a/service/controller/azure/v4/version_bundle.go
+++ b/service/controller/azure/v4/version_bundle.go
@@ -12,11 +12,20 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Added chartconfig resource.",
 				Kind:        versionbundle.KindAdded,
 			},
+			{
+				Component:   "cluster-operator",
+				Description: "Added external-dns chartconfig resource.",
+				Kind:        versionbundle.KindAdded,
+			},
 		},
 		Components: []versionbundle.Component{
 			{
 				Name:    "nginx-ingress-controller",
 				Version: "0.12.0",
+			},
+			{
+				Name:    "external-dns",
+				Version: "0.5.2",
 			},
 		},
 		Name:     "cluster-operator",


### PR DESCRIPTION
Add new chart for Azure "external-dns". External DNS needed just to add DNS entry for ingress load balancer, that's now managed by Kubernetes itself in Azure.

Part-of: https://github.com/giantswarm/giantswarm/issues/3268