### PR TITLE
fix chart-operator update for v3 and v2 too

### DIFF
--- a/pkg/v2/resource/chart/update.go
+++ b/pkg/v2/resource/chart/update.go
@@ -38,7 +38,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 	if !reflect.DeepEqual(updateState, ResourceState{}) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "updating chart-operator chart")
 
-		tarballPath, err := r.apprClient.PullChartTarball(updateState.ReleaseName, chartOperatorChannel)
+		tarballPath, err := r.apprClient.PullChartTarball(updateState.ChartName, chartOperatorChannel)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/pkg/v3/resource/chart/update.go
+++ b/pkg/v3/resource/chart/update.go
@@ -58,7 +58,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 	if !reflect.DeepEqual(updateState, ResourceState{}) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "updating chart-operator chart")
 
-		tarballPath, err := r.apprClient.PullChartTarball(updateState.ReleaseName, chartOperatorChannel)
+		tarballPath, err := r.apprClient.PullChartTarball(updateState.ChartName, chartOperatorChannel)
 		if err != nil {
 			return microerror.Mask(err)
 		}


### PR DESCRIPTION
We are still getting alerts for `v2` and `v3` clusters.