### PR TITLE
Inject image registry value into components

### DIFF
--- a/pkg/v5/configmap/configmap.go
+++ b/pkg/v5/configmap/configmap.go
@@ -15,7 +15,8 @@ type Config struct {
 	Guest  guestcluster.Interface
 	Logger micrologger.Logger
 
-	ProjectName string
+	ProjectName    string
+	RegistryDomain string
 }
 
 // Service provides shared functionality for managing configmaps.
@@ -23,7 +24,8 @@ type Service struct {
 	guest  guestcluster.Interface
 	logger micrologger.Logger
 
-	projectName string
+	projectName    string
+	registryDomain string
 }
 
 // New creates a new configmap service.
@@ -38,11 +40,15 @@ func New(config Config) (*Service, error) {
 	if config.ProjectName == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ProjectName must not be empty", config)
 	}
+	if config.RegistryDomain == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.RegistryDomain must not be empty", config)
+	}
 
 	s := &Service{
-		guest:       config.Guest,
-		logger:      config.Logger,
-		projectName: config.ProjectName,
+		guest:          config.Guest,
+		logger:         config.Logger,
+		projectName:    config.ProjectName,
+		registryDomain: config.RegistryDomain,
 	}
 
 	return s, nil

--- a/pkg/v5/configmap/create_test.go
+++ b/pkg/v5/configmap/create_test.go
@@ -155,9 +155,10 @@ func Test_ConfigMap_newCreateChange(t *testing.T) {
 	}
 
 	c := Config{
-		Guest:       &guestMock{},
-		Logger:      microloggertest.New(),
-		ProjectName: "cluster-operator",
+		Guest:          &guestMock{},
+		Logger:         microloggertest.New(),
+		ProjectName:    "cluster-operator",
+		RegistryDomain: "quay.io",
 	}
 	newService, err := New(c)
 	if err != nil {

--- a/pkg/v5/configmap/current_test.go
+++ b/pkg/v5/configmap/current_test.go
@@ -204,9 +204,10 @@ func Test_ConfigMap_GetCurrentState(t *testing.T) {
 			}
 
 			c := Config{
-				Guest:       guestService,
-				Logger:      microloggertest.New(),
-				ProjectName: "cluster-operator",
+				Guest:          guestService,
+				Logger:         microloggertest.New(),
+				ProjectName:    "cluster-operator",
+				RegistryDomain: "quay.io",
 			}
 			newService, err := New(c)
 			if err != nil {

--- a/pkg/v5/configmap/delete_test.go
+++ b/pkg/v5/configmap/delete_test.go
@@ -219,9 +219,10 @@ func Test_ConfigMap_newDeleteChangeForDeletePatch(t *testing.T) {
 	}
 
 	c := Config{
-		Guest:       &guestMock{},
-		Logger:      microloggertest.New(),
-		ProjectName: "cluster-operator",
+		Guest:          &guestMock{},
+		Logger:         microloggertest.New(),
+		ProjectName:    "cluster-operator",
+		RegistryDomain: "quay.io",
 	}
 	newService, err := New(c)
 	if err != nil {
@@ -352,9 +353,10 @@ func Test_ConfigMap_newDeleteChangeForUpdatePatch(t *testing.T) {
 	}
 
 	c := Config{
-		Guest:       &guestMock{},
-		Logger:      microloggertest.New(),
-		ProjectName: "cluster-operator",
+		Guest:          &guestMock{},
+		Logger:         microloggertest.New(),
+		ProjectName:    "cluster-operator",
+		RegistryDomain: "quay.io",
 	}
 	newService, err := New(c)
 	if err != nil {

--- a/pkg/v5/configmap/desired.go
+++ b/pkg/v5/configmap/desired.go
@@ -11,19 +11,10 @@ import (
 	"github.com/giantswarm/cluster-operator/pkg/label"
 )
 
-func (s *Service) GetDesiredState(ctx context.Context, configMapValues ConfigMapValues) ([]*corev1.ConfigMap, error) {
-	desiredConfigMaps := make([]*corev1.ConfigMap, 0)
+type configMapGenerator func(ctx context.Context, configMapValues ConfigMapValues, projectName string) (*corev1.ConfigMap, error)
 
-	{
-		configMap, err := s.newIngressControllerConfigMap(ctx, configMapValues, s.projectName)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-
-		desiredConfigMaps = append(desiredConfigMaps, configMap)
-	}
-
-	return desiredConfigMaps, nil
+type BasicConfigMap struct {
+	Image Image `json:"image"`
 }
 
 type IngressController struct {
@@ -31,7 +22,32 @@ type IngressController struct {
 }
 
 type IngressControllerController struct {
-	Replicas int `json:"replicas"`
+	Replicas int   `json:"replicas"`
+	Image    Image `json:"image"`
+}
+
+type Image struct {
+	Registry string `json:"registry"`
+}
+
+func (s *Service) GetDesiredState(ctx context.Context, configMapValues ConfigMapValues) ([]*corev1.ConfigMap, error) {
+	desiredConfigMaps := make([]*corev1.ConfigMap, 0)
+
+	generators := []configMapGenerator{
+		s.newIngressControllerConfigMap,
+		s.newKubeStateMetricsConfigMap,
+		s.newNodeExporterConfigMap,
+	}
+
+	for _, g := range generators {
+		configMap, err := g(ctx, configMapValues, s.projectName)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		desiredConfigMaps = append(desiredConfigMaps, configMap)
+	}
+
+	return desiredConfigMaps, nil
 }
 
 func (s *Service) newIngressControllerConfigMap(ctx context.Context, configMapValues ConfigMapValues, projectName string) (*corev1.ConfigMap, error) {
@@ -42,6 +58,46 @@ func (s *Service) newIngressControllerConfigMap(ctx context.Context, configMapVa
 	values := IngressController{
 		Controller: IngressControllerController{
 			Replicas: configMapValues.WorkerCount,
+			Image: Image{
+				Registry: s.registryDomain,
+			},
+		},
+	}
+	json, err := json.Marshal(values)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	data := map[string]string{
+		"values.json": string(json),
+	}
+
+	newConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: metav1.NamespaceSystem,
+			Labels:    labels,
+		},
+		Data: data,
+	}
+
+	return newConfigMap, nil
+}
+
+func (s *Service) newKubeStateMetricsConfigMap(ctx context.Context, configMapValues ConfigMapValues, projectName string) (*corev1.ConfigMap, error) {
+	return s.newBasicConfigMap(ctx, configMapValues, projectName, "kube-state-metrics")
+}
+
+func (s *Service) newNodeExporterConfigMap(ctx context.Context, configMapValues ConfigMapValues, projectName string) (*corev1.ConfigMap, error) {
+	return s.newBasicConfigMap(ctx, configMapValues, projectName, "node-exporter")
+}
+
+func (s *Service) newBasicConfigMap(ctx context.Context, configMapValues ConfigMapValues, projectName string, appName string) (*corev1.ConfigMap, error) {
+	configMapName := appName + "-values"
+	labels := newConfigMapLabels(configMapValues, appName, projectName)
+
+	values := BasicConfigMap{
+		Image: Image{
+			Registry: s.registryDomain,
 		},
 	}
 	json, err := json.Marshal(values)

--- a/pkg/v5/configmap/desired_test.go
+++ b/pkg/v5/configmap/desired_test.go
@@ -38,7 +38,39 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 						},
 					},
 					Data: map[string]string{
-						"values.json": "{\"controller\":{\"replicas\":3}}",
+						"values.json": "{\"controller\":{\"replicas\":3,\"image\":{\"registry\":\"quay.io\"}}}",
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kube-state-metrics-values",
+						Namespace: metav1.NamespaceSystem,
+						Labels: map[string]string{
+							label.App:          "kube-state-metrics",
+							label.Cluster:      "5xchu",
+							label.ManagedBy:    "cluster-operator",
+							label.Organization: "giantswarm",
+							label.ServiceType:  "managed",
+						},
+					},
+					Data: map[string]string{
+						"values.json": "{\"image\":{\"registry\":\"quay.io\"}}",
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "node-exporter-values",
+						Namespace: metav1.NamespaceSystem,
+						Labels: map[string]string{
+							label.App:          "node-exporter",
+							label.Cluster:      "5xchu",
+							label.ManagedBy:    "cluster-operator",
+							label.Organization: "giantswarm",
+							label.ServiceType:  "managed",
+						},
+					},
+					Data: map[string]string{
+						"values.json": "{\"image\":{\"registry\":\"quay.io\"}}",
 					},
 				},
 			},
@@ -64,7 +96,39 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 						},
 					},
 					Data: map[string]string{
-						"values.json": "{\"controller\":{\"replicas\":7}}",
+						"values.json": "{\"controller\":{\"replicas\":7,\"image\":{\"registry\":\"quay.io\"}}}",
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kube-state-metrics-values",
+						Namespace: metav1.NamespaceSystem,
+						Labels: map[string]string{
+							label.App:          "kube-state-metrics",
+							label.Cluster:      "5xchu",
+							label.ManagedBy:    "cluster-operator",
+							label.Organization: "giantswarm",
+							label.ServiceType:  "managed",
+						},
+					},
+					Data: map[string]string{
+						"values.json": "{\"image\":{\"registry\":\"quay.io\"}}",
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "node-exporter-values",
+						Namespace: metav1.NamespaceSystem,
+						Labels: map[string]string{
+							label.App:          "node-exporter",
+							label.Cluster:      "5xchu",
+							label.ManagedBy:    "cluster-operator",
+							label.Organization: "giantswarm",
+							label.ServiceType:  "managed",
+						},
+					},
+					Data: map[string]string{
+						"values.json": "{\"image\":{\"registry\":\"quay.io\"}}",
 					},
 				},
 			},
