### PR TITLE
Update ingress controller version in AWS and Azure changelogs.

### DIFF
--- a/service/controller/aws/v6/version_bundle.go
+++ b/service/controller/aws/v6/version_bundle.go
@@ -27,6 +27,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Added support for deploying nginx-ingress-controller.",
 				Kind:        versionbundle.KindAdded,
 			},
+			{
+				Component:   "nginx-ingress-controller",
+				Description: "Updated to 0.15.0.",
+				Kind:        versionbundle.KindUpdated,
+			},
 		},
 		Components: []versionbundle.Component{
 			{
@@ -35,7 +40,7 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Name:    "nginx-ingress-controller",
-				Version: "0.12.0",
+				Version: "0.15.0",
 			},
 			{
 				Name:    "node-exporter",

--- a/service/controller/azure/v6/version_bundle.go
+++ b/service/controller/azure/v6/version_bundle.go
@@ -22,11 +22,16 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Added support for deploying net-exporter.",
 				Kind:        versionbundle.KindAdded,
 			},
+			{
+				Component:   "nginx-ingress-controller",
+				Description: "Updated to 0.15.0.",
+				Kind:        versionbundle.KindUpdated,
+			},
 		},
 		Components: []versionbundle.Component{
 			{
 				Name:    "nginx-ingress-controller",
-				Version: "0.12.0",
+				Version: "0.15.0",
 			},
 			{
 				Name:    "external-dns",


### PR DESCRIPTION
IC has been updated to 0.15.0 on AWS and Azure. I'll update KVM when the IC chart is enabled there.

For Azure 0.6.0 is already active and this was done as a patch release. So it is already rolled out to clusters on this version. So I think updating the changelog is the best approach.

For Service Catalog I think we need to find a better way of exposing patch version updates in cluster-operator. To avoid needing to update the changelog.