### PR TITLE
opsctl: copy v5 to v6

### DIFF
--- a/service/controller/kvm/v6/error.go
+++ b/service/controller/kvm/v6/error.go
@@ -1,0 +1,17 @@
+package v5
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/kvm/v6/key/error.go
+++ b/service/controller/kvm/v6/key/error.go
@@ -1,0 +1,17 @@
+package key
+
+import "github.com/giantswarm/microerror"
+
+var emptyValueError = microerror.New("empty value")
+
+// IsEmptyValueError asserts emptyValueError.
+func IsEmptyValueError(err error) bool {
+	return microerror.Cause(err) == emptyValueError
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/kvm/v6/key/key.go
+++ b/service/controller/kvm/v6/key/key.go
@@ -1,0 +1,46 @@
+package key
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/microerror"
+)
+
+// ClusterGuestConfig extracts ClusterGuestConfig from KVMClusterConfig.
+func ClusterGuestConfig(kvmClusterConfig v1alpha1.KVMClusterConfig) v1alpha1.ClusterGuestConfig {
+	return kvmClusterConfig.Spec.Guest.ClusterGuestConfig
+}
+
+// ClusterID extracts clusterID from v1alpha1.KVMClusterConfig.
+func ClusterID(customObject v1alpha1.KVMClusterConfig) string {
+	return customObject.Spec.Guest.ClusterGuestConfig.ID
+}
+
+// ToClusterGuestConfig extracts ClusterGuestConfig from KVMClusterConfig.
+func ToClusterGuestConfig(kvmClusterConfig v1alpha1.KVMClusterConfig) v1alpha1.ClusterGuestConfig {
+	return kvmClusterConfig.Spec.Guest.ClusterGuestConfig
+}
+
+// ToCustomObject converts value to v1alpha1.KVMClusterConfig and returns it or
+// error if type does not match.
+func ToCustomObject(v interface{}) (v1alpha1.KVMClusterConfig, error) {
+	customObjectPointer, ok := v.(*v1alpha1.KVMClusterConfig)
+	if !ok {
+		return v1alpha1.KVMClusterConfig{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &v1alpha1.KVMClusterConfig{}, v)
+	}
+
+	if customObjectPointer == nil {
+		return v1alpha1.KVMClusterConfig{}, microerror.Maskf(emptyValueError,
+			"empty value cannot be converted to CustomObject")
+	}
+
+	return *customObjectPointer, nil
+}
+
+// VersionBundleVersion extracts version bundle version from KVMClusterConfig.
+func VersionBundleVersion(kvmClusterConfig v1alpha1.KVMClusterConfig) string {
+	return kvmClusterConfig.Spec.VersionBundle.Version
+}
+
+func WorkerCount(kvmClusterConfig v1alpha1.KVMClusterConfig) int {
+	return len(kvmClusterConfig.Spec.Guest.Workers)
+}

