### PR TITLE
Set resource version to allow updating certconfigs

### DIFF
--- a/pkg/v4/resource/certconfig/update.go
+++ b/pkg/v4/resource/certconfig/update.go
@@ -90,7 +90,12 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 
 		if isCertConfigModified(desiredCertConfig, currentCertConfig) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found certconfig '%s' that has to be updated", desiredCertConfig.GetName()))
-			certConfigsToUpdate = append(certConfigsToUpdate, desiredCertConfig)
+
+			// Create a copy and set the resource version to allow the CR to be updated.
+			certConfigToUpdate := desiredCertConfig.DeepCopy()
+			certConfigToUpdate.ObjectMeta.ResourceVersion = currentCertConfig.ObjectMeta.ResourceVersion
+
+			certConfigsToUpdate = append(certConfigsToUpdate, certConfigToUpdate)
 		} else {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not updating certconfig '%s': no changes found", currentCertConfig.GetName()))
 		}


### PR DESCRIPTION
Fixes same issue as #150 we need to set the resource version from the current certconfig to be able to update it.

I checked the other resources and they don't look affected.