### PR TITLE
vendor update for helmclient

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -229,7 +229,7 @@
   branch = "master"
   name = "github.com/giantswarm/helmclient"
   packages = ["."]
-  revision = "3914877fd51ce6d6fed716e770748abc8ab73501"
+  revision = "382dab3023ef7ed0de57a13607a1dad541b397a0"
 
 [[projects]]
   branch = "master"

--- a/pkg/v1/resource/chart/mock_test.go
+++ b/pkg/v1/resource/chart/mock_test.go
@@ -57,6 +57,10 @@ func (h *helmMock) DeleteRelease(releaseName string, options ...helm.DeleteOptio
 	return nil
 }
 
+func (h *helmMock) EnsureTillerInstalled() error {
+	return nil
+}
+
 func (h *helmMock) GetReleaseContent(releaseName string) (*helmclient.ReleaseContent, error) {
 	if h.defaultError != nil {
 		return nil, h.defaultError
@@ -77,10 +81,10 @@ func (h *helmMock) InstallFromTarball(path, ns string, options ...helm.InstallOp
 	return nil
 }
 
-func (h *helmMock) UpdateReleaseFromTarball(releaseName, path string, options ...helm.UpdateOption) error {
+func (h *helmMock) RunReleaseTest(releaseName string, options ...helm.ReleaseTestOption) error {
 	return nil
 }
 
-func (h *helmMock) EnsureTillerInstalled() error {
+func (h *helmMock) UpdateReleaseFromTarball(releaseName, path string, options ...helm.UpdateOption) error {
 	return nil
 }

--- a/pkg/v2/resource/chart/mock_test.go
+++ b/pkg/v2/resource/chart/mock_test.go
@@ -57,6 +57,10 @@ func (h *helmMock) DeleteRelease(releaseName string, options ...helm.DeleteOptio
 	return nil
 }
 
+func (h *helmMock) EnsureTillerInstalled() error {
+	return nil
+}
+
 func (h *helmMock) GetReleaseContent(releaseName string) (*helmclient.ReleaseContent, error) {
 	if h.defaultError != nil {
 		return nil, h.defaultError
@@ -77,10 +81,10 @@ func (h *helmMock) InstallFromTarball(path, ns string, options ...helm.InstallOp
 	return nil
 }
 
-func (h *helmMock) UpdateReleaseFromTarball(releaseName, path string, options ...helm.UpdateOption) error {
+func (h *helmMock) RunReleaseTest(releaseName string, options ...helm.ReleaseTestOption) error {
 	return nil
 }
 
-func (h *helmMock) EnsureTillerInstalled() error {
+func (h *helmMock) UpdateReleaseFromTarball(releaseName, path string, options ...helm.UpdateOption) error {
 	return nil
 }

--- a/pkg/v3/resource/chart/mock_test.go
+++ b/pkg/v3/resource/chart/mock_test.go
@@ -77,6 +77,10 @@ func (h *helmMock) InstallFromTarball(path, ns string, options ...helm.InstallOp
 	return nil
 }
 
+func (h *helmMock) RunReleaseTest(releaseName string, options ...helm.ReleaseTestOption) error {
+	return nil
+}
+
 func (h *helmMock) UpdateReleaseFromTarball(releaseName, path string, options ...helm.UpdateOption) error {
 	return nil
 }

--- a/pkg/v4/resource/chart/mock_test.go
+++ b/pkg/v4/resource/chart/mock_test.go
@@ -57,6 +57,10 @@ func (h *helmMock) DeleteRelease(releaseName string, options ...helm.DeleteOptio
 	return nil
 }
 
+func (h *helmMock) EnsureTillerInstalled() error {
+	return nil
+}
+
 func (h *helmMock) GetReleaseContent(releaseName string) (*helmclient.ReleaseContent, error) {
 	if h.defaultError != nil {
 		return nil, h.defaultError
@@ -77,10 +81,10 @@ func (h *helmMock) InstallFromTarball(path, ns string, options ...helm.InstallOp
 	return nil
 }
 
-func (h *helmMock) UpdateReleaseFromTarball(releaseName, path string, options ...helm.UpdateOption) error {
+func (h *helmMock) RunReleaseTest(releaseName string, options ...helm.ReleaseTestOption) error {
 	return nil
 }
 
-func (h *helmMock) EnsureTillerInstalled() error {
+func (h *helmMock) UpdateReleaseFromTarball(releaseName, path string, options ...helm.UpdateOption) error {
 	return nil
 }

--- a/pkg/v5/resource/chart/mock_test.go
+++ b/pkg/v5/resource/chart/mock_test.go
@@ -57,6 +57,10 @@ func (h *helmMock) DeleteRelease(releaseName string, options ...helm.DeleteOptio
 	return nil
 }
 
+func (h *helmMock) EnsureTillerInstalled() error {
+	return nil
+}
+
 func (h *helmMock) GetReleaseContent(releaseName string) (*helmclient.ReleaseContent, error) {
 	if h.defaultError != nil {
 		return nil, h.defaultError
@@ -77,10 +81,10 @@ func (h *helmMock) InstallFromTarball(path, ns string, options ...helm.InstallOp
 	return nil
 }
 
-func (h *helmMock) UpdateReleaseFromTarball(releaseName, path string, options ...helm.UpdateOption) error {
+func (h *helmMock) RunReleaseTest(releaseName string, options ...helm.ReleaseTestOption) error {
 	return nil
 }
 
-func (h *helmMock) EnsureTillerInstalled() error {
+func (h *helmMock) UpdateReleaseFromTarball(releaseName, path string, options ...helm.UpdateOption) error {
 	return nil
 }

--- a/pkg/v6/resource/chart/mock_test.go
+++ b/pkg/v6/resource/chart/mock_test.go
@@ -57,6 +57,10 @@ func (h *helmMock) DeleteRelease(releaseName string, options ...helm.DeleteOptio
 	return nil
 }
 
+func (h *helmMock) EnsureTillerInstalled() error {
+	return nil
+}
+
 func (h *helmMock) GetReleaseContent(releaseName string) (*helmclient.ReleaseContent, error) {
 	if h.defaultError != nil {
 		return nil, h.defaultError
@@ -77,10 +81,10 @@ func (h *helmMock) InstallFromTarball(path, ns string, options ...helm.InstallOp
 	return nil
 }
 
-func (h *helmMock) UpdateReleaseFromTarball(releaseName, path string, options ...helm.UpdateOption) error {
+func (h *helmMock) RunReleaseTest(releaseName string, options ...helm.ReleaseTestOption) error {
 	return nil
 }
 
-func (h *helmMock) EnsureTillerInstalled() error {
+func (h *helmMock) UpdateReleaseFromTarball(releaseName, path string, options ...helm.UpdateOption) error {
 	return nil
 }

--- a/vendor/github.com/giantswarm/helmclient/Gopkg.lock
+++ b/vendor/github.com/giantswarm/helmclient/Gopkg.lock
@@ -146,7 +146,7 @@
   branch = "master"
   name = "github.com/giantswarm/errors"
   packages = ["guest"]
-  revision = "e829655ed78351b795407d7ec2b9b27d9a40dcf7"
+  revision = "9e78ca0e32a019481beb21ae3e158d1bb150730d"
 
 [[projects]]
   branch = "master"

--- a/vendor/github.com/giantswarm/helmclient/error.go
+++ b/vendor/github.com/giantswarm/helmclient/error.go
@@ -103,6 +103,20 @@ func IsReleaseNotFound(err error) bool {
 	return false
 }
 
+var testReleaseFailureError = microerror.New("test release failure")
+
+// IsTestReleaseFailure asserts testReleaseFailureError.
+func IsTestReleaseFailure(err error) bool {
+	return microerror.Cause(err) == testReleaseFailureError
+}
+
+var testReleaseTimeoutError = microerror.New("test release timeout")
+
+// IsTestReleaseTimeout asserts testReleaseTimeoutError.
+func IsTestReleaseTimeout(err error) bool {
+	return microerror.Cause(err) == testReleaseTimeoutError
+}
+
 var tillerInstallationFailedError = microerror.New("Tiller installation failed")
 
 // IsTillerInstallationFailed asserts tillerInstallationFailedError.

--- a/vendor/github.com/giantswarm/helmclient/spec.go
+++ b/vendor/github.com/giantswarm/helmclient/spec.go
@@ -29,6 +29,9 @@ type Interface interface {
 	GetReleaseHistory(releaseName string) (*ReleaseHistory, error)
 	// InstallFromTarball installs a Helm Chart packaged in the given tarball.
 	InstallFromTarball(path, ns string, options ...helm.InstallOption) error
+	// RunReleaseTest runs the tests for a Helm Release. This is the same
+	// action as running the helm test command.
+	RunReleaseTest(releaseName string, options ...helm.ReleaseTestOption) error
 	// UpdateReleaseFromTarball updates the given release using the chart packaged
 	// in the tarball.
 	UpdateReleaseFromTarball(releaseName, path string, options ...helm.UpdateOption) error


### PR DESCRIPTION
I changed the interface of giantswarm/helmclient to add RunReleaseTest so the mocks also need to be updated. Otherwise CI will fail.