--- a/service/controller/kvm/v6/key/key_test.go
+++ b/service/controller/kvm/v6/key/key_test.go
@@ -1,0 +1,191 @@
+package key
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/microerror"
+)
+
+func Test_ClusterID(t *testing.T) {
+	testCases := []struct {
+		description  string
+		customObject v1alpha1.KVMClusterConfig
+		expectedID   string
+	}{
+		{
+			description:  "empty value KVMClusterConfig produces empty ID",
+			customObject: v1alpha1.KVMClusterConfig{},
+			expectedID:   "",
+		},
+		{
+			description: "present ID value returned as ClusterID",
+			customObject: v1alpha1.KVMClusterConfig{
+				Spec: v1alpha1.KVMClusterConfigSpec{
+					Guest: v1alpha1.KVMClusterConfigSpecGuest{
+						ClusterGuestConfig: v1alpha1.ClusterGuestConfig{
+							ID: "cluster-1",
+						},
+					},
+				},
+			},
+			expectedID: "cluster-1",
+		},
+		{
+			description: "only present ID value returned as ClusterID",
+			customObject: v1alpha1.KVMClusterConfig{
+				Spec: v1alpha1.KVMClusterConfigSpec{
+					Guest: v1alpha1.KVMClusterConfigSpecGuest{
+						ClusterGuestConfig: v1alpha1.ClusterGuestConfig{
+							ID:   "cluster-123",
+							Name: "First cluster",
+						},
+					},
+				},
+			},
+			expectedID: "cluster-123",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			clusterID := ClusterID(tc.customObject)
+			if clusterID != tc.expectedID {
+				t.Fatalf("ClusterID %s doesn't match. expected: %s", clusterID, tc.expectedID)
+			}
+		})
+	}
+}
+
+func Test_ToCustomObject(t *testing.T) {
+	var emptyKVMClusterConfigPtr *v1alpha1.KVMClusterConfig
+
+	testCases := []struct {
+		description          string
+		inputObject          interface{}
+		expectedCustomObject v1alpha1.KVMClusterConfig
+		expectedError        error
+	}{
+		{
+			description:          "reference to empty value KVMClusterConfig returns empty KVMClusterConfig",
+			inputObject:          &v1alpha1.KVMClusterConfig{},
+			expectedCustomObject: v1alpha1.KVMClusterConfig{},
+			expectedError:        nil,
+		},
+		{
+			description: "verify that internal KVMClusterConfig fields are returned as well",
+			inputObject: &v1alpha1.KVMClusterConfig{
+				Spec: v1alpha1.KVMClusterConfigSpec{
+					Guest: v1alpha1.KVMClusterConfigSpecGuest{
+						ClusterGuestConfig: v1alpha1.ClusterGuestConfig{
+							ID:   "cluster-1",
+							Name: "My own snowflake cluster",
+						},
+					},
+				},
+			},
+			expectedCustomObject: v1alpha1.KVMClusterConfig{
+				Spec: v1alpha1.KVMClusterConfigSpec{
+					Guest: v1alpha1.KVMClusterConfigSpecGuest{
+						ClusterGuestConfig: v1alpha1.ClusterGuestConfig{
+							ID:   "cluster-1",
+							Name: "My own snowflake cluster",
+						},
+					},
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			description:          "nil pointer to KVMClusterConfig must return emptyValueError",
+			inputObject:          emptyKVMClusterConfigPtr,
+			expectedCustomObject: v1alpha1.KVMClusterConfig{},
+			expectedError:        emptyValueError,
+		},
+		{
+			description:          "non-pointer value of KVMClusterConfig must return wrontTypeError",
+			inputObject:          v1alpha1.KVMClusterConfig{},
+			expectedCustomObject: v1alpha1.KVMClusterConfig{},
+			expectedError:        wrongTypeError,
+		},
+		{
+			description:          "wrong type must return wrongTypeError",
+			inputObject:          &v1alpha1.AzureClusterConfig{},
+			expectedCustomObject: v1alpha1.KVMClusterConfig{},
+			expectedError:        wrongTypeError,
+		},
+		{
+			description:          "nil interface{} must return wrongTypeError",
+			inputObject:          nil,
+			expectedCustomObject: v1alpha1.KVMClusterConfig{},
+			expectedError:        wrongTypeError,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			customObject, err := ToCustomObject(tc.inputObject)
+			if microerror.Cause(err) != tc.expectedError {
+				t.Errorf("Received error %#v doesn't match expected %#v",
+					err, tc.expectedError)
+			}
+
+			if !reflect.DeepEqual(customObject, tc.expectedCustomObject) {
+				t.Fatalf("customObject %#v doesn't match expected %#v",
+					customObject, tc.expectedCustomObject)
+			}
+		})
+	}
+}
+
+func Test_WorkerCount(t *testing.T) {
+	testCases := []struct {
+		description         string
+		clusterConfig       v1alpha1.KVMClusterConfig
+		expectedWorkerCount int
+	}{
+		{
+			description:         "case 0: empty value",
+			clusterConfig:       v1alpha1.KVMClusterConfig{},
+			expectedWorkerCount: 0,
+		},
+		{
+			description: "case 1: basic match",
+			clusterConfig: v1alpha1.KVMClusterConfig{
+				Spec: v1alpha1.KVMClusterConfigSpec{
+					Guest: v1alpha1.KVMClusterConfigSpecGuest{
+						Workers: []v1alpha1.KVMClusterConfigSpecGuestWorker{
+							v1alpha1.KVMClusterConfigSpecGuestWorker{},
+						},
+					},
+				},
+			},
+			expectedWorkerCount: 1,
+		},
+		{
+			description: "case 2: different worker count",
+			clusterConfig: v1alpha1.KVMClusterConfig{
+				Spec: v1alpha1.KVMClusterConfigSpec{
+					Guest: v1alpha1.KVMClusterConfigSpecGuest{
+						Workers: []v1alpha1.KVMClusterConfigSpecGuestWorker{
+							v1alpha1.KVMClusterConfigSpecGuestWorker{},
+							v1alpha1.KVMClusterConfigSpecGuestWorker{},
+							v1alpha1.KVMClusterConfigSpecGuestWorker{},
+						},
+					},
+				},
+			},
+			expectedWorkerCount: 3,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			workerCount := WorkerCount(tc.clusterConfig)
+			if workerCount != tc.expectedWorkerCount {
+				t.Fatalf("WorkerCount %d doesn't match expected %d", workerCount, tc.expectedWorkerCount)
+			}
+		})
+	}
+}

