### PR TITLE
Get current chartconfig and set values when updating CRs

### DIFF
--- a/pkg/v3/resource/chartconfig/update.go
+++ b/pkg/v3/resource/chartconfig/update.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
@@ -24,7 +26,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 		}
 
 		for _, chartConfigToUpdate := range chartConfigsToUpdate {
-			_, err := guestG8sClient.CoreV1alpha1().ChartConfigs(resourceNamespace).Update(chartConfigToUpdate)
+			err := r.updateChartConfig(ctx, chartConfigToUpdate, guestG8sClient)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -95,4 +97,24 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d chartconfigs which have to be updated", len(chartConfigsToUpdate)))
 
 	return chartConfigsToUpdate, nil
+}
+
+func (r *Resource) updateChartConfig(ctx context.Context, updatedChartConfig *v1alpha1.ChartConfig, guestG8sClient versioned.Interface) error {
+	chartConfigName := updatedChartConfig.ObjectMeta.Name
+
+	chartConfig, err := guestG8sClient.CoreV1alpha1().ChartConfigs(resourceNamespace).Get(chartConfigName, metav1.GetOptions{})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Update current CR with new desired state.
+	chartConfig.ObjectMeta.Labels = updatedChartConfig.ObjectMeta.Labels
+	chartConfig.Spec = updatedChartConfig.Spec
+
+	_, err = guestG8sClient.CoreV1alpha1().ChartConfigs(resourceNamespace).Update(chartConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
 }

--- a/pkg/v3/resource/chartconfig/update.go
+++ b/pkg/v3/resource/chartconfig/update.go
@@ -101,7 +101,6 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 
 func (r *Resource) updateChartConfig(ctx context.Context, updatedChartConfig *v1alpha1.ChartConfig, guestG8sClient versioned.Interface) error {
 	chartConfigName := updatedChartConfig.ObjectMeta.Name
-
 	chartConfig, err := guestG8sClient.CoreV1alpha1().ChartConfigs(resourceNamespace).Get(chartConfigName, metav1.GetOptions{})
 	if err != nil {
 		return microerror.Mask(err)

--- a/pkg/v3/resource/chartconfig/update.go
+++ b/pkg/v3/resource/chartconfig/update.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
@@ -24,7 +26,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 		}
 
 		for _, chartConfigToUpdate := range chartConfigsToUpdate {
-			_, err := guestG8sClient.CoreV1alpha1().ChartConfigs(resourceNamespace).Update(chartConfigToUpdate)
+			err := r.updateChartConfig(ctx, chartConfigToUpdate, guestG8sClient)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -86,8 +88,6 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 		}
 
 		if isChartConfigModified(desiredChartConfig, currentChartConfig) {
-			// Set resource version to allow updating the CR.
-			desiredChartConfig.ObjectMeta.ResourceVersion = currentChartConfig.ObjectMeta.ResourceVersion
 			chartConfigsToUpdate = append(chartConfigsToUpdate, desiredChartConfig)
 
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found chartconfig '%s' that has to be updated", desiredChartConfig.GetName()))
@@ -97,4 +97,23 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d chartconfigs which have to be updated", len(chartConfigsToUpdate)))
 
 	return chartConfigsToUpdate, nil
+}
+
+func (r *Resource) updateChartConfig(ctx context.Context, updatedChartConfig *v1alpha1.ChartConfig, guestG8sClient versioned.Interface) error {
+	chartConfigName := updatedChartConfig.ObjectMeta.Name
+	chartConfig, err := guestG8sClient.CoreV1alpha1().ChartConfigs(resourceNamespace).Get(chartConfigName, metav1.GetOptions{})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Update current CR with new desired state.
+	chartConfig.ObjectMeta.Labels = updatedChartConfig.ObjectMeta.Labels
+	chartConfig.Spec = updatedChartConfig.Spec
+
+	_, err = guestG8sClient.CoreV1alpha1().ChartConfigs(resourceNamespace).Update(chartConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
 }

--- a/pkg/v4/resource/chartconfig/update.go
+++ b/pkg/v4/resource/chartconfig/update.go
@@ -117,24 +117,12 @@ func (r *Resource) updateChartConfig(ctx context.Context, updatedChartConfig *v1
 		return microerror.Mask(err)
 	}
 
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
 	// Update current CR with new desired state.
 	chartConfig.ObjectMeta.Labels = updatedChartConfig.ObjectMeta.Labels
 	chartConfig.Spec = updatedChartConfig.Spec
 
 	_, err = guestG8sClient.CoreV1alpha1().ChartConfigs(resourceNamespace).Update(chartConfig)
-	if guest.IsAPINotAvailable(err) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster is not available.")
-
-		// Guest API is not available. We will retry on next reconciliation loop.
-		resourcecanceledcontext.SetCanceled(ctx)
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
-
-		return nil
-	} else if err != nil {
+	if err != nil {
 		return microerror.Mask(err)
 	}
 

--- a/pkg/v4/resource/chartconfig/update.go
+++ b/pkg/v4/resource/chartconfig/update.go
@@ -37,7 +37,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 
 				return nil
 			} else if err != nil {
-				return nil
+				return microerror.Mask(err)
 			}
 		}
 

--- a/pkg/v4/resource/chartconfig/update.go
+++ b/pkg/v4/resource/chartconfig/update.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
-	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/errors/guest"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
@@ -28,9 +26,18 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 		}
 
 		for _, chartConfigToUpdate := range chartConfigsToUpdate {
-			err := r.updateChartConfig(ctx, chartConfigToUpdate, guestG8sClient)
-			if err != nil {
-				return microerror.Mask(err)
+			_, err := guestG8sClient.CoreV1alpha1().ChartConfigs(resourceNamespace).Update(chartConfigToUpdate)
+			if guest.IsAPINotAvailable(err) {
+				r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster is not available.")
+
+				// We should not hammer guest API if it is not available, the guest cluster
+				// might be initializing. We will retry on next reconciliation loop.
+				resourcecanceledcontext.SetCanceled(ctx)
+				r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+				return nil
+			} else if err != nil {
+				return nil
 			}
 		}
 
@@ -90,6 +97,8 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 		}
 
 		if isChartConfigModified(desiredChartConfig, currentChartConfig) {
+			// Set resource version to allow updating the CR.
+			desiredChartConfig.ObjectMeta.ResourceVersion = currentChartConfig.ObjectMeta.ResourceVersion
 			chartConfigsToUpdate = append(chartConfigsToUpdate, desiredChartConfig)
 
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found chartconfig '%s' that has to be updated", desiredChartConfig.GetName()))
@@ -99,32 +108,4 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d chartconfigs which have to be updated", len(chartConfigsToUpdate)))
 
 	return chartConfigsToUpdate, nil
-}
-
-func (r *Resource) updateChartConfig(ctx context.Context, updatedChartConfig *v1alpha1.ChartConfig, guestG8sClient versioned.Interface) error {
-	chartConfigName := updatedChartConfig.ObjectMeta.Name
-
-	chartConfig, err := guestG8sClient.CoreV1alpha1().ChartConfigs(resourceNamespace).Get(chartConfigName, metav1.GetOptions{})
-	if guest.IsAPINotAvailable(err) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster is not available.")
-
-		// Guest API is not available. We will retry on next reconciliation loop.
-		resourcecanceledcontext.SetCanceled(ctx)
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
-
-		return nil
-	} else if err != nil {
-		return microerror.Mask(err)
-	}
-
-	// Update current CR with new desired state.
-	chartConfig.ObjectMeta.Labels = updatedChartConfig.ObjectMeta.Labels
-	chartConfig.Spec = updatedChartConfig.Spec
-
-	_, err = guestG8sClient.CoreV1alpha1().ChartConfigs(resourceNamespace).Update(chartConfig)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	return nil
 }