@@ -74,9 +138,10 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			c := Config{
-				Guest:       &guestMock{},
-				Logger:      microloggertest.New(),
-				ProjectName: "cluster-operator",
+				Guest:          &guestMock{},
+				Logger:         microloggertest.New(),
+				ProjectName:    "cluster-operator",
+				RegistryDomain: "quay.io",
 			}
 			newService, err := New(c)
 			if err != nil {

--- a/pkg/v5/configmap/update_test.go
+++ b/pkg/v5/configmap/update_test.go
@@ -235,9 +235,10 @@ func Test_ConfigMap_newUpdateChange(t *testing.T) {
 	}
 
 	c := Config{
-		Guest:       &guestMock{},
-		Logger:      microloggertest.New(),
-		ProjectName: "cluster-operator",
+		Guest:          &guestMock{},
+		Logger:         microloggertest.New(),
+		ProjectName:    "cluster-operator",
+		RegistryDomain: "quay.io",
 	}
 	newService, err := New(c)
 	if err != nil {

--- a/service/controller/aws/v5/resource/configmap/create.go
+++ b/service/controller/aws/v5/resource/configmap/create.go
@@ -1,0 +1,51 @@
+package configmap
+
+import (
+	"context"
+
+	"github.com/giantswarm/errors/guest"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+
+	"github.com/giantswarm/cluster-operator/pkg/v5/configmap"
+	"github.com/giantswarm/cluster-operator/pkg/v5/key"
+	awskey "github.com/giantswarm/cluster-operator/service/controller/aws/v5/key"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	customObject, err := awskey.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	configMapsToCreate, err := toConfigMaps(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	clusterGuestConfig := awskey.ClusterGuestConfig(customObject)
+	guestAPIDomain, err := key.APIDomain(clusterGuestConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	configMapConfig := configmap.ConfigMapConfig{
+		ClusterID:      key.ClusterID(clusterGuestConfig),
+		GuestAPIDomain: guestAPIDomain,
+	}
+	err = r.configMap.ApplyCreateChange(ctx, configMapConfig, configMapsToCreate)
+	if guest.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster is not available")
+
+		// We can't continue without a successful K8s connection. Cluster
+		// may not be up yet. We will retry during the next execution.
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/service/controller/aws/v5/resource/configmap/current.go
+++ b/service/controller/aws/v5/resource/configmap/current.go
@@ -1,0 +1,46 @@
+package configmap
+
+import (
+	"context"
+
+	"github.com/giantswarm/errors/guest"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+
+	"github.com/giantswarm/cluster-operator/pkg/v5/configmap"
+	"github.com/giantswarm/cluster-operator/pkg/v5/key"
+	awskey "github.com/giantswarm/cluster-operator/service/controller/aws/v5/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := awskey.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	clusterGuestConfig := awskey.ClusterGuestConfig(customObject)
+	guestAPIDomain, err := key.APIDomain(clusterGuestConfig)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	configMapConfig := configmap.ConfigMapConfig{
+		ClusterID:      key.ClusterID(clusterGuestConfig),
+		GuestAPIDomain: guestAPIDomain,
+	}
+	configMaps, err := r.configMap.GetCurrentState(ctx, configMapConfig)
+	if guest.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster is not available")
+
+		// We can't continue without a successful K8s connection. Cluster
+		// may not be up yet. We will retry during the next execution.
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return nil, nil
+	} else if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return configMaps, nil
+}

--- a/service/controller/aws/v5/resource/configmap/delete.go
+++ b/service/controller/aws/v5/resource/configmap/delete.go
@@ -1,0 +1,71 @@
+package configmap
+
+import (
+	"context"
+
+	"github.com/giantswarm/errors/guest"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+
+	"github.com/giantswarm/cluster-operator/pkg/v5/configmap"
+	"github.com/giantswarm/cluster-operator/pkg/v5/key"
+	awskey "github.com/giantswarm/cluster-operator/service/controller/aws/v5/key"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	customObject, err := awskey.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	configMapsToDelete, err := toConfigMaps(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	clusterGuestConfig := awskey.ClusterGuestConfig(customObject)
+	guestAPIDomain, err := key.APIDomain(clusterGuestConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	configMapConfig := configmap.ConfigMapConfig{
+		ClusterID:      key.ClusterID(clusterGuestConfig),
+		GuestAPIDomain: guestAPIDomain,
+	}
+	err = r.configMap.ApplyDeleteChange(ctx, configMapConfig, configMapsToDelete)
+	if guest.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster is not available")
+
+		// We can't continue without a successful K8s connection. Cluster
+		// may not be up yet. We will retry during the next execution.
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	currentConfigMaps, err := toConfigMaps(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	desiredConfigMaps, err := toConfigMaps(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch, err := r.configMap.NewDeletePatch(ctx, currentConfigMaps, desiredConfigMaps)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return patch, nil
+}

--- a/service/controller/aws/v5/resource/configmap/desired.go
+++ b/service/controller/aws/v5/resource/configmap/desired.go
@@ -1,0 +1,30 @@
+package configmap
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/cluster-operator/pkg/v5/configmap"
+	"github.com/giantswarm/cluster-operator/pkg/v5/key"
+	awskey "github.com/giantswarm/cluster-operator/service/controller/aws/v5/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := awskey.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	clusterGuestConfig := awskey.ClusterGuestConfig(customObject)
+	configMapValues := configmap.ConfigMapValues{
+		ClusterID:    key.ClusterID(clusterGuestConfig),
+		Organization: key.ClusterOrganization(clusterGuestConfig),
+	}
+	desiredConfigMaps, err := r.configMap.GetDesiredState(ctx, configMapValues)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return desiredConfigMaps, nil
+}

--- a/service/controller/aws/v5/resource/configmap/error.go
+++ b/service/controller/aws/v5/resource/configmap/error.go
@@ -1,0 +1,24 @@
+package configmap
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = microerror.New("not found")
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongType asserts wrongTypeError.
+func IsWrongType(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/aws/v5/resource/configmap/resource.go
+++ b/service/controller/aws/v5/resource/configmap/resource.go
@@ -1,0 +1,81 @@
+package configmap
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/cluster-operator/pkg/v5/configmap"
+	"github.com/giantswarm/cluster-operator/pkg/v5/guestcluster"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "configmapv5"
+)
+
+// Config represents the configuration used to create a new chart config resource.
+type Config struct {
+	ConfigMap   configmap.Interface
+	Guest       guestcluster.Interface
+	K8sClient   kubernetes.Interface
+	Logger      micrologger.Logger
+	ProjectName string
+}
+
+// Resource implements the chart config resource.
+type Resource struct {
+	configMap   configmap.Interface
+	guest       guestcluster.Interface
+	k8sClient   kubernetes.Interface
+	logger      micrologger.Logger
+	projectName string
+}
+
+// New creates a new configured chart config resource.
+func New(config Config) (*Resource, error) {
+	if config.ConfigMap == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ConfigMap must not be empty", config)
+	}
+	if config.Guest == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Guest must not be empty", config)
+	}
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.ProjectName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ProjectName must not be empty", config)
+	}
+
+	r := &Resource{
+		configMap:   config.ConfigMap,
+		guest:       config.Guest,
+		k8sClient:   config.K8sClient,
+		logger:      config.Logger,
+		projectName: config.ProjectName,
+	}
+
+	return r, nil
+}
+
+// Name returns name of the Resource.
+func (r *Resource) Name() string {
+	return Name
+}
+
+func toConfigMaps(v interface{}) ([]*corev1.ConfigMap, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	configMaps, ok := v.([]*corev1.ConfigMap)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", []*corev1.ConfigMap{}, v)
+	}
+
+	return configMaps, nil
+}

--- a/service/controller/aws/v5/resource/configmap/update.go
+++ b/service/controller/aws/v5/resource/configmap/update.go
@@ -1,0 +1,71 @@
+package configmap
+
+import (
+	"context"
+
+	"github.com/giantswarm/errors/guest"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+
+	"github.com/giantswarm/cluster-operator/pkg/v5/configmap"
+	"github.com/giantswarm/cluster-operator/pkg/v5/key"
+	awskey "github.com/giantswarm/cluster-operator/service/controller/aws/v5/key"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	customObject, err := awskey.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	configMapsToUpdate, err := toConfigMaps(updateChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	clusterGuestConfig := awskey.ClusterGuestConfig(customObject)
+	guestAPIDomain, err := key.APIDomain(clusterGuestConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	configMapConfig := configmap.ConfigMapConfig{
+		ClusterID:      key.ClusterID(clusterGuestConfig),
+		GuestAPIDomain: guestAPIDomain,
+	}
+	err = r.configMap.ApplyUpdateChange(ctx, configMapConfig, configMapsToUpdate)
+	if guest.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster is not available")
+
+		// We can't continue without a successful K8s connection. Cluster
+		// may not be up yet. We will retry during the next execution.
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	currentConfigMaps, err := toConfigMaps(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	desiredConfigMaps, err := toConfigMaps(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch, err := r.configMap.NewUpdatePatch(ctx, currentConfigMaps, desiredConfigMaps)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return patch, nil
+}

--- a/service/controller/aws/v5/resource_set.go
+++ b/service/controller/aws/v5/resource_set.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/giantswarm/cluster-operator/pkg/cluster"
 	"github.com/giantswarm/cluster-operator/pkg/label"
+	configmapservice "github.com/giantswarm/cluster-operator/pkg/v5/configmap"
 	"github.com/giantswarm/cluster-operator/pkg/v5/guestcluster"
 	"github.com/giantswarm/cluster-operator/pkg/v5/resource/certconfig"
 	"github.com/giantswarm/cluster-operator/pkg/v5/resource/chart"
@@ -26,6 +27,7 @@ import (
 	"github.com/giantswarm/cluster-operator/pkg/v5/resource/namespace"
 	"github.com/giantswarm/cluster-operator/service/controller/aws/v5/key"
 	"github.com/giantswarm/cluster-operator/service/controller/aws/v5/resource/awsconfig"
+	"github.com/giantswarm/cluster-operator/service/controller/aws/v5/resource/configmap"
 )
 
 // ResourceSetConfig contains necessary dependencies and settings for
@@ -183,6 +185,42 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		}
 	}
 
+	var configMapService configmapservice.Interface
+	{
+		c := configmapservice.Config{
+			Guest:          guestClusterService,
+			Logger:         config.Logger,
+			ProjectName:    config.ProjectName,
+			RegistryDomain: config.RegistryDomain,
+		}
+
+		configMapService, err = configmapservice.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var configMapResource controller.Resource
+	{
+		c := configmap.Config{
+			ConfigMap:   configMapService,
+			Guest:       guestClusterService,
+			K8sClient:   config.K8sClient,
+			Logger:      config.Logger,
+			ProjectName: config.ProjectName,
+		}
+
+		ops, err := configmap.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		configMapResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var chartConfigResource controller.Resource
 	{
 		c := chartconfig.Config{
@@ -214,10 +252,11 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		encryptionKeyResource,
 		certConfigResource,
 		awsConfigResource,
-		// namespace, chart and chartconfig resources manage resources in
+		// namespace, chart, configmap and chartconfig resources manage resources in
 		// guest clusters so they should be executed last.
 		namespaceResource,
 		chartResource,
+		configMapResource,
 		chartConfigResource,
 	}
 

--- a/service/controller/azure/v5/resource_set.go
+++ b/service/controller/azure/v5/resource_set.go
@@ -189,9 +189,10 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var configMapService configmapservice.Interface
 	{
 		c := configmapservice.Config{
-			Guest:       guestClusterService,
-			Logger:      config.Logger,
-			ProjectName: config.ProjectName,
+			Guest:          guestClusterService,
+			Logger:         config.Logger,
+			ProjectName:    config.ProjectName,
+			RegistryDomain: config.RegistryDomain,
 		}
 
 		configMapService, err = configmapservice.New(c)

--- a/service/controller/kvm/v5/key/key.go
+++ b/service/controller/kvm/v5/key/key.go
@@ -5,6 +5,11 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
+// ClusterGuestConfig extracts ClusterGuestConfig from KVMClusterConfig.
+func ClusterGuestConfig(kvmClusterConfig v1alpha1.KVMClusterConfig) v1alpha1.ClusterGuestConfig {
+	return kvmClusterConfig.Spec.Guest.ClusterGuestConfig
+}
+
 // ClusterID extracts clusterID from v1alpha1.KVMClusterConfig.
 func ClusterID(customObject v1alpha1.KVMClusterConfig) string {
 	return customObject.Spec.Guest.ClusterGuestConfig.ID

--- a/service/controller/kvm/v5/resource/configmap/create.go
+++ b/service/controller/kvm/v5/resource/configmap/create.go
@@ -1,0 +1,51 @@
+package configmap
+
+import (
+	"context"
+
+	"github.com/giantswarm/errors/guest"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+
+	"github.com/giantswarm/cluster-operator/pkg/v5/configmap"
+	"github.com/giantswarm/cluster-operator/pkg/v5/key"
+	kvmkey "github.com/giantswarm/cluster-operator/service/controller/kvm/v5/key"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	customObject, err := kvmkey.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	configMapsToCreate, err := toConfigMaps(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	clusterGuestConfig := kvmkey.ClusterGuestConfig(customObject)
+	guestAPIDomain, err := key.APIDomain(clusterGuestConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	configMapConfig := configmap.ConfigMapConfig{
+		ClusterID:      key.ClusterID(clusterGuestConfig),
+		GuestAPIDomain: guestAPIDomain,
+	}
+	err = r.configMap.ApplyCreateChange(ctx, configMapConfig, configMapsToCreate)
+	if guest.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster is not available")
+
+		// We can't continue without a successful K8s connection. Cluster
+		// may not be up yet. We will retry during the next execution.
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/service/controller/kvm/v5/resource/configmap/current.go
+++ b/service/controller/kvm/v5/resource/configmap/current.go
@@ -1,0 +1,46 @@
+package configmap
+
+import (
+	"context"
+
+	"github.com/giantswarm/errors/guest"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+
+	"github.com/giantswarm/cluster-operator/pkg/v5/configmap"
+	"github.com/giantswarm/cluster-operator/pkg/v5/key"
+	kvmkey "github.com/giantswarm/cluster-operator/service/controller/kvm/v5/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := kvmkey.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	clusterGuestConfig := kvmkey.ClusterGuestConfig(customObject)
+	guestAPIDomain, err := key.APIDomain(clusterGuestConfig)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	configMapConfig := configmap.ConfigMapConfig{
+		ClusterID:      key.ClusterID(clusterGuestConfig),
+		GuestAPIDomain: guestAPIDomain,
+	}
+	configMaps, err := r.configMap.GetCurrentState(ctx, configMapConfig)
+	if guest.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster is not available")
+
+		// We can't continue without a successful K8s connection. Cluster
+		// may not be up yet. We will retry during the next execution.
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return nil, nil
+	} else if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return configMaps, nil
+}

--- a/service/controller/kvm/v5/resource/configmap/delete.go
+++ b/service/controller/kvm/v5/resource/configmap/delete.go
@@ -1,0 +1,71 @@
+package configmap
+
+import (
+	"context"
+
+	"github.com/giantswarm/errors/guest"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+
+	"github.com/giantswarm/cluster-operator/pkg/v5/configmap"
+	"github.com/giantswarm/cluster-operator/pkg/v5/key"
+	kvmkey "github.com/giantswarm/cluster-operator/service/controller/kvm/v5/key"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	customObject, err := kvmkey.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	configMapsToDelete, err := toConfigMaps(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	clusterGuestConfig := kvmkey.ClusterGuestConfig(customObject)
+	guestAPIDomain, err := key.APIDomain(clusterGuestConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	configMapConfig := configmap.ConfigMapConfig{
+		ClusterID:      key.ClusterID(clusterGuestConfig),
+		GuestAPIDomain: guestAPIDomain,
+	}
+	err = r.configMap.ApplyDeleteChange(ctx, configMapConfig, configMapsToDelete)
+	if guest.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster is not available")
+
+		// We can't continue without a successful K8s connection. Cluster
+		// may not be up yet. We will retry during the next execution.
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	currentConfigMaps, err := toConfigMaps(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	desiredConfigMaps, err := toConfigMaps(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch, err := r.configMap.NewDeletePatch(ctx, currentConfigMaps, desiredConfigMaps)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return patch, nil
+}

--- a/service/controller/kvm/v5/resource/configmap/desired.go
+++ b/service/controller/kvm/v5/resource/configmap/desired.go
@@ -1,0 +1,30 @@
+package configmap
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/cluster-operator/pkg/v5/configmap"
+	"github.com/giantswarm/cluster-operator/pkg/v5/key"
+	kvmkey "github.com/giantswarm/cluster-operator/service/controller/kvm/v5/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := kvmkey.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	clusterGuestConfig := kvmkey.ClusterGuestConfig(customObject)
+	configMapValues := configmap.ConfigMapValues{
+		ClusterID:    key.ClusterID(clusterGuestConfig),
+		Organization: key.ClusterOrganization(clusterGuestConfig),
+	}
+	desiredConfigMaps, err := r.configMap.GetDesiredState(ctx, configMapValues)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return desiredConfigMaps, nil
+}

--- a/service/controller/kvm/v5/resource/configmap/error.go
+++ b/service/controller/kvm/v5/resource/configmap/error.go
@@ -1,0 +1,24 @@
+package configmap
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = microerror.New("not found")
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongType asserts wrongTypeError.
+func IsWrongType(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/kvm/v5/resource/configmap/resource.go
+++ b/service/controller/kvm/v5/resource/configmap/resource.go
@@ -1,0 +1,81 @@
+package configmap
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/cluster-operator/pkg/v5/configmap"
+	"github.com/giantswarm/cluster-operator/pkg/v5/guestcluster"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "configmapv5"
+)
+
+// Config represents the configuration used to create a new chart config resource.
+type Config struct {
+	ConfigMap   configmap.Interface
+	Guest       guestcluster.Interface
+	K8sClient   kubernetes.Interface
+	Logger      micrologger.Logger
+	ProjectName string
+}
+
+// Resource implements the chart config resource.
+type Resource struct {
+	configMap   configmap.Interface
+	guest       guestcluster.Interface
+	k8sClient   kubernetes.Interface
+	logger      micrologger.Logger
+	projectName string
+}
+
+// New creates a new configured chart config resource.
+func New(config Config) (*Resource, error) {
+	if config.ConfigMap == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ConfigMap must not be empty", config)
+	}
+	if config.Guest == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Guest must not be empty", config)
+	}
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.ProjectName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ProjectName must not be empty", config)
+	}
+
+	r := &Resource{
+		configMap:   config.ConfigMap,
+		guest:       config.Guest,
+		k8sClient:   config.K8sClient,
+		logger:      config.Logger,
+		projectName: config.ProjectName,
+	}
+
+	return r, nil
+}
+
+// Name returns name of the Resource.
+func (r *Resource) Name() string {
+	return Name
+}
+
+func toConfigMaps(v interface{}) ([]*corev1.ConfigMap, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	configMaps, ok := v.([]*corev1.ConfigMap)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", []*corev1.ConfigMap{}, v)
+	}
+
+	return configMaps, nil
+}

--- a/service/controller/kvm/v5/resource/configmap/update.go
+++ b/service/controller/kvm/v5/resource/configmap/update.go
@@ -1,0 +1,71 @@
+package configmap
+
+import (
+	"context"
+
+	"github.com/giantswarm/errors/guest"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+
+	"github.com/giantswarm/cluster-operator/pkg/v5/configmap"
+	"github.com/giantswarm/cluster-operator/pkg/v5/key"
+	kvmkey "github.com/giantswarm/cluster-operator/service/controller/kvm/v5/key"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	customObject, err := kvmkey.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	configMapsToUpdate, err := toConfigMaps(updateChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	clusterGuestConfig := kvmkey.ClusterGuestConfig(customObject)
+	guestAPIDomain, err := key.APIDomain(clusterGuestConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	configMapConfig := configmap.ConfigMapConfig{
+		ClusterID:      key.ClusterID(clusterGuestConfig),
+		GuestAPIDomain: guestAPIDomain,
+	}
+	err = r.configMap.ApplyUpdateChange(ctx, configMapConfig, configMapsToUpdate)
+	if guest.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster is not available")
+
+		// We can't continue without a successful K8s connection. Cluster
+		// may not be up yet. We will retry during the next execution.
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	currentConfigMaps, err := toConfigMaps(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	desiredConfigMaps, err := toConfigMaps(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch, err := r.configMap.NewUpdatePatch(ctx, currentConfigMaps, desiredConfigMaps)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return patch, nil
+}

--- a/service/controller/kvm/v5/resource_set.go
+++ b/service/controller/kvm/v5/resource_set.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/giantswarm/cluster-operator/pkg/cluster"
 	"github.com/giantswarm/cluster-operator/pkg/label"
+	configmapservice "github.com/giantswarm/cluster-operator/pkg/v5/configmap"
 	"github.com/giantswarm/cluster-operator/pkg/v5/guestcluster"
 	"github.com/giantswarm/cluster-operator/pkg/v5/resource/certconfig"
 	"github.com/giantswarm/cluster-operator/pkg/v5/resource/chart"
@@ -25,6 +26,7 @@ import (
 	"github.com/giantswarm/cluster-operator/pkg/v5/resource/encryptionkey"
 	"github.com/giantswarm/cluster-operator/pkg/v5/resource/namespace"
 	"github.com/giantswarm/cluster-operator/service/controller/kvm/v5/key"
+	"github.com/giantswarm/cluster-operator/service/controller/kvm/v5/resource/configmap"
 	"github.com/giantswarm/cluster-operator/service/controller/kvm/v5/resource/kvmconfig"
 )
 
@@ -183,6 +185,42 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		}
 	}
 
+	var configMapService configmapservice.Interface
+	{
+		c := configmapservice.Config{
+			Guest:          guestClusterService,
+			Logger:         config.Logger,
+			ProjectName:    config.ProjectName,
+			RegistryDomain: config.RegistryDomain,
+		}
+
+		configMapService, err = configmapservice.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var configMapResource controller.Resource
+	{
+		c := configmap.Config{
+			ConfigMap:   configMapService,
+			Guest:       guestClusterService,
+			K8sClient:   config.K8sClient,
+			Logger:      config.Logger,
+			ProjectName: config.ProjectName,
+		}
+
+		ops, err := configmap.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		configMapResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var chartConfigResource controller.Resource
 	{
 		c := chartconfig.Config{
@@ -214,10 +252,11 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		encryptionKeyResource,
 		certConfigResource,
 		kvmConfigResource,
-		// namespace, chart and chartconfig resources manage resources in
+		// namespace, chart, configmap and chartconfig resources manage resources in
 		// guest clusters so they should be executed last.
 		namespaceResource,
 		chartResource,
+		configMapResource,
 		chartConfigResource,
 	}
 


### PR DESCRIPTION
Sets image registry for all the components on the configmap service and adds configmap resources for aws and kvm.