### PR TITLE
Use API domain for node-operator cert until guest cluster role is pre…

### DIFF
--- a/pkg/v4/resource/certconfig/desired.go
+++ b/pkg/v4/resource/certconfig/desired.go
@@ -381,9 +381,11 @@ func newNodeOperatorCertConfig(clusterConfig cluster.Config, cert certs.Cert, na
 		},
 		Spec: v1alpha1.CertConfigSpec{
 			Cert: v1alpha1.CertConfigSpecCert{
-				AllowBareDomains:    false,
-				ClusterComponent:    certName,
-				ClusterID:           clusterConfig.ClusterID,
+				AllowBareDomains: false,
+				ClusterComponent: certName,
+				ClusterID:        clusterConfig.ClusterID,
+				// TODO: Once there's role for node-operator in guest cluster, fix CN below.
+				//		 See: https://github.com/giantswarm/giantswarm/issues/3450
 				CommonName:          clusterConfig.Domain.API,
 				DisableRegeneration: false,
 				TTL:                 clusterConfig.CertTTL,

--- a/pkg/v4/resource/certconfig/desired.go
+++ b/pkg/v4/resource/certconfig/desired.go
@@ -384,7 +384,7 @@ func newNodeOperatorCertConfig(clusterConfig cluster.Config, cert certs.Cert, na
 				AllowBareDomains:    false,
 				ClusterComponent:    certName,
 				ClusterID:           clusterConfig.ClusterID,
-				CommonName:          clusterConfig.Domain.NodeOperator,
+				CommonName:          clusterConfig.Domain.API,
 				DisableRegeneration: false,
 				TTL:                 clusterConfig.CertTTL,
 			},


### PR DESCRIPTION
…sent

In order to have enough rights for guest cluster API, node-operator
needs specific role there which it didn't have yet. Until this role is
present, use API domain for authorization in order to have required
permissions.