### PR TITLE
Set worker count for AWS and KVM

### DIFF
--- a/service/controller/aws/v5/key/key.go
+++ b/service/controller/aws/v5/key/key.go
@@ -29,3 +29,7 @@ func ToCustomObject(v interface{}) (v1alpha1.AWSClusterConfig, error) {
 func VersionBundleVersion(awsClusterConfig v1alpha1.AWSClusterConfig) string {
 	return awsClusterConfig.Spec.VersionBundle.Version
 }
+
+func WorkerCount(awsClusterConfig v1alpha1.AWSClusterConfig) int {
+	return len(awsClusterConfig.Spec.Guest.Workers)
+}

--- a/service/controller/aws/v5/key/key_test.go
+++ b/service/controller/aws/v5/key/key_test.go
@@ -61,7 +61,7 @@ func Test_ToCustomObject(t *testing.T) {
 		},
 		{
 			description:          "wrong type must return wrongTypeError",
-			inputObject:          &v1alpha1.AzureClusterConfig{},
+			inputObject:          &v1alpha1.AWSClusterConfig{},
 			expectedCustomObject: v1alpha1.AWSClusterConfig{},
 			expectedError:        wrongTypeError,
 		},
@@ -84,6 +84,57 @@ func Test_ToCustomObject(t *testing.T) {
 			if !reflect.DeepEqual(customObject, tc.expectedCustomObject) {
 				t.Fatalf("customObject %#v doesn't match expected %#v",
 					customObject, tc.expectedCustomObject)
+			}
+		})
+	}
+}
+
+func Test_WorkerCount(t *testing.T) {
+	testCases := []struct {
+		description         string
+		clusterConfig       v1alpha1.AWSClusterConfig
+		expectedWorkerCount int
+	}{
+		{
+			description:         "case 0: empty value",
+			clusterConfig:       v1alpha1.AWSClusterConfig{},
+			expectedWorkerCount: 0,
+		},
+		{
+			description: "case 1: basic match",
+			clusterConfig: v1alpha1.AWSClusterConfig{
+				Spec: v1alpha1.AWSClusterConfigSpec{
+					Guest: v1alpha1.AWSClusterConfigSpecGuest{
+						Workers: []v1alpha1.AWSClusterConfigSpecGuestWorker{
+							v1alpha1.AWSClusterConfigSpecGuestWorker{},
+						},
+					},
+				},
+			},
+			expectedWorkerCount: 1,
+		},
+		{
+			description: "case 2: different worker count",
+			clusterConfig: v1alpha1.AWSClusterConfig{
+				Spec: v1alpha1.AWSClusterConfigSpec{
+					Guest: v1alpha1.AWSClusterConfigSpecGuest{
+						Workers: []v1alpha1.AWSClusterConfigSpecGuestWorker{
+							v1alpha1.AWSClusterConfigSpecGuestWorker{},
+							v1alpha1.AWSClusterConfigSpecGuestWorker{},
+							v1alpha1.AWSClusterConfigSpecGuestWorker{},
+						},
+					},
+				},
+			},
+			expectedWorkerCount: 3,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			workerCount := WorkerCount(tc.clusterConfig)
+			if workerCount != tc.expectedWorkerCount {
+				t.Fatalf("WorkerCount %d doesn't match expected %d", workerCount, tc.expectedWorkerCount)
 			}
 		})
 	}

--- a/service/controller/aws/v5/key/key_test.go
+++ b/service/controller/aws/v5/key/key_test.go
@@ -61,7 +61,7 @@ func Test_ToCustomObject(t *testing.T) {
 		},
 		{
 			description:          "wrong type must return wrongTypeError",
-			inputObject:          &v1alpha1.AWSClusterConfig{},
+			inputObject:          &v1alpha1.AzureClusterConfig{},
 			expectedCustomObject: v1alpha1.AWSClusterConfig{},
 			expectedError:        wrongTypeError,
 		},

