### PR TITLE
Check for guest cluster not available error in chart resource

### DIFF
--- a/pkg/v6/resource/chart/current.go
+++ b/pkg/v6/resource/chart/current.go
@@ -12,6 +12,8 @@ import (
 
 // GetCurrentState gets the state of the chart in the guest cluster.
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding chart-operator chart in the guest cluster")
+
 	guestHelmClient, err := r.getGuestHelmClient(ctx, obj)
 	if guestcluster.IsTimeout(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "did not get a Helm client for the guest cluster")
@@ -19,7 +21,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		// We can't continue without a Helm client. We will retry during the
 		// next execution.
 		reconciliationcanceledcontext.SetCanceled(ctx)
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation for custom object")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 
 		return nil, nil
 	} else if guest.IsAPINotAvailable(err) {
@@ -28,7 +30,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		// We can't continue without a successful K8s connection. Cluster
 		// may not be up yet. We will retry during the next execution.
 		reconciliationcanceledcontext.SetCanceled(ctx)
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation for custom object")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 
 		return nil, nil
 	} else if err != nil {
@@ -45,7 +47,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		// We can't continue without a successful K8s connection. Cluster
 		// may not be up yet. We will retry during the next execution.
 		reconciliationcanceledcontext.SetCanceled(ctx)
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation for custom object")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 
 		return nil, nil
 	} else if err != nil {

--- a/pkg/v6/resource/chart/current.go
+++ b/pkg/v6/resource/chart/current.go
@@ -39,7 +39,15 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	if helmclient.IsReleaseNotFound(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the chart-operator chart in the guest cluster")
 		return nil, nil
+	} else if guest.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster is not available")
 
+		// We can't continue without a successful K8s connection. Cluster
+		// may not be up yet. We will retry during the next execution.
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation for custom object")
+
+		return nil, nil
 	} else if err != nil {
 		return nil, microerror.Mask(err)
 	}


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/3836

The chart resource misses the error check for the guest cluster not being available. Updates error handling to match the namespace and chartconfig resources. Fix is also backported to `v5`.