### PR TITLE
Ingress Controller configmap settings for migration

### DIFF
--- a/pkg/v6/configmap/desired.go
+++ b/pkg/v6/configmap/desired.go
@@ -20,11 +20,11 @@ type BasicConfigMap struct {
 type IngressController struct {
 	Controller IngressControllerController `json:"controller"`
 	Global     IngressControllerGlobal     `json:"global"`
+	Image      Image                       `json:"image"`
 }
 
 type IngressControllerController struct {
 	Replicas int                                `json:"replicas"`
-	Image    Image                              `json:"image"`
 	Service  IngressControllerControllerService `json:"service"`
 }
 
@@ -97,6 +97,9 @@ func (s *Service) newIngressControllerConfigMap(ctx context.Context, configMapVa
 					Enabled: configMapValues.IngressControllerMigrationEnabled,
 				},
 			},
+		},
+		Image: Image{
+			Registry: s.registryDomain,
 		},
 	}
 	json, err := json.Marshal(values)

--- a/pkg/v6/configmap/desired.go
+++ b/pkg/v6/configmap/desired.go
@@ -19,11 +19,34 @@ type BasicConfigMap struct {
 
 type IngressController struct {
 	Controller IngressControllerController `json:"controller"`
+	Global     IngressControllerGlobal     `json:"global"`
 }
 
 type IngressControllerController struct {
-	Replicas int   `json:"replicas"`
-	Image    Image `json:"image"`
+	Replicas int                                `json:"replicas"`
+	Image    Image                              `json:"image"`
+	Service  IngressControllerControllerService `json:"service"`
+}
+
+type IngressControllerControllerService struct {
+	Enabled bool `json:"enabled"`
+}
+
+type IngressControllerGlobal struct {
+	Controller IngressControllerGlobalController `json:"controller"`
+	Migration  IngressControllerGlobalMigration  `json:"migration"`
+}
+
+type IngressControllerGlobalController struct {
+	Replicas int `json:"replicas"`
+}
+
+type IngressControllerGlobalMigration struct {
+	Job IngressControllerGlobalMigrationJob `json:"job"`
+}
+
+type IngressControllerGlobalMigrationJob struct {
+	Enabled bool `json:"enabled"`
 }
 
 type Image struct {
@@ -60,6 +83,19 @@ func (s *Service) newIngressControllerConfigMap(ctx context.Context, configMapVa
 			Replicas: configMapValues.WorkerCount,
 			Image: Image{
 				Registry: s.registryDomain,
+			},
+			Service: IngressControllerControllerService{
+				Enabled: configMapValues.IngressControllerServiceEnabled,
+			},
+		},
+		Global: IngressControllerGlobal{
+			Controller: IngressControllerGlobalController{
+				Replicas: configMapValues.WorkerCount,
+			},
+			Migration: IngressControllerGlobalMigration{
+				Job: IngressControllerGlobalMigrationJob{
+					Enabled: configMapValues.IngressControllerMigrationEnabled,
+				},
 			},
 		},
 	}

--- a/pkg/v6/configmap/desired.go
+++ b/pkg/v6/configmap/desired.go
@@ -24,12 +24,7 @@ type IngressController struct {
 }
 
 type IngressControllerController struct {
-	Replicas int                                `json:"replicas"`
-	Service  IngressControllerControllerService `json:"service"`
-}
-
-type IngressControllerControllerService struct {
-	Enabled bool `json:"enabled"`
+	Replicas int `json:"replicas"`
 }
 
 type IngressControllerGlobal struct {
@@ -42,10 +37,6 @@ type IngressControllerGlobalController struct {
 }
 
 type IngressControllerGlobalMigration struct {
-	Job IngressControllerGlobalMigrationJob `json:"job"`
-}
-
-type IngressControllerGlobalMigrationJob struct {
 	Enabled bool `json:"enabled"`
 }
 
@@ -81,21 +72,13 @@ func (s *Service) newIngressControllerConfigMap(ctx context.Context, configMapVa
 	values := IngressController{
 		Controller: IngressControllerController{
 			Replicas: configMapValues.WorkerCount,
-			Image: Image{
-				Registry: s.registryDomain,
-			},
-			Service: IngressControllerControllerService{
-				Enabled: configMapValues.IngressControllerServiceEnabled,
-			},
 		},
 		Global: IngressControllerGlobal{
 			Controller: IngressControllerGlobalController{
 				Replicas: configMapValues.WorkerCount,
 			},
 			Migration: IngressControllerGlobalMigration{
-				Job: IngressControllerGlobalMigrationJob{
-					Enabled: configMapValues.IngressControllerMigrationEnabled,
-				},
+				Enabled: configMapValues.IngressControllerMigrationEnabled,
 			},
 		},
 		Image: Image{

--- a/pkg/v6/configmap/desired_test.go
+++ b/pkg/v6/configmap/desired_test.go
@@ -78,7 +78,7 @@ const (
 			},
 			"migration": {
 				"job": {
-					"enabled": true
+					"enabled": false
 				}
 			}
 		}

--- a/pkg/v6/configmap/desired_test.go
+++ b/pkg/v6/configmap/desired_test.go
@@ -18,69 +18,54 @@ const (
 	basicMatchJSON = `
 	{
 		"controller": {
-			"replicas": 3,
-			"image": {
-				"registry": "quay.io"
-			},
-			"service": {
-				"enabled": true
-			}
+			"replicas": 3
 		},
 		"global": {
 			"controller": {
 				"replicas": 3
 			},
 			"migration": {
-				"job": {
-					"enabled": true
-				}
+				"enabled": true
 			}
+		},
+		"image": {
+			"registry": "quay.io"
 		}
 	}	
 	`
 	differentWorkerCountJSON = `
 	{
 		"controller": {
-			"replicas": 7,
-			"image": {
-				"registry": "quay.io"
-			},
-			"service": {
-				"enabled": true
-			}
+			"replicas": 7
 		},
 		"global": {
 			"controller": {
 				"replicas": 7
 			},
 			"migration": {
-				"job": {
-					"enabled": true
-				}
+				"enabled": true
 			}
+		},
+		"image": {
+			"registry": "quay.io"
 		}
 	}	
 	`
 	differentSettingsJSON = `
 	{
 		"controller": {
-			"replicas": 3,
-			"image": {
-				"registry": "quay.io"
-			},
-			"service": {
-				"enabled": false
-			}
+			"replicas": 3
 		},
 		"global": {
 			"controller": {
 				"replicas": 3
 			},
 			"migration": {
-				"job": {
-					"enabled": true
-				}
+				"enabled": false
 			}
+		},
+		"image": {
+			"registry": "quay.io"
 		}
 	}	
 	`
@@ -97,7 +82,6 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 			configMapValues: ConfigMapValues{
 				ClusterID:                         "5xchu",
 				IngressControllerMigrationEnabled: true,
-				IngressControllerServiceEnabled:   true,
 				Organization:                      "giantswarm",
 				WorkerCount:                       3,
 			},
@@ -158,7 +142,6 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 				ClusterID:                         "5xchu",
 				Organization:                      "giantswarm",
 				IngressControllerMigrationEnabled: true,
-				IngressControllerServiceEnabled:   true,
 				WorkerCount:                       7,
 			},
 			expectedConfigMaps: []*corev1.ConfigMap{
@@ -216,8 +199,7 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 			name: "case 2: different ingress controller settings",
 			configMapValues: ConfigMapValues{
 				ClusterID:                         "5xchu",
-				IngressControllerMigrationEnabled: true,
-				IngressControllerServiceEnabled:   false,
+				IngressControllerMigrationEnabled: false,
 				Organization:                      "giantswarm",
 				WorkerCount:                       3,
 			},

--- a/pkg/v6/configmap/desired_test.go
+++ b/pkg/v6/configmap/desired_test.go
@@ -69,7 +69,7 @@ const (
 				"registry": "quay.io"
 			},
 			"service": {
-				"enabled": true
+				"enabled": false
 			}
 		},
 		"global": {
@@ -78,7 +78,7 @@ const (
 			},
 			"migration": {
 				"job": {
-					"enabled": false
+					"enabled": true
 				}
 			}
 		}

--- a/pkg/v6/configmap/desired_test.go
+++ b/pkg/v6/configmap/desired_test.go
@@ -2,13 +2,88 @@ package configmap
 
 import (
 	"context"
+	"encoding/json"
 	"reflect"
 	"testing"
 
-	"github.com/giantswarm/cluster-operator/pkg/label"
+	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger/microloggertest"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/cluster-operator/pkg/label"
+)
+
+const (
+	basicMatchJSON = `
+	{
+		"controller": {
+			"replicas": 3,
+			"image": {
+				"registry": "quay.io"
+			},
+			"service": {
+				"enabled": true
+			}
+		},
+		"global": {
+			"controller": {
+				"replicas": 3
+			},
+			"migration": {
+				"job": {
+					"enabled": true
+				}
+			}
+		}
+	}	
+	`
+	differentWorkerCountJSON = `
+	{
+		"controller": {
+			"replicas": 7,
+			"image": {
+				"registry": "quay.io"
+			},
+			"service": {
+				"enabled": true
+			}
+		},
+		"global": {
+			"controller": {
+				"replicas": 7
+			},
+			"migration": {
+				"job": {
+					"enabled": true
+				}
+			}
+		}
+	}	
+	`
+	differentSettingsJSON = `
+	{
+		"controller": {
+			"replicas": 3,
+			"image": {
+				"registry": "quay.io"
+			},
+			"service": {
+				"enabled": true
+			}
+		},
+		"global": {
+			"controller": {
+				"replicas": 3
+			},
+			"migration": {
+				"job": {
+					"enabled": true
+				}
+			}
+		}
+	}	
+	`
 )
 
 func Test_ConfigMap_GetDesiredState(t *testing.T) {
@@ -20,9 +95,11 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 		{
 			name: "case 0: basic match",
 			configMapValues: ConfigMapValues{
-				ClusterID:    "5xchu",
-				Organization: "giantswarm",
-				WorkerCount:  3,
+				ClusterID:                         "5xchu",
+				IngressControllerMigrationEnabled: true,
+				IngressControllerServiceEnabled:   true,
+				Organization:                      "giantswarm",
+				WorkerCount:                       3,
 			},
 			expectedConfigMaps: []*corev1.ConfigMap{
 				&corev1.ConfigMap{
@@ -38,7 +115,7 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 						},
 					},
 					Data: map[string]string{
-						"values.json": "{\"controller\":{\"replicas\":3,\"image\":{\"registry\":\"quay.io\"}}}",
+						"values.json": basicMatchJSON,
 					},
 				},
 				&corev1.ConfigMap{
@@ -78,9 +155,11 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 		{
 			name: "case 1: different worker count",
 			configMapValues: ConfigMapValues{
-				ClusterID:    "5xchu",
-				Organization: "giantswarm",
-				WorkerCount:  7,
+				ClusterID:                         "5xchu",
+				Organization:                      "giantswarm",
+				IngressControllerMigrationEnabled: true,
+				IngressControllerServiceEnabled:   true,
+				WorkerCount:                       7,
 			},
 			expectedConfigMaps: []*corev1.ConfigMap{
 				&corev1.ConfigMap{
@@ -96,7 +175,67 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 						},
 					},
 					Data: map[string]string{
-						"values.json": "{\"controller\":{\"replicas\":7,\"image\":{\"registry\":\"quay.io\"}}}",
+						"values.json": differentWorkerCountJSON,
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kube-state-metrics-values",
+						Namespace: metav1.NamespaceSystem,
+						Labels: map[string]string{
+							label.App:          "kube-state-metrics",
+							label.Cluster:      "5xchu",
+							label.ManagedBy:    "cluster-operator",
+							label.Organization: "giantswarm",
+							label.ServiceType:  "managed",
+						},
+					},
+					Data: map[string]string{
+						"values.json": "{\"image\":{\"registry\":\"quay.io\"}}",
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "node-exporter-values",
+						Namespace: metav1.NamespaceSystem,
+						Labels: map[string]string{
+							label.App:          "node-exporter",
+							label.Cluster:      "5xchu",
+							label.ManagedBy:    "cluster-operator",
+							label.Organization: "giantswarm",
+							label.ServiceType:  "managed",
+						},
+					},
+					Data: map[string]string{
+						"values.json": "{\"image\":{\"registry\":\"quay.io\"}}",
+					},
+				},
+			},
+		},
+		{
+			name: "case 2: different ingress controller settings",
+			configMapValues: ConfigMapValues{
+				ClusterID:                         "5xchu",
+				IngressControllerMigrationEnabled: true,
+				IngressControllerServiceEnabled:   false,
+				Organization:                      "giantswarm",
+				WorkerCount:                       3,
+			},
+			expectedConfigMaps: []*corev1.ConfigMap{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "nginx-ingress-controller-values",
+						Namespace: metav1.NamespaceSystem,
+						Labels: map[string]string{
+							label.App:          "nginx-ingress-controller",
+							label.Cluster:      "5xchu",
+							label.ManagedBy:    "cluster-operator",
+							label.Organization: "giantswarm",
+							label.ServiceType:  "managed",
+						},
+					},
+					Data: map[string]string{
+						"values.json": differentSettingsJSON,
 					},
 				},
 				&corev1.ConfigMap{
@@ -160,19 +299,48 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 			for _, expectedConfigMap := range tc.expectedConfigMaps {
 				configMap, err := getConfigMapByNameAndNamespace(configMaps, expectedConfigMap.Name, expectedConfigMap.Namespace)
 				if IsNotFound(err) {
-					t.Fatalf("expected config map %s not found", expectedConfigMap.Name)
+					t.Fatalf("expected config map '%s' not found", expectedConfigMap.Name)
 				} else if err != nil {
 					t.Fatalf("expected nil, got %#v", err)
-				}
-
-				if !reflect.DeepEqual(configMap.Data, expectedConfigMap.Data) {
-					t.Fatalf("expected config map data %#v, got %#v", expectedConfigMap.Data, configMap.Data)
 				}
 
 				if !reflect.DeepEqual(configMap.ObjectMeta.Labels, expectedConfigMap.ObjectMeta.Labels) {
 					t.Fatalf("expected config map labels %#v, got %#v", expectedConfigMap.ObjectMeta.Labels, configMap.ObjectMeta.Labels)
 				}
+
+				for expectedKey, expectedValues := range expectedConfigMap.Data {
+					values, ok := configMap.Data[expectedKey]
+					if !ok {
+						t.Fatalf("expected key '%s' not found", expectedKey)
+					}
+
+					equalValues, err := compareJSON(expectedValues, values)
+					if err != nil {
+						t.Fatal("expected", nil, "got", err)
+					}
+					if !equalValues {
+						t.Fatal("expected", expectedValues, "got", values)
+					}
+				}
 			}
 		})
 	}
+}
+
+func compareJSON(expectedJSON, valuesJSON string) (bool, error) {
+	var err error
+
+	expectedValues := make(map[string]interface{})
+	err = json.Unmarshal([]byte(expectedJSON), &expectedValues)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	values := make(map[string]interface{})
+	err = json.Unmarshal([]byte(valuesJSON), &values)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	return reflect.DeepEqual(expectedValues, values), nil
 }

--- a/pkg/v6/configmap/spec.go
+++ b/pkg/v6/configmap/spec.go
@@ -31,6 +31,5 @@ type ConfigMapValues struct {
 	ClusterID                         string
 	Organization                      string
 	IngressControllerMigrationEnabled bool
-	IngressControllerServiceEnabled   bool
 	WorkerCount                       int
 }

--- a/pkg/v6/configmap/spec.go
+++ b/pkg/v6/configmap/spec.go
@@ -28,7 +28,9 @@ type ConfigMapConfig struct {
 // ConfigMapValues is used by the configmap resources to provide data to the
 // configmap service.
 type ConfigMapValues struct {
-	ClusterID    string
-	Organization string
-	WorkerCount  int
+	ClusterID                         string
+	Organization                      string
+	IngressControllerMigrationEnabled bool
+	IngressControllerServiceEnabled   bool
+	WorkerCount                       int
 }

--- a/service/controller/aws/v6/resource/configmap/desired.go
+++ b/service/controller/aws/v6/resource/configmap/desired.go
@@ -20,10 +20,13 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	configMapValues := configmap.ConfigMapValues{
 		ClusterID:    key.ClusterID(clusterGuestConfig),
 		Organization: key.ClusterOrganization(clusterGuestConfig),
-		// TODO Better comments and issue.
+		// Migration is enabled so existing k8scloudconfig resources are
+		// replaced.
 		IngressControllerMigrationEnabled: true,
-		IngressControllerServiceEnabled:   false,
-		WorkerCount:                       awskey.WorkerCount(customObject),
+		// Controller Service is disabled because it is created by
+		// k8scloudconfig during the migration process.
+		IngressControllerServiceEnabled: false,
+		WorkerCount:                     awskey.WorkerCount(customObject),
 	}
 	desiredConfigMaps, err := r.configMap.GetDesiredState(ctx, configMapValues)
 	if err != nil {

--- a/service/controller/aws/v6/resource/configmap/desired.go
+++ b/service/controller/aws/v6/resource/configmap/desired.go
@@ -20,7 +20,10 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	configMapValues := configmap.ConfigMapValues{
 		ClusterID:    key.ClusterID(clusterGuestConfig),
 		Organization: key.ClusterOrganization(clusterGuestConfig),
-		WorkerCount:  awskey.WorkerCount(customObject),
+		// TODO Better comments and issue.
+		IngressControllerMigrationEnabled: true,
+		IngressControllerServiceEnabled:   false,
+		WorkerCount:                       awskey.WorkerCount(customObject),
 	}
 	desiredConfigMaps, err := r.configMap.GetDesiredState(ctx, configMapValues)
 	if err != nil {

--- a/service/controller/aws/v6/resource/configmap/desired.go
+++ b/service/controller/aws/v6/resource/configmap/desired.go
@@ -23,10 +23,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		// Migration is enabled so existing k8scloudconfig resources are
 		// replaced.
 		IngressControllerMigrationEnabled: true,
-		// Controller Service is disabled because it is created by
-		// k8scloudconfig during the migration process.
-		IngressControllerServiceEnabled: false,
-		WorkerCount:                     awskey.WorkerCount(customObject),
+		WorkerCount:                       awskey.WorkerCount(customObject),
 	}
 	desiredConfigMaps, err := r.configMap.GetDesiredState(ctx, configMapValues)
 	if err != nil {

--- a/service/controller/azure/v6/resource/configmap/desired.go
+++ b/service/controller/azure/v6/resource/configmap/desired.go
@@ -19,11 +19,13 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	clusterGuestConfig := azurekey.ClusterGuestConfig(customObject)
 	configMapValues := configmap.ConfigMapValues{
 		ClusterID: key.ClusterID(clusterGuestConfig),
-		// TODO Better comments and issue.
+		// Migration is disabled because Azure is already migrated.
 		IngressControllerMigrationEnabled: false,
-		IngressControllerServiceEnabled:   true,
-		Organization:                      key.ClusterOrganization(clusterGuestConfig),
-		WorkerCount:                       azurekey.WorkerCount(customObject),
+		// Controller Service is enabled because it is created by the chart not
+		// by k8scloudconfig.
+		IngressControllerServiceEnabled: true,
+		Organization:                    key.ClusterOrganization(clusterGuestConfig),
+		WorkerCount:                     azurekey.WorkerCount(customObject),
 	}
 	desiredConfigMaps, err := r.configMap.GetDesiredState(ctx, configMapValues)
 	if err != nil {

--- a/service/controller/azure/v6/resource/configmap/desired.go
+++ b/service/controller/azure/v6/resource/configmap/desired.go
@@ -21,11 +21,8 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		ClusterID: key.ClusterID(clusterGuestConfig),
 		// Migration is disabled because Azure is already migrated.
 		IngressControllerMigrationEnabled: false,
-		// Controller Service is enabled because it is created by the chart not
-		// by k8scloudconfig.
-		IngressControllerServiceEnabled: true,
-		Organization:                    key.ClusterOrganization(clusterGuestConfig),
-		WorkerCount:                     azurekey.WorkerCount(customObject),
+		Organization:                      key.ClusterOrganization(clusterGuestConfig),
+		WorkerCount:                       azurekey.WorkerCount(customObject),
 	}
 	desiredConfigMaps, err := r.configMap.GetDesiredState(ctx, configMapValues)
 	if err != nil {

--- a/service/controller/azure/v6/resource/configmap/desired.go
+++ b/service/controller/azure/v6/resource/configmap/desired.go
@@ -18,9 +18,12 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 
 	clusterGuestConfig := azurekey.ClusterGuestConfig(customObject)
 	configMapValues := configmap.ConfigMapValues{
-		ClusterID:    key.ClusterID(clusterGuestConfig),
-		Organization: key.ClusterOrganization(clusterGuestConfig),
-		WorkerCount:  azurekey.WorkerCount(customObject),
+		ClusterID: key.ClusterID(clusterGuestConfig),
+		// TODO Better comments and issue.
+		IngressControllerMigrationEnabled: false,
+		IngressControllerServiceEnabled:   true,
+		Organization:                      key.ClusterOrganization(clusterGuestConfig),
+		WorkerCount:                       azurekey.WorkerCount(customObject),
 	}
 	desiredConfigMaps, err := r.configMap.GetDesiredState(ctx, configMapValues)
 	if err != nil {

--- a/service/controller/kvm/v6/resource/configmap/desired.go
+++ b/service/controller/kvm/v6/resource/configmap/desired.go
@@ -20,7 +20,13 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	configMapValues := configmap.ConfigMapValues{
 		ClusterID:    key.ClusterID(clusterGuestConfig),
 		Organization: key.ClusterOrganization(clusterGuestConfig),
-		WorkerCount:  kvmkey.WorkerCount(customObject),
+		// Migration is enabled so existing k8scloudconfig resources are
+		// replaced.
+		IngressControllerMigrationEnabled: true,
+		// Controller Service is disabled because it is created by
+		// k8scloudconfig during the migration process.
+		IngressControllerServiceEnabled: false,
+		WorkerCount:                     kvmkey.WorkerCount(customObject),
 	}
 	desiredConfigMaps, err := r.configMap.GetDesiredState(ctx, configMapValues)
 	if err != nil {

--- a/service/controller/kvm/v6/resource/configmap/desired.go
+++ b/service/controller/kvm/v6/resource/configmap/desired.go
@@ -23,10 +23,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		// Migration is enabled so existing k8scloudconfig resources are
 		// replaced.
 		IngressControllerMigrationEnabled: true,
-		// Controller Service is disabled because it is created by
-		// k8scloudconfig during the migration process.
-		IngressControllerServiceEnabled: false,
-		WorkerCount:                     kvmkey.WorkerCount(customObject),
+		WorkerCount:                       kvmkey.WorkerCount(customObject),
 	}
 	desiredConfigMaps, err := r.configMap.GetDesiredState(ctx, configMapValues)
 	if err != nil {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3710

Adds extra settings for controlling the migration process.

We create the configmap for all providers but only Azure is active because it also has the IC chartconfig. Activating IC on AWS and KVM will come in later PRs.

