### PR TITLE
Add coredns params

### DIFF
--- a/helm/cluster-operator-chart/templates/configmap.yaml
+++ b/helm/cluster-operator-chart/templates/configmap.yaml
@@ -13,6 +13,9 @@ data:
         address: 'http://0.0.0.0:8000'
     guest:
       cluster:
+        calico:
+          subnet: '{{ .Values.Installation.V1.Guest.Calico.Subnet }}'
+          cidr: '{{ .Values.Installation.V1.Guest.Calico.CIDR }}'
         kubernetes:
           api:
             clusterIPRange: '{{ .Values.Installation.V1.Guest.Kubernetes.API.ClusterIPRange }}'

--- a/main.go
+++ b/main.go
@@ -109,6 +109,8 @@ func mainWithError() (err error) {
 
 	daemonCommand := newCommand.DaemonCommand().CobraCommand()
 
+	daemonCommand.PersistentFlags().String(f.Guest.Cluster.Calico.CIDR, "", "Prefix length for the CIDR block used by Calico.")
+	daemonCommand.PersistentFlags().String(f.Guest.Cluster.Calico.Subnet, "", "Network address for the CIDR block used by Calico.")
 	daemonCommand.PersistentFlags().String(f.Guest.Cluster.Kubernetes.API.ClusterIPRange, "", "CIDR Range for Pods in cluster.")
 	daemonCommand.PersistentFlags().String(f.Guest.Cluster.Vault.Certificate.TTL, "", "Vault certificate TTL.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.Address, "", "Address used to connect to Kubernetes. When empty in-cluster config is created.")


### PR DESCRIPTION
Towards giantswarm/giantswarm#1902

Adds missing installations params required by coredns (flags are already in place).