--- a/service/controller/aws/v5/resource/configmap/desired.go
+++ b/service/controller/aws/v5/resource/configmap/desired.go
@@ -20,6 +20,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	configMapValues := configmap.ConfigMapValues{
 		ClusterID:    key.ClusterID(clusterGuestConfig),
 		Organization: key.ClusterOrganization(clusterGuestConfig),
+		WorkerCount:  awskey.WorkerCount(customObject),
 	}
 	desiredConfigMaps, err := r.configMap.GetDesiredState(ctx, configMapValues)
 	if err != nil {

--- a/service/controller/kvm/v5/key/key.go
+++ b/service/controller/kvm/v5/key/key.go
@@ -40,3 +40,7 @@ func ToCustomObject(v interface{}) (v1alpha1.KVMClusterConfig, error) {
 func VersionBundleVersion(kvmClusterConfig v1alpha1.KVMClusterConfig) string {
 	return kvmClusterConfig.Spec.VersionBundle.Version
 }
+
+func WorkerCount(kvmClusterConfig v1alpha1.KVMClusterConfig) int {
+	return len(kvmClusterConfig.Spec.Guest.Workers)
+}

--- a/service/controller/kvm/v5/key/key_test.go
+++ b/service/controller/kvm/v5/key/key_test.go
@@ -138,3 +138,54 @@ func Test_ToCustomObject(t *testing.T) {
 		})
 	}
 }
+
+func Test_WorkerCount(t *testing.T) {
+	testCases := []struct {
+		description         string
+		clusterConfig       v1alpha1.KVMClusterConfig
+		expectedWorkerCount int
+	}{
+		{
+			description:         "case 0: empty value",
+			clusterConfig:       v1alpha1.KVMClusterConfig{},
+			expectedWorkerCount: 0,
+		},
+		{
+			description: "case 1: basic match",
+			clusterConfig: v1alpha1.KVMClusterConfig{
+				Spec: v1alpha1.KVMClusterConfigSpec{
+					Guest: v1alpha1.KVMClusterConfigSpecGuest{
+						Workers: []v1alpha1.KVMClusterConfigSpecGuestWorker{
+							v1alpha1.KVMClusterConfigSpecGuestWorker{},
+						},
+					},
+				},
+			},
+			expectedWorkerCount: 1,
+		},
+		{
+			description: "case 2: different worker count",
+			clusterConfig: v1alpha1.KVMClusterConfig{
+				Spec: v1alpha1.KVMClusterConfigSpec{
+					Guest: v1alpha1.KVMClusterConfigSpecGuest{
+						Workers: []v1alpha1.KVMClusterConfigSpecGuestWorker{
+							v1alpha1.KVMClusterConfigSpecGuestWorker{},
+							v1alpha1.KVMClusterConfigSpecGuestWorker{},
+							v1alpha1.KVMClusterConfigSpecGuestWorker{},
+						},
+					},
+				},
+			},
+			expectedWorkerCount: 3,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			workerCount := WorkerCount(tc.clusterConfig)
+			if workerCount != tc.expectedWorkerCount {
+				t.Fatalf("WorkerCount %d doesn't match expected %d", workerCount, tc.expectedWorkerCount)
+			}
+		})
+	}
+}

--- a/service/controller/kvm/v5/resource/configmap/desired.go
+++ b/service/controller/kvm/v5/resource/configmap/desired.go
@@ -20,6 +20,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	configMapValues := configmap.ConfigMapValues{
 		ClusterID:    key.ClusterID(clusterGuestConfig),
 		Organization: key.ClusterOrganization(clusterGuestConfig),
+		WorkerCount:  kvmkey.WorkerCount(customObject),
 	}
 	desiredConfigMaps, err := r.configMap.GetDesiredState(ctx, configMapValues)
 	if err != nil {


### PR DESCRIPTION
On Azure the Ingress Controller configmap has the worker count. IC isn't enabled on AWS and KVM but this means the worker count is set to 0 in the config map.

I think its safer to set this correctly now. As we plan to move Ingress Controller to chart-operator on AWS and KVM soon.