### PR TITLE
Adds net-exporter chart

### DIFF
--- a/pkg/v6/configmap/desired.go
+++ b/pkg/v6/configmap/desired.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/cluster-operator/pkg/label"
@@ -30,12 +31,17 @@ type Image struct {
 	Registry string `json:"registry"`
 }
 
+type NetExporter struct {
+	Namespace string `json:"namespace"`
+}
+
 func (s *Service) GetDesiredState(ctx context.Context, configMapValues ConfigMapValues) ([]*corev1.ConfigMap, error) {
 	desiredConfigMaps := make([]*corev1.ConfigMap, 0)
 
 	generators := []configMapGenerator{
 		s.newIngressControllerConfigMap,
 		s.newKubeStateMetricsConfigMap,
+		s.newNetExporterConfigMap,
 		s.newNodeExporterConfigMap,
 	}
 
@@ -85,6 +91,34 @@ func (s *Service) newIngressControllerConfigMap(ctx context.Context, configMapVa
 
 func (s *Service) newKubeStateMetricsConfigMap(ctx context.Context, configMapValues ConfigMapValues, projectName string) (*corev1.ConfigMap, error) {
 	return s.newBasicConfigMap(ctx, configMapValues, projectName, "kube-state-metrics")
+}
+
+func (s *Service) newNetExporterConfigMap(ctx context.Context, configMapValues ConfigMapValues, projectName string) (*corev1.ConfigMap, error) {
+	configMapName := "net-exporter-values"
+	appName := "net-exporter"
+	labels := newConfigMapLabels(configMapValues, appName, projectName)
+
+	values := NetExporter{
+		Namespace: apismetav1.NamespaceSystem,
+	}
+	json, err := json.Marshal(values)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	data := map[string]string{
+		"values.json": string(json),
+	}
+
+	newConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: metav1.NamespaceSystem,
+			Labels:    labels,
+		},
+		Data: data,
+	}
+
+	return newConfigMap, nil
 }
 
 func (s *Service) newNodeExporterConfigMap(ctx context.Context, configMapValues ConfigMapValues, projectName string) (*corev1.ConfigMap, error) {

--- a/pkg/v6/configmap/desired_test.go
+++ b/pkg/v6/configmap/desired_test.go
@@ -31,7 +31,7 @@ const (
 		"image": {
 			"registry": "quay.io"
 		}
-	}	
+	}
 	`
 	differentWorkerCountJSON = `
 	{
@@ -49,7 +49,7 @@ const (
 		"image": {
 			"registry": "quay.io"
 		}
-	}	
+	}
 	`
 	differentSettingsJSON = `
 	{
@@ -67,7 +67,7 @@ const (
 		"image": {
 			"registry": "quay.io"
 		}
-	}	
+	}
 	`
 )
 
@@ -191,6 +191,22 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 					},
 					Data: map[string]string{
 						"values.json": "{\"image\":{\"registry\":\"quay.io\"}}",
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "net-exporter-values",
+						Namespace: metav1.NamespaceSystem,
+						Labels: map[string]string{
+							label.App:          "net-exporter",
+							label.Cluster:      "5xchu",
+							label.ManagedBy:    "cluster-operator",
+							label.Organization: "giantswarm",
+							label.ServiceType:  "managed",
+						},
+					},
+					Data: map[string]string{
+						"values.json": "{\"namespace\":\"kube-system\"}",
 					},
 				},
 				&corev1.ConfigMap{

--- a/pkg/v6/configmap/desired_test.go
+++ b/pkg/v6/configmap/desired_test.go
@@ -59,6 +59,22 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 				},
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
+						Name:      "net-exporter-values",
+						Namespace: metav1.NamespaceSystem,
+						Labels: map[string]string{
+							label.App:          "net-exporter",
+							label.Cluster:      "5xchu",
+							label.ManagedBy:    "cluster-operator",
+							label.Organization: "giantswarm",
+							label.ServiceType:  "managed",
+						},
+					},
+					Data: map[string]string{
+						"values.json": "{\"namespace\":\"kube-system\"}",
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "node-exporter-values",
 						Namespace: metav1.NamespaceSystem,
 						Labels: map[string]string{
@@ -113,6 +129,22 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 					},
 					Data: map[string]string{
 						"values.json": "{\"image\":{\"registry\":\"quay.io\"}}",
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "net-exporter-values",
+						Namespace: metav1.NamespaceSystem,
+						Labels: map[string]string{
+							label.App:          "net-exporter",
+							label.Cluster:      "5xchu",
+							label.ManagedBy:    "cluster-operator",
+							label.Organization: "giantswarm",
+							label.ServiceType:  "managed",
+						},
+					},
+					Data: map[string]string{
+						"values.json": "{\"namespace\":\"kube-system\"}",
 					},
 				},
 				&corev1.ConfigMap{

--- a/pkg/v6/resource/chartconfig/desired.go
+++ b/pkg/v6/resource/chartconfig/desired.go
@@ -46,6 +46,13 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		}
 		desiredChartConfigs = append(desiredChartConfigs, chartConfig)
 	}
+	{
+		chartConfig, err := r.newNetExporterChartConfig(ctx, clusterConfig, r.projectName)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		desiredChartConfigs = append(desiredChartConfigs, chartConfig)
+	}
 
 	// Only enable Ingress Controller for Azure.
 	if r.provider == label.ProviderAzure {
@@ -138,6 +145,43 @@ func (r *Resource) newKubeStateMetricsChartConfig(ctx context.Context, clusterCo
 	channelName := "0-1-stable"
 	configMapName := "kube-state-metrics-values"
 	releaseName := "kube-state-metrics"
+	labels := newChartConfigLabels(clusterConfig, releaseName, projectName)
+
+	configMapSpec, err := r.getConfigMapSpec(ctx, clusterConfig, configMapName, apismetav1.NamespaceSystem)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	chartConfigCR := &v1alpha1.ChartConfig{
+		TypeMeta: apismetav1.TypeMeta{
+			Kind:       chartConfigKind,
+			APIVersion: chartConfigAPIVersion,
+		},
+		ObjectMeta: apismetav1.ObjectMeta{
+			Name:   chartName,
+			Labels: labels,
+		},
+		Spec: v1alpha1.ChartConfigSpec{
+			Chart: v1alpha1.ChartConfigSpecChart{
+				Name:      chartName,
+				Channel:   channelName,
+				ConfigMap: *configMapSpec,
+				Namespace: apismetav1.NamespaceSystem,
+				Release:   releaseName,
+			},
+			VersionBundle: v1alpha1.ChartConfigSpecVersionBundle{
+				Version: chartConfigVersionBundleVersion,
+			},
+		},
+	}
+	return chartConfigCR, nil
+}
+
+func (r *Resource) newNetExporterChartConfig(ctx context.Context, clusterConfig cluster.Config, projectName string) (*v1alpha1.ChartConfig, error) {
+	chartName := "net-exporter-chart"
+	channelName := "stable"
+	configMapName := "net-exporter-values"
+	releaseName := "net-exporter"
 	labels := newChartConfigLabels(clusterConfig, releaseName, projectName)
 
 	configMapSpec, err := r.getConfigMapSpec(ctx, clusterConfig, configMapName, apismetav1.NamespaceSystem)

--- a/pkg/v6/resource/chartconfig/desired_test.go
+++ b/pkg/v6/resource/chartconfig/desired_test.go
@@ -35,6 +35,7 @@ func Test_ChartConfig_GetDesiredState(t *testing.T) {
 			expectedChartConfigNames: []string{
 				"kubernetes-node-exporter-chart",
 				"kubernetes-kube-state-metrics-chart",
+				"net-exporter-chart",
 			},
 		},
 		{
@@ -48,6 +49,7 @@ func Test_ChartConfig_GetDesiredState(t *testing.T) {
 			expectedChartConfigNames: []string{
 				"kubernetes-node-exporter-chart",
 				"kubernetes-kube-state-metrics-chart",
+				"net-exporter-chart",
 			},
 		},
 		{
@@ -63,6 +65,7 @@ func Test_ChartConfig_GetDesiredState(t *testing.T) {
 				"kubernetes-kube-state-metrics-chart",
 				"kubernetes-nginx-ingress-controller-chart",
 				"kubernetes-external-dns-chart",
+				"net-exporter-chart",
 			},
 		},
 	}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3711

```
$ helm list --tiller-namespace giantswarm
NAME                    	REVISION	UPDATED                 	STATUS  	CHART                                                       	NAMESPACE
chart-operator          	1       	Wed Aug 15 14:53:32 2018	DEPLOYED	chart-operator-chart-0.2.2                                  	giantswarm
external-dns            	1       	Wed Aug 15 14:58:18 2018	DEPLOYED	kubernetes-external-dns-chart-0.1.0                         	kube-system
kube-state-metrics      	1       	Wed Aug 15 14:57:43 2018	DEPLOYED	kubernetes-kube-state-metrics-chart-0.1.7                   	kube-system
net-exporter            	1       	Wed Aug 15 14:58:11 2018	DEPLOYED	net-exporter-chart-1.0.0-befd30be628347c9380ccdf6230c5a88...	kube-system
nginx-ingress-controller	1       	Wed Aug 15 14:58:14 2018	DEPLOYED	kubernetes-nginx-ingress-controller-chart-0.2.12            	kube-system
node-exporter           	1       	Wed Aug 15 14:57:59 2018	DEPLOYED	kubernetes-node-exporter-chart-0.1.8                        	kube-system
```

```
$ kubectl -n=kube-system get ds,pod -o wide -l=app=net-exporter
NAME                                DESIRED   CURRENT   READY     UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE       CONTAINERS     IMAGES                                                                     SELECTOR
daemonset.extensions/net-exporter   4         4         4         4            4           <none>          1h        net-exporter   quay.io/giantswarm/net-exporter:befd30be628347c9380ccdf6230c5a8865ea0688   app=net-exporter

NAME                     READY     STATUS    RESTARTS   AGE       IP           NODE
pod/net-exporter-cjhdf   1/1       Running   0          1h        10.1.130.5   4bims-worker-000003
pod/net-exporter-cp442   1/1       Running   0          1h        10.1.128.2   4bims-master-000000
pod/net-exporter-sdwvt   1/1       Running   0          1h        10.1.131.4   4bims-worker-000000
pod/net-exporter-zdhnf   1/1       Running   0          1h        10.1.129.3   4bims-worker-000002
```

```
$ curl -Ss 10.1.130.5:8000/metrics | grep network | head -n 10
# HELP network_error_total Total number of network dial errors.
# TYPE network_error_total counter
network_error_total 3
# HELP network_latency_seconds Histogram of latency of network dials.
# TYPE network_latency_seconds histogram
network_latency_seconds_bucket{host="net-exporter:8000",le="0.001"} 1
network_latency_seconds_bucket{host="net-exporter:8000",le="0.002"} 1
network_latency_seconds_bucket{host="net-exporter:8000",le="0.004"} 2
network_latency_seconds_bucket{host="net-exporter:8000",le="0.008"} 2
network_latency_seconds_bucket{host="net-exporter:8000",le="0.016"} 2
```