### PR TITLE
Backport node-operator cert CN fix to v3

### DIFF
--- a/pkg/v3/resource/certconfig/desired.go
+++ b/pkg/v3/resource/certconfig/desired.go
@@ -369,10 +369,12 @@ func newNodeOperatorCertConfig(clusterConfig cluster.Config, cert certs.Cert, pr
 		},
 		Spec: v1alpha1.CertConfigSpec{
 			Cert: v1alpha1.CertConfigSpecCert{
-				AllowBareDomains:    false,
-				ClusterComponent:    certName,
-				ClusterID:           clusterConfig.ClusterID,
-				CommonName:          clusterConfig.Domain.NodeOperator,
+				AllowBareDomains: false,
+				ClusterComponent: certName,
+				ClusterID:        clusterConfig.ClusterID,
+				// TODO: Once there's role for node-operator in guest cluster, fix CN below.
+				//		 See: https://github.com/giantswarm/giantswarm/issues/3450
+				CommonName:          clusterConfig.Domain.API,
 				DisableRegeneration: false,
 				TTL:                 clusterConfig.CertTTL,
 			},


### PR DESCRIPTION
Version v3 already contained activated certconfigs resource, but
node-opearator cert / RBAC workaround was only added to v4 so it needs
to be backported to v3 as well.