--- a/pkg/v4/resource/chartconfig/update.go
+++ b/pkg/v4/resource/chartconfig/update.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/errors/guest"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
@@ -26,17 +28,8 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 		}
 
 		for _, chartConfigToUpdate := range chartConfigsToUpdate {
-			_, err := guestG8sClient.CoreV1alpha1().ChartConfigs(resourceNamespace).Update(chartConfigToUpdate)
-			if guest.IsAPINotAvailable(err) {
-				r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster is not available.")
-
-				// We should not hammer guest API if it is not available, the guest cluster
-				// might be initializing. We will retry on next reconciliation loop.
-				resourcecanceledcontext.SetCanceled(ctx)
-				r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
-
-				return nil
-			} else if err != nil {
+			err := r.updateChartConfig(ctx, chartConfigToUpdate, guestG8sClient)
+			if err != nil {
 				return microerror.Mask(err)
 			}
 		}
@@ -97,8 +90,6 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 		}
 
 		if isChartConfigModified(desiredChartConfig, currentChartConfig) {
-			// Set resource version to allow updating the CR.
-			desiredChartConfig.ObjectMeta.ResourceVersion = currentChartConfig.ObjectMeta.ResourceVersion
 			chartConfigsToUpdate = append(chartConfigsToUpdate, desiredChartConfig)
 
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found chartconfig '%s' that has to be updated", desiredChartConfig.GetName()))
@@ -108,4 +99,32 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d chartconfigs which have to be updated", len(chartConfigsToUpdate)))
 
 	return chartConfigsToUpdate, nil
+}
+
+func (r *Resource) updateChartConfig(ctx context.Context, updatedChartConfig *v1alpha1.ChartConfig, guestG8sClient versioned.Interface) error {
+	chartConfigName := updatedChartConfig.ObjectMeta.Name
+
+	chartConfig, err := guestG8sClient.CoreV1alpha1().ChartConfigs(resourceNamespace).Get(chartConfigName, metav1.GetOptions{})
+	if guest.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster is not available.")
+
+		// Guest API is not available. We will retry on next reconciliation loop.
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Update current CR with new desired state.
+	chartConfig.ObjectMeta.Labels = updatedChartConfig.ObjectMeta.Labels
+	chartConfig.Spec = updatedChartConfig.Spec
+
+	_, err = guestG8sClient.CoreV1alpha1().ChartConfigs(resourceNamespace).Update(chartConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
 }

--- a/pkg/v4/resource/chartconfig/update.go
+++ b/pkg/v4/resource/chartconfig/update.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/errors/guest"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
@@ -26,17 +28,8 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 		}
 
 		for _, chartConfigToUpdate := range chartConfigsToUpdate {
-			_, err := guestG8sClient.CoreV1alpha1().ChartConfigs(resourceNamespace).Update(chartConfigToUpdate)
-			if guest.IsAPINotAvailable(err) {
-				r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster is not available.")
-
-				// We should not hammer guest API if it is not available, the guest cluster
-				// might be initializing. We will retry on next reconciliation loop.
-				resourcecanceledcontext.SetCanceled(ctx)
-				r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
-
-				return nil
-			} else if err != nil {
+			err := r.updateChartConfig(ctx, chartConfigToUpdate, guestG8sClient)
+			if err != nil {
 				return microerror.Mask(err)
 			}
 		}
@@ -106,4 +99,44 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d chartconfigs which have to be updated", len(chartConfigsToUpdate)))
 
 	return chartConfigsToUpdate, nil
+}
+
+func (r *Resource) updateChartConfig(ctx context.Context, updatedChartConfig *v1alpha1.ChartConfig, guestG8sClient versioned.Interface) error {
+	chartConfigName := updatedChartConfig.ObjectMeta.Name
+
+	chartConfig, err := guestG8sClient.CoreV1alpha1().ChartConfigs(resourceNamespace).Get(chartConfigName, metav1.GetOptions{})
+	if guest.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster is not available.")
+
+		// Guest API is not available. We will retry on next reconciliation loop.
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Update current CR with new desired state.
+	chartConfig.ObjectMeta.Labels = updatedChartConfig.ObjectMeta.Labels
+	chartConfig.Spec = updatedChartConfig.Spec
+
+	_, err = guestG8sClient.CoreV1alpha1().ChartConfigs(resourceNamespace).Update(chartConfig)
+	if guest.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster is not available.")
+
+		// Guest API is not available. We will retry on next reconciliation loop.
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Updating existing chartconfigs fails because Kubernetes requires the resource version to be set.

```
chartconfigs.core.giantswarm.io \"kubernetes-kube-state-metrics-chart\" is invalid:
metadata.resourceVersion: Invalid value: 0x0: must be specified for an update
```

We need to get the current CR, set the spec and labels and then update it. This ensures that the resource version is correct.

