### PR TITLE
Add missing API cert altName for v3

### DIFF
--- a/pkg/v3/key/key.go
+++ b/pkg/v3/key/key.go
@@ -11,6 +11,11 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// APIAltNames returns the alt names for API certs.
+func APIAltNames(clusterID string, kubeAltNames []string) []string {
+	return append(kubeAltNames, fmt.Sprintf("master.%s", clusterID))
+}
+
 // APIDomain returns the API server domain for the guest cluster.
 func APIDomain(clusterGuestConfig v1alpha1.ClusterGuestConfig) (string, error) {
 	return serverDomain(clusterGuestConfig, certs.APICert)

--- a/pkg/v3/resource/certconfig/desired.go
+++ b/pkg/v3/resource/certconfig/desired.go
@@ -172,7 +172,7 @@ func newAPICertConfig(clusterConfig cluster.Config, cert certs.Cert, projectName
 		Spec: v1alpha1.CertConfigSpec{
 			Cert: v1alpha1.CertConfigSpecCert{
 				AllowBareDomains:    true,
-				AltNames:            kubeAltNames,
+				AltNames:            key.APIAltNames(clusterConfig.ClusterID, kubeAltNames),
 				ClusterComponent:    certName,
 				ClusterID:           clusterConfig.ClusterID,
 				CommonName:          clusterConfig.Domain.API,


### PR DESCRIPTION
master.* altname was missing from API certconfig and it was added to v4
and v5 but forgotten from v3 which is used in anubis on two clusters.

This completes earlier PR: https://github.com/giantswarm/cluster-operator/pull/165/files