--- a/service/controller/kvm/v6/resource/configmap/create.go
+++ b/service/controller/kvm/v6/resource/configmap/create.go
@@ -1,0 +1,51 @@
+package configmap
+
+import (
+	"context"
+
+	"github.com/giantswarm/errors/guest"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+
+	"github.com/giantswarm/cluster-operator/pkg/v5/configmap"
+	"github.com/giantswarm/cluster-operator/pkg/v5/key"
+	kvmkey "github.com/giantswarm/cluster-operator/service/controller/kvm/v5/key"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	customObject, err := kvmkey.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	configMapsToCreate, err := toConfigMaps(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	clusterGuestConfig := kvmkey.ClusterGuestConfig(customObject)
+	guestAPIDomain, err := key.APIDomain(clusterGuestConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	configMapConfig := configmap.ConfigMapConfig{
+		ClusterID:      key.ClusterID(clusterGuestConfig),
+		GuestAPIDomain: guestAPIDomain,
+	}
+	err = r.configMap.ApplyCreateChange(ctx, configMapConfig, configMapsToCreate)
+	if guest.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster is not available")
+
+		// We can't continue without a successful K8s connection. Cluster
+		// may not be up yet. We will retry during the next execution.
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/service/controller/kvm/v6/resource/configmap/current.go
+++ b/service/controller/kvm/v6/resource/configmap/current.go
@@ -1,0 +1,46 @@
+package configmap
+
+import (
+	"context"
+
+	"github.com/giantswarm/errors/guest"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+
+	"github.com/giantswarm/cluster-operator/pkg/v5/configmap"
+	"github.com/giantswarm/cluster-operator/pkg/v5/key"
+	kvmkey "github.com/giantswarm/cluster-operator/service/controller/kvm/v5/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := kvmkey.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	clusterGuestConfig := kvmkey.ClusterGuestConfig(customObject)
+	guestAPIDomain, err := key.APIDomain(clusterGuestConfig)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	configMapConfig := configmap.ConfigMapConfig{
+		ClusterID:      key.ClusterID(clusterGuestConfig),
+		GuestAPIDomain: guestAPIDomain,
+	}
+	configMaps, err := r.configMap.GetCurrentState(ctx, configMapConfig)
+	if guest.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster is not available")
+
+		// We can't continue without a successful K8s connection. Cluster
+		// may not be up yet. We will retry during the next execution.
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return nil, nil
+	} else if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return configMaps, nil
+}

--- a/service/controller/kvm/v6/resource/configmap/delete.go
+++ b/service/controller/kvm/v6/resource/configmap/delete.go
@@ -1,0 +1,71 @@
+package configmap
+
+import (
+	"context"
+
+	"github.com/giantswarm/errors/guest"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+
+	"github.com/giantswarm/cluster-operator/pkg/v5/configmap"
+	"github.com/giantswarm/cluster-operator/pkg/v5/key"
+	kvmkey "github.com/giantswarm/cluster-operator/service/controller/kvm/v5/key"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	customObject, err := kvmkey.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	configMapsToDelete, err := toConfigMaps(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	clusterGuestConfig := kvmkey.ClusterGuestConfig(customObject)
+	guestAPIDomain, err := key.APIDomain(clusterGuestConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	configMapConfig := configmap.ConfigMapConfig{
+		ClusterID:      key.ClusterID(clusterGuestConfig),
+		GuestAPIDomain: guestAPIDomain,
+	}
+	err = r.configMap.ApplyDeleteChange(ctx, configMapConfig, configMapsToDelete)
+	if guest.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster is not available")
+
+		// We can't continue without a successful K8s connection. Cluster
+		// may not be up yet. We will retry during the next execution.
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	currentConfigMaps, err := toConfigMaps(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	desiredConfigMaps, err := toConfigMaps(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch, err := r.configMap.NewDeletePatch(ctx, currentConfigMaps, desiredConfigMaps)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return patch, nil
+}

--- a/service/controller/kvm/v6/resource/configmap/desired.go
+++ b/service/controller/kvm/v6/resource/configmap/desired.go
@@ -1,0 +1,31 @@
+package configmap
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/cluster-operator/pkg/v5/configmap"
+	"github.com/giantswarm/cluster-operator/pkg/v5/key"
+	kvmkey "github.com/giantswarm/cluster-operator/service/controller/kvm/v5/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := kvmkey.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	clusterGuestConfig := kvmkey.ClusterGuestConfig(customObject)
+	configMapValues := configmap.ConfigMapValues{
+		ClusterID:    key.ClusterID(clusterGuestConfig),
+		Organization: key.ClusterOrganization(clusterGuestConfig),
+		WorkerCount:  kvmkey.WorkerCount(customObject),
+	}
+	desiredConfigMaps, err := r.configMap.GetDesiredState(ctx, configMapValues)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return desiredConfigMaps, nil
+}

--- a/service/controller/kvm/v6/resource/configmap/error.go
+++ b/service/controller/kvm/v6/resource/configmap/error.go
@@ -1,0 +1,24 @@
+package configmap
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = microerror.New("not found")
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongType asserts wrongTypeError.
+func IsWrongType(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/kvm/v6/resource/configmap/resource.go
+++ b/service/controller/kvm/v6/resource/configmap/resource.go
@@ -1,0 +1,81 @@
+package configmap
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/cluster-operator/pkg/v5/configmap"
+	"github.com/giantswarm/cluster-operator/pkg/v5/guestcluster"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "configmapv5"
+)
+
+// Config represents the configuration used to create a new chart config resource.
+type Config struct {
+	ConfigMap   configmap.Interface
+	Guest       guestcluster.Interface
+	K8sClient   kubernetes.Interface
+	Logger      micrologger.Logger
+	ProjectName string
+}
+
+// Resource implements the chart config resource.
+type Resource struct {
+	configMap   configmap.Interface
+	guest       guestcluster.Interface
+	k8sClient   kubernetes.Interface
+	logger      micrologger.Logger
+	projectName string
+}
+
+// New creates a new configured chart config resource.
+func New(config Config) (*Resource, error) {
+	if config.ConfigMap == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ConfigMap must not be empty", config)
+	}
+	if config.Guest == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Guest must not be empty", config)
+	}
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.ProjectName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ProjectName must not be empty", config)
+	}
+
+	r := &Resource{
+		configMap:   config.ConfigMap,
+		guest:       config.Guest,
+		k8sClient:   config.K8sClient,
+		logger:      config.Logger,
+		projectName: config.ProjectName,
+	}
+
+	return r, nil
+}
+
+// Name returns name of the Resource.
+func (r *Resource) Name() string {
+	return Name
+}
+
+func toConfigMaps(v interface{}) ([]*corev1.ConfigMap, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	configMaps, ok := v.([]*corev1.ConfigMap)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", []*corev1.ConfigMap{}, v)
+	}
+
+	return configMaps, nil
+}

--- a/service/controller/kvm/v6/resource/configmap/update.go
+++ b/service/controller/kvm/v6/resource/configmap/update.go
@@ -1,0 +1,71 @@
+package configmap
+
+import (
+	"context"
+
+	"github.com/giantswarm/errors/guest"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+
+	"github.com/giantswarm/cluster-operator/pkg/v5/configmap"
+	"github.com/giantswarm/cluster-operator/pkg/v5/key"
+	kvmkey "github.com/giantswarm/cluster-operator/service/controller/kvm/v5/key"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	customObject, err := kvmkey.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	configMapsToUpdate, err := toConfigMaps(updateChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	clusterGuestConfig := kvmkey.ClusterGuestConfig(customObject)
+	guestAPIDomain, err := key.APIDomain(clusterGuestConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	configMapConfig := configmap.ConfigMapConfig{
+		ClusterID:      key.ClusterID(clusterGuestConfig),
+		GuestAPIDomain: guestAPIDomain,
+	}
+	err = r.configMap.ApplyUpdateChange(ctx, configMapConfig, configMapsToUpdate)
+	if guest.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster is not available")
+
+		// We can't continue without a successful K8s connection. Cluster
+		// may not be up yet. We will retry during the next execution.
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	currentConfigMaps, err := toConfigMaps(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	desiredConfigMaps, err := toConfigMaps(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch, err := r.configMap.NewUpdatePatch(ctx, currentConfigMaps, desiredConfigMaps)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return patch, nil
+}

--- a/service/controller/kvm/v6/resource/kvmconfig/create.go
+++ b/service/controller/kvm/v6/resource/kvmconfig/create.go
@@ -1,0 +1,12 @@
+package kvmconfig
+
+import (
+	"context"
+)
+
+// ApplyCreateChange takes observed custom object and create portion of the
+// Patch provided by NewUpdatePatch or NewDeletePatch. It creates KVMConfig if
+// needed.
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	return nil
+}

--- a/service/controller/kvm/v6/resource/kvmconfig/create_test.go
+++ b/service/controller/kvm/v6/resource/kvmconfig/create_test.go
@@ -1,0 +1,1 @@
+package kvmconfig

--- a/service/controller/kvm/v6/resource/kvmconfig/current.go
+++ b/service/controller/kvm/v6/resource/kvmconfig/current.go
@@ -1,0 +1,12 @@
+package kvmconfig
+
+import (
+	"context"
+)
+
+// GetCurrentState takes observed custom object as an input and based on that
+// information looks for current state of KVMConfig and returns it. Return
+// value is of type *v1alpha1.KVMConfig.
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/controller/kvm/v6/resource/kvmconfig/delete.go
+++ b/service/controller/kvm/v6/resource/kvmconfig/delete.go
@@ -1,0 +1,23 @@
+package kvmconfig
+
+import (
+	"context"
+
+	"github.com/giantswarm/operatorkit/controller"
+)
+
+// ApplyDeleteChange takes observed custom object and delete portion of the
+// Patch provided by NewUpdatePatch and NewDeletePatch. It deletes KVMConfig if
+// needed.
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	return nil
+}
+
+// NewDeletePatch is called upon observed custom object deletion. It receives
+// the deleted custom object, the current state as provided by GetCurrentState
+// and the desired state as provided by GetDesiredState. NewDeletePatch
+// analyses the current and desired state and returns the patch to be applied by
+// Create, Delete, and Update functions.
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	return nil, nil
+}

--- a/service/controller/kvm/v6/resource/kvmconfig/delete_test.go
+++ b/service/controller/kvm/v6/resource/kvmconfig/delete_test.go
@@ -1,0 +1,1 @@
+package kvmconfig

--- a/service/controller/kvm/v6/resource/kvmconfig/desired.go
+++ b/service/controller/kvm/v6/resource/kvmconfig/desired.go
@@ -1,0 +1,11 @@
+package kvmconfig
+
+import (
+	"context"
+)
+
+// GetDesiredState takes observed (during create, delete and update events)
+// custom object as an input and returns computed desired state for it.
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/controller/kvm/v6/resource/kvmconfig/desired_test.go
+++ b/service/controller/kvm/v6/resource/kvmconfig/desired_test.go
@@ -1,0 +1,1 @@
+package kvmconfig

--- a/service/controller/kvm/v6/resource/kvmconfig/error.go
+++ b/service/controller/kvm/v6/resource/kvmconfig/error.go
@@ -1,0 +1,17 @@
+package kvmconfig
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/kvm/v6/resource/kvmconfig/resource.go
+++ b/service/controller/kvm/v6/resource/kvmconfig/resource.go
@@ -1,0 +1,61 @@
+package kvmconfig
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "kvmconfigv2"
+)
+
+// Config represents the configuration used to create a new cloud config resource.
+type Config struct {
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+// Resource implements the cloud config resource.
+type Resource struct {
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+// New creates a new configured cloud config resource.
+func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+
+	newService := &Resource{
+		// Dependencies.
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}
+
+	return newService, nil
+}
+
+// Name returns name of the Resource.
+func (r *Resource) Name() string {
+	return Name
+}
+
+func toKvmConfig(v interface{}) (*v1alpha1.KVMConfig, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	kvmConfig, ok := v.(*v1alpha1.KVMConfig)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &v1alpha1.KVMConfig{}, v)
+	}
+
+	return kvmConfig, nil
+}

