### PR TITLE
Set config map resource version in chartconfig CRs

### DIFF
--- a/pkg/v5/resource/chartconfig/desired.go
+++ b/pkg/v5/resource/chartconfig/desired.go
@@ -211,7 +211,7 @@ func (r *Resource) getConfigMapSpec(ctx context.Context, guestConfig cluster.Con
 	configMapSpec := &v1alpha1.ChartConfigSpecConfigMap{
 		Name:            configMapName,
 		Namespace:       namespace,
-		ResourceVersion: configMap.ObjectMeta.ResourceVersion,
+		ResourceVersion: configMap.ResourceVersion,
 	}
 
 	return configMapSpec, nil

--- a/pkg/v5/resource/chartconfig/desired.go
+++ b/pkg/v5/resource/chartconfig/desired.go
@@ -43,7 +43,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 
 	// Only enable Ingress Controller for Azure.
 	if r.provider == label.ProviderAzure {
-		chartConfig, err := r.newIngressControllerChartConfig(ctx, clusterConfig, r.projectName)
+		chartConfig, err := r.newIngressControllerChartConfig(ctx, clusterConfig)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -60,12 +60,12 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	return desiredChartConfigs, nil
 }
 
-func (r *Resource) newIngressControllerChartConfig(ctx context.Context, clusterConfig cluster.Config, projectName string) (*v1alpha1.ChartConfig, error) {
+func (r *Resource) newIngressControllerChartConfig(ctx context.Context, clusterConfig cluster.Config) (*v1alpha1.ChartConfig, error) {
 	chartName := "kubernetes-nginx-ingress-controller-chart"
 	channelName := "0-1-stable"
 	configMapName := "nginx-ingress-controller-values"
 	releaseName := "nginx-ingress-controller"
-	labels := newChartConfigLabels(clusterConfig, releaseName, projectName)
+	labels := newChartConfigLabels(clusterConfig, releaseName, r.projectName)
 
 	configMapSpec, err := r.getConfigMapSpec(ctx, clusterConfig, configMapName, apismetav1.NamespaceSystem)
 	if err != nil {

--- a/pkg/v5/resource/chartconfig/desired.go
+++ b/pkg/v5/resource/chartconfig/desired.go
@@ -205,9 +205,9 @@ func (r *Resource) getConfigMapSpec(ctx context.Context, guestConfig cluster.Con
 		return nil, microerror.Mask(err)
 	}
 
-	// Set the configmap resource version. This will generate an update event
-	// for chart-operator which will recalculate the desired state including
-	// any updated config map values.
+	// Set the configmap resource version. When this changes it will generate
+	// an update event for chart-operator. chart-operator will recalculate the
+	// desired state including any updated config map values.
 	configMapSpec := &v1alpha1.ChartConfigSpecConfigMap{
 		Name:            configMapName,
 		Namespace:       namespace,

--- a/pkg/v5/resource/chartconfig/desired_test.go
+++ b/pkg/v5/resource/chartconfig/desired_test.go
@@ -146,7 +146,7 @@ func Test_ChartConfig_getConfigMapSpec(t *testing.T) {
 			configMapName:      "ingress-controller-values",
 			configMapNamespace: metav1.NamespaceSystem,
 			presentConfigMaps: []*corev1.ConfigMap{
-				&corev1.ConfigMap{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test",
 						Namespace: metav1.NamespaceSystem,
@@ -169,7 +169,7 @@ func Test_ChartConfig_getConfigMapSpec(t *testing.T) {
 			configMapName:      "ingress-controller-values",
 			configMapNamespace: metav1.NamespaceSystem,
 			presentConfigMaps: []*corev1.ConfigMap{
-				&corev1.ConfigMap{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "ingress-controller-values",
 						Namespace:       metav1.NamespacePublic,
@@ -193,7 +193,7 @@ func Test_ChartConfig_getConfigMapSpec(t *testing.T) {
 			configMapName:      "ingress-controller-values",
 			configMapNamespace: metav1.NamespaceSystem,
 			presentConfigMaps: []*corev1.ConfigMap{
-				&corev1.ConfigMap{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "ingress-controller-values",
 						Namespace:       metav1.NamespaceSystem,
@@ -218,7 +218,7 @@ func Test_ChartConfig_getConfigMapSpec(t *testing.T) {
 			configMapName:      "ingress-controller-values",
 			configMapNamespace: metav1.NamespaceSystem,
 			presentConfigMaps: []*corev1.ConfigMap{
-				&corev1.ConfigMap{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "ingress-controller-values",
 						Namespace:       metav1.NamespaceSystem,
@@ -228,7 +228,7 @@ func Test_ChartConfig_getConfigMapSpec(t *testing.T) {
 						"key": "value",
 					},
 				},
-				&corev1.ConfigMap{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "test-values",
 						Namespace:       metav1.NamespaceSystem,

--- a/pkg/v5/resource/chartconfig/desired_test.go
+++ b/pkg/v5/resource/chartconfig/desired_test.go
@@ -69,8 +69,10 @@ func Test_ChartConfig_GetDesiredState(t *testing.T) {
 				BaseClusterConfig: cluster.Config{
 					ClusterID: "test-cluster",
 				},
-				G8sClient:   fake.NewSimpleClientset(),
-				Guest:       &guestMock{},
+				G8sClient: fake.NewSimpleClientset(),
+				Guest: &guestMock{
+					fakeGuestK8sClient: clientgofake.NewSimpleClientset(),
+				},
 				K8sClient:   clientgofake.NewSimpleClientset(),
 				Logger:      microloggertest.New(),
 				ProjectName: "cluster-operator",

--- a/pkg/v5/resource/chartconfig/desired_test.go
+++ b/pkg/v5/resource/chartconfig/desired_test.go
@@ -2,11 +2,15 @@ package chartconfig
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned/fake"
 	"github.com/giantswarm/micrologger/microloggertest"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	clientgofake "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/giantswarm/cluster-operator/pkg/cluster"
@@ -107,6 +111,180 @@ func Test_ChartConfig_GetDesiredState(t *testing.T) {
 				} else if err != nil {
 					t.Fatalf("expected nil, got %#v", err)
 				}
+			}
+		})
+	}
+}
+
+func Test_ChartConfig_getConfigMapSpec(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		clusterConfig         cluster.Config
+		configMapName         string
+		configMapNamespace    string
+		presentConfigMaps     []*corev1.ConfigMap
+		expectedConfigMapSpec *v1alpha1.ChartConfigSpecConfigMap
+	}{
+		{
+			name: "case 0: basic match with no configmaps",
+			clusterConfig: cluster.Config{
+				ClusterID: "5xchu",
+			},
+			configMapName:      "ingress-controller-values",
+			configMapNamespace: metav1.NamespaceSystem,
+			presentConfigMaps:  []*corev1.ConfigMap{},
+			expectedConfigMapSpec: &v1alpha1.ChartConfigSpecConfigMap{
+				Name:      "ingress-controller-values",
+				Namespace: metav1.NamespaceSystem,
+			},
+		},
+		{
+			name: "case 1: no matching configmaps",
+			clusterConfig: cluster.Config{
+				ClusterID: "5xchu",
+			},
+			configMapName:      "ingress-controller-values",
+			configMapNamespace: metav1.NamespaceSystem,
+			presentConfigMaps: []*corev1.ConfigMap{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: metav1.NamespaceSystem,
+					},
+					Data: map[string]string{
+						"key": "value",
+					},
+				},
+			},
+			expectedConfigMapSpec: &v1alpha1.ChartConfigSpecConfigMap{
+				Name:      "ingress-controller-values",
+				Namespace: metav1.NamespaceSystem,
+			},
+		},
+		{
+			name: "case 2: configmap in different namespace",
+			clusterConfig: cluster.Config{
+				ClusterID: "5xchu",
+			},
+			configMapName:      "ingress-controller-values",
+			configMapNamespace: metav1.NamespaceSystem,
+			presentConfigMaps: []*corev1.ConfigMap{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "ingress-controller-values",
+						Namespace:       metav1.NamespacePublic,
+						ResourceVersion: "12345",
+					},
+					Data: map[string]string{
+						"key": "value",
+					},
+				},
+			},
+			expectedConfigMapSpec: &v1alpha1.ChartConfigSpecConfigMap{
+				Name:      "ingress-controller-values",
+				Namespace: metav1.NamespaceSystem,
+			},
+		},
+		{
+			name: "case 3: matching configmap, resource version is set",
+			clusterConfig: cluster.Config{
+				ClusterID: "5xchu",
+			},
+			configMapName:      "ingress-controller-values",
+			configMapNamespace: metav1.NamespaceSystem,
+			presentConfigMaps: []*corev1.ConfigMap{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "ingress-controller-values",
+						Namespace:       metav1.NamespaceSystem,
+						ResourceVersion: "12345",
+					},
+					Data: map[string]string{
+						"key": "value",
+					},
+				},
+			},
+			expectedConfigMapSpec: &v1alpha1.ChartConfigSpecConfigMap{
+				Name:            "ingress-controller-values",
+				Namespace:       metav1.NamespaceSystem,
+				ResourceVersion: "12345",
+			},
+		},
+		{
+			name: "case 4: multiple configmaps, correct resource version is set",
+			clusterConfig: cluster.Config{
+				ClusterID: "5xchu",
+			},
+			configMapName:      "ingress-controller-values",
+			configMapNamespace: metav1.NamespaceSystem,
+			presentConfigMaps: []*corev1.ConfigMap{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "ingress-controller-values",
+						Namespace:       metav1.NamespaceSystem,
+						ResourceVersion: "12345",
+					},
+					Data: map[string]string{
+						"key": "value",
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "test-values",
+						Namespace:       metav1.NamespaceSystem,
+						ResourceVersion: "67890",
+					},
+					Data: map[string]string{
+						"key": "value",
+					},
+				},
+			},
+			expectedConfigMapSpec: &v1alpha1.ChartConfigSpecConfigMap{
+				Name:            "ingress-controller-values",
+				Namespace:       metav1.NamespaceSystem,
+				ResourceVersion: "12345",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			objs := make([]runtime.Object, 0, len(tc.presentConfigMaps))
+			for _, cm := range tc.presentConfigMaps {
+				objs = append(objs, cm)
+			}
+
+			fakeGuestK8sClient := clientgofake.NewSimpleClientset(objs...)
+			guestService := &guestMock{
+				fakeGuestK8sClient: fakeGuestK8sClient,
+			}
+
+			c := Config{
+				BaseClusterConfig: cluster.Config{
+					ClusterID: "test-cluster",
+				},
+				G8sClient:   fake.NewSimpleClientset(),
+				Guest:       guestService,
+				K8sClient:   clientgofake.NewSimpleClientset(),
+				Logger:      microloggertest.New(),
+				ProjectName: "cluster-operator",
+				Provider:    label.ProviderAWS,
+				ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
+					return v.(v1alpha1.ClusterGuestConfig), nil
+				},
+			}
+			newResource, err := New(c)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+
+			result, err := newResource.getConfigMapSpec(context.TODO(), tc.clusterConfig, tc.configMapName, tc.configMapNamespace)
+			if err != nil {
+				t.Fatalf("expected nil, got %#v", err)
+			}
+
+			if !reflect.DeepEqual(result, tc.expectedConfigMapSpec) {
+				t.Fatalf("expected config map spec %#v, got %#v", tc.expectedConfigMapSpec, result)
 			}
 		})
 	}

--- a/pkg/v5/resource/chartconfig/resource.go
+++ b/pkg/v5/resource/chartconfig/resource.go
@@ -136,6 +136,15 @@ func (r *Resource) getGuestG8sClient(ctx context.Context, obj interface{}) (vers
 	return guestG8sClient, nil
 }
 
+func (r *Resource) getGuestK8sClient(ctx context.Context, guestConfig cluster.Config) (kubernetes.Interface, error) {
+	guestK8sClient, err := r.guest.NewK8sClient(ctx, guestConfig.ClusterID, guestConfig.Domain.API)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return guestK8sClient, nil
+}
+
 func containsChartConfig(list []*v1alpha1.ChartConfig, item *v1alpha1.ChartConfig) bool {
 	for _, l := range list {
 		if reflect.DeepEqual(item, l) {


### PR DESCRIPTION
Towards giantswarm/giantswarm#3389

Sets the resource version of the values configmap in the chartconfig CR.

When this is updated it will trigger an update event for chart-operator. chart-operator will recalculate the desired state including any updated values and update the Helm release if the desired state has changed.