### PR TITLE
Update Ingress Controller release channel to 0-2-stable for Azure

### DIFF
--- a/pkg/v6/resource/chartconfig/desired.go
+++ b/pkg/v6/resource/chartconfig/desired.go
@@ -68,7 +68,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 
 func (r *Resource) newIngressControllerChartConfig(ctx context.Context, clusterConfig cluster.Config) (*v1alpha1.ChartConfig, error) {
 	chartName := "kubernetes-nginx-ingress-controller-chart"
-	channelName := "0-1-stable"
+	channelName := "0-2-stable"
 	configMapName := "nginx-ingress-controller-values"
 	releaseName := "nginx-ingress-controller"
 	labels := newChartConfigLabels(clusterConfig, releaseName, r.projectName)

--- a/service/controller/azure/v6/version_bundle.go
+++ b/service/controller/azure/v6/version_bundle.go
@@ -9,7 +9,7 @@ func VersionBundle() versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "nginx-ingress-controller",
-				Description: "Disable HSTS headers.",
+				Description: "Disabled HSTS headers.",
 				Kind:        versionbundle.KindChanged,
 			},
 		},

--- a/service/controller/azure/v6/version_bundle.go
+++ b/service/controller/azure/v6/version_bundle.go
@@ -8,8 +8,8 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "cluster-operator",
-				Description: "Add your changes here",
+				Component:   "nginx-ingress-controller",
+				Description: "Disable HSTS headers.",
 				Kind:        versionbundle.KindChanged,
 			},
 		},


### PR DESCRIPTION
To deploy https://github.com/giantswarm/kubernetes-nginx-ingress-controller/pull/23 once its merged.