--- a/service/controller/kvm/v6/resource/kvmconfig/update.go
+++ b/service/controller/kvm/v6/resource/kvmconfig/update.go
@@ -1,0 +1,20 @@
+package kvmconfig
+
+import (
+	"context"
+
+	"github.com/giantswarm/operatorkit/controller"
+)
+
+// ApplyUpdateChange takes observed custom object and update portion of the
+// Patch provided by NewUpdatePatch or NewDeletePatch. This updates KVMConfig
+// when needed.
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	return nil
+}
+
+// NewUpdatePatch computes appropriate Patch based on difference in current
+// state and desired state.
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	return nil, nil
+}

--- a/service/controller/kvm/v6/resource/kvmconfig/update_test.go
+++ b/service/controller/kvm/v6/resource/kvmconfig/update_test.go
@@ -1,0 +1,1 @@
+package kvmconfig

--- a/service/controller/kvm/v6/resource_set.go
+++ b/service/controller/kvm/v6/resource_set.go
@@ -1,0 +1,351 @@
+package v5
+
+import (
+	"context"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/apprclient"
+	"github.com/giantswarm/certs"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/resource/metricsresource"
+	"github.com/giantswarm/operatorkit/controller/resource/retryresource"
+	"github.com/spf13/afero"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/cluster-operator/pkg/cluster"
+	"github.com/giantswarm/cluster-operator/pkg/label"
+	configmapservice "github.com/giantswarm/cluster-operator/pkg/v5/configmap"
+	"github.com/giantswarm/cluster-operator/pkg/v5/guestcluster"
+	"github.com/giantswarm/cluster-operator/pkg/v5/resource/certconfig"
+	"github.com/giantswarm/cluster-operator/pkg/v5/resource/chart"
+	"github.com/giantswarm/cluster-operator/pkg/v5/resource/chartconfig"
+	"github.com/giantswarm/cluster-operator/pkg/v5/resource/encryptionkey"
+	"github.com/giantswarm/cluster-operator/pkg/v5/resource/namespace"
+	"github.com/giantswarm/cluster-operator/service/controller/kvm/v5/key"
+	"github.com/giantswarm/cluster-operator/service/controller/kvm/v5/resource/configmap"
+	"github.com/giantswarm/cluster-operator/service/controller/kvm/v5/resource/kvmconfig"
+)
+
+// ResourceSetConfig contains necessary dependencies and settings for
+// KVMClusterConfig controller ResourceSet configuration.
+type ResourceSetConfig struct {
+	ApprClient        *apprclient.Client
+	BaseClusterConfig *cluster.Config
+	CertSearcher      certs.Interface
+	Fs                afero.Fs
+	G8sClient         versioned.Interface
+	Guest             guestcluster.Interface
+	K8sClient         kubernetes.Interface
+	Logger            micrologger.Logger
+
+	HandledVersionBundles []string
+	ProjectName           string
+	RegistryDomain        string
+}
+
+// NewResourceSet returns a configured KVMClusterConfig controller ResourceSet.
+func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
+	var err error
+
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+	if config.ProjectName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.ProjectName must not be empty")
+	}
+
+	var certConfigResource controller.Resource
+	{
+		c := certconfig.Config{
+			BaseClusterConfig:        *config.BaseClusterConfig,
+			G8sClient:                config.G8sClient,
+			K8sClient:                config.K8sClient,
+			Logger:                   config.Logger,
+			ProjectName:              config.ProjectName,
+			Provider:                 label.ProviderKVM,
+			ToClusterGuestConfigFunc: toClusterGuestConfig,
+			ToClusterObjectMetaFunc:  toClusterObjectMeta,
+		}
+
+		ops, err := certconfig.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		certConfigResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var encryptionKeyResource controller.Resource
+	{
+		c := encryptionkey.Config{
+			K8sClient:                config.K8sClient,
+			Logger:                   config.Logger,
+			ProjectName:              config.ProjectName,
+			ToClusterGuestConfigFunc: toClusterGuestConfig,
+			ToClusterObjectMetaFunc:  toClusterObjectMeta,
+		}
+
+		ops, err := encryptionkey.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		encryptionKeyResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var kvmConfigResource controller.Resource
+	{
+		c := kvmconfig.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+		}
+
+		ops, err := kvmconfig.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		kvmConfigResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var guestClusterService *guestcluster.Service
+	{
+		c := guestcluster.Config{
+			CertsSearcher: config.CertSearcher,
+			Logger:        config.Logger,
+		}
+
+		guestClusterService, err = guestcluster.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var namespaceResource controller.Resource
+	{
+		c := namespace.Config{
+			BaseClusterConfig:        *config.BaseClusterConfig,
+			Guest:                    guestClusterService,
+			Logger:                   config.Logger,
+			ProjectName:              config.ProjectName,
+			ToClusterGuestConfigFunc: toClusterGuestConfig,
+			ToClusterObjectMetaFunc:  toClusterObjectMeta,
+		}
+
+		ops, err := namespace.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		namespaceResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var chartResource controller.Resource
+	{
+		c := chart.Config{
+			ApprClient:               config.ApprClient,
+			BaseClusterConfig:        *config.BaseClusterConfig,
+			Fs:                       config.Fs,
+			G8sClient:                config.G8sClient,
+			Guest:                    guestClusterService,
+			K8sClient:                config.K8sClient,
+			Logger:                   config.Logger,
+			ProjectName:              config.ProjectName,
+			RegistryDomain:           config.RegistryDomain,
+			ToClusterGuestConfigFunc: toClusterGuestConfig,
+		}
+
+		ops, err := chart.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		chartResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var configMapService configmapservice.Interface
+	{
+		c := configmapservice.Config{
+			Guest:          guestClusterService,
+			Logger:         config.Logger,
+			ProjectName:    config.ProjectName,
+			RegistryDomain: config.RegistryDomain,
+		}
+
+		configMapService, err = configmapservice.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var configMapResource controller.Resource
+	{
+		c := configmap.Config{
+			ConfigMap:   configMapService,
+			Guest:       guestClusterService,
+			K8sClient:   config.K8sClient,
+			Logger:      config.Logger,
+			ProjectName: config.ProjectName,
+		}
+
+		ops, err := configmap.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		configMapResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var chartConfigResource controller.Resource
+	{
+		c := chartconfig.Config{
+			BaseClusterConfig:        *config.BaseClusterConfig,
+			G8sClient:                config.G8sClient,
+			Guest:                    guestClusterService,
+			K8sClient:                config.K8sClient,
+			Logger:                   config.Logger,
+			ProjectName:              config.ProjectName,
+			Provider:                 label.ProviderKVM,
+			ToClusterGuestConfigFunc: toClusterGuestConfig,
+		}
+
+		ops, err := chartconfig.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		chartConfigResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	resources := []controller.Resource{
+		// Put encryptionKeyResource first because it executes faster than
+		// kvmConfigResource and could introduce dependency during cluster
+		// creation.
+		encryptionKeyResource,
+		certConfigResource,
+		kvmConfigResource,
+		// namespace, chart, configmap and chartconfig resources manage resources in
+		// guest clusters so they should be executed last.
+		namespaceResource,
+		chartResource,
+		configMapResource,
+		chartConfigResource,
+	}
+
+	// Wrap resources with retry and metrics.
+	{
+		c := retryresource.WrapConfig{
+			Logger: config.Logger,
+		}
+
+		resources, err = retryresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	{
+		c := metricsresource.WrapConfig{
+			Name: config.ProjectName,
+		}
+
+		resources, err = metricsresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	initCtxFunc := func(ctx context.Context, obj interface{}) (context.Context, error) {
+		return ctx, nil
+	}
+
+	handlesFunc := func(obj interface{}) bool {
+		kvmClusterConfig, err := key.ToCustomObject(obj)
+		if err != nil {
+			return false
+		}
+
+		if key.VersionBundleVersion(kvmClusterConfig) == VersionBundle().Version {
+			return true
+		}
+
+		return false
+	}
+
+	var resourceSet *controller.ResourceSet
+	{
+		c := controller.ResourceSetConfig{
+			Handles:   handlesFunc,
+			InitCtx:   initCtxFunc,
+			Logger:    config.Logger,
+			Resources: resources,
+		}
+
+		resourceSet, err = controller.NewResourceSet(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return resourceSet, nil
+}
+
+func toClusterGuestConfig(obj interface{}) (v1alpha1.ClusterGuestConfig, error) {
+	kvmClusterConfig, err := key.ToCustomObject(obj)
+	if err != nil {
+		return v1alpha1.ClusterGuestConfig{}, microerror.Mask(err)
+	}
+
+	return key.ToClusterGuestConfig(kvmClusterConfig), nil
+}
+
+func toClusterObjectMeta(obj interface{}) (apismetav1.ObjectMeta, error) {
+	kvmClusterConfig, err := key.ToCustomObject(obj)
+	if err != nil {
+		return apismetav1.ObjectMeta{}, microerror.Mask(err)
+	}
+
+	return kvmClusterConfig.ObjectMeta, nil
+}
+
+func toCRUDResource(logger micrologger.Logger, ops controller.CRUDResourceOps) (*controller.CRUDResource, error) {
+	c := controller.CRUDResourceConfig{
+		Logger: logger,
+		Ops:    ops,
+	}
+
+	r, err := controller.NewCRUDResource(c)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return r, nil
+}

--- a/service/controller/kvm/v6/version_bundle.go
+++ b/service/controller/kvm/v6/version_bundle.go
@@ -1,0 +1,30 @@
+package v5
+
+import (
+	"github.com/giantswarm/versionbundle"
+)
+
+func VersionBundle() versionbundle.Bundle {
+	return versionbundle.Bundle{
+		Changelogs: []versionbundle.Changelog{
+			{
+				Component:   "cluster-operator",
+				Description: "Added configmap resource for managing chart configuration in guest clusters.",
+				Kind:        versionbundle.KindAdded,
+			},
+		},
+		Components: []versionbundle.Component{
+			{
+				Name:    "kube-state-metrics",
+				Version: "1.3.1",
+			},
+			{
+				Name:    "node-exporter",
+				Version: "0.15.1",
+			},
+		},
+		Name:     "cluster-operator",
+		Provider: "kvm",
+		Version:  "0.5.0",
+	}
+}


### PR DESCRIPTION
This PR got created by `opsctl` in order to automate the creation of a new WIP version bundle. This specific PR is to copy the latest resource package only. FYI @giantswarm/sig-operator @giantswarm/sig-customer @giantswarm/sre.