### PR TITLE
Remove secret policy from psp

### DIFF
--- a/helm/cluster-operator-chart/templates/psp.yaml
+++ b/helm/cluster-operator-chart/templates/psp.yaml
@@ -13,7 +13,6 @@ spec:
   supplementalGroups:
     rule: RunAsAny
   volumes:
-    - 'secret'
     - 'configMap'
   hostNetwork: false
   hostIPC: false


### PR DESCRIPTION
The secret policy from the PSP seems unnecessary. The integration tests succeed. Is there something else necessary to test this?

/cc @pipo02mix 