### PR TITLE
set CoreDNS configmap params

### DIFF
--- a/pkg/v7/configmap/configmap.go
+++ b/pkg/v7/configmap/configmap.go
@@ -14,8 +14,11 @@ type Config struct {
 	Guest  guestcluster.Interface
 	Logger micrologger.Logger
 
-	ProjectName    string
-	RegistryDomain string
+	CalicoAddress      string
+	CalicoPrefixLength string
+	ClusterIPRange     string
+	ProjectName        string
+	RegistryDomain     string
 }
 
 // Service provides shared functionality for managing configmaps.
@@ -23,8 +26,11 @@ type Service struct {
 	guest  guestcluster.Interface
 	logger micrologger.Logger
 
-	projectName    string
-	registryDomain string
+	calicoAddress      string
+	calicoPrefixLength string
+	clusterIPRange     string
+	projectName        string
+	registryDomain     string
 }
 
 // New creates a new configmap service.
@@ -36,6 +42,15 @@ func New(config Config) (*Service, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 
+	if config.CalicoAddress == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CalicoAddress must not be empty", config)
+	}
+	if config.CalicoPrefixLength == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CalicoPrefixLength must not be empty", config)
+	}
+	if config.ClusterIPRange == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ClusterIPRange must not be empty", config)
+	}
 	if config.ProjectName == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ProjectName must not be empty", config)
 	}
@@ -44,10 +59,13 @@ func New(config Config) (*Service, error) {
 	}
 
 	s := &Service{
-		guest:          config.Guest,
-		logger:         config.Logger,
-		projectName:    config.ProjectName,
-		registryDomain: config.RegistryDomain,
+		guest:              config.Guest,
+		logger:             config.Logger,
+		calicoAddress:      config.CalicoAddress,
+		calicoPrefixLength: config.CalicoPrefixLength,
+		clusterIPRange:     config.ClusterIPRange,
+		projectName:        config.ProjectName,
+		registryDomain:     config.RegistryDomain,
 	}
 
 	return s, nil

--- a/pkg/v7/configmap/create_test.go
+++ b/pkg/v7/configmap/create_test.go
@@ -155,10 +155,13 @@ func Test_ConfigMap_newCreateChange(t *testing.T) {
 	}
 
 	c := Config{
-		Guest:          &guestMock{},
-		Logger:         microloggertest.New(),
-		ProjectName:    "cluster-operator",
-		RegistryDomain: "quay.io",
+		Guest:              &guestMock{},
+		Logger:             microloggertest.New(),
+		CalicoAddress:      "172.20.0.0",
+		CalicoPrefixLength: "16",
+		ClusterIPRange:     "172.31.0.0/16",
+		ProjectName:        "cluster-operator",
+		RegistryDomain:     "quay.io",
 	}
 	newService, err := New(c)
 	if err != nil {

--- a/pkg/v7/configmap/current_test.go
+++ b/pkg/v7/configmap/current_test.go
@@ -409,10 +409,13 @@ func Test_ConfigMap_GetCurrentState(t *testing.T) {
 			}
 
 			c := Config{
-				Guest:          guestService,
-				Logger:         microloggertest.New(),
-				ProjectName:    "cluster-operator",
-				RegistryDomain: "quay.io",
+				Guest:              guestService,
+				Logger:             microloggertest.New(),
+				CalicoAddress:      "172.20.0.0",
+				CalicoPrefixLength: "16",
+				ClusterIPRange:     "172.31.0.0/16",
+				ProjectName:        "cluster-operator",
+				RegistryDomain:     "quay.io",
 			}
 			newService, err := New(c)
 			if err != nil {

--- a/pkg/v7/configmap/delete_test.go
+++ b/pkg/v7/configmap/delete_test.go
@@ -219,10 +219,13 @@ func Test_ConfigMap_newDeleteChangeForDeletePatch(t *testing.T) {
 	}
 
 	c := Config{
-		Guest:          &guestMock{},
-		Logger:         microloggertest.New(),
-		ProjectName:    "cluster-operator",
-		RegistryDomain: "quay.io",
+		Guest:              &guestMock{},
+		Logger:             microloggertest.New(),
+		CalicoAddress:      "172.20.0.0",
+		CalicoPrefixLength: "16",
+		ClusterIPRange:     "172.31.0.0/16",
+		ProjectName:        "cluster-operator",
+		RegistryDomain:     "quay.io",
 	}
 	newService, err := New(c)
 	if err != nil {

--- a/pkg/v7/configmap/desired_test.go
+++ b/pkg/v7/configmap/desired_test.go
@@ -517,9 +517,12 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 				Guest: &guestMock{
 					fakeGuestHelmClient: helmClient,
 				},
-				Logger:         microloggertest.New(),
-				ProjectName:    "cluster-operator",
-				RegistryDomain: "quay.io",
+				Logger:             microloggertest.New(),
+				CalicoAddress:      "172.20.0.0",
+				CalicoPrefixLength: "16",
+				ClusterIPRange:     "172.31.0.0/16",
+				ProjectName:        "cluster-operator",
+				RegistryDomain:     "quay.io",
 			}
 			newService, err := New(c)
 			if err != nil {

--- a/pkg/v7/configmap/update_test.go
+++ b/pkg/v7/configmap/update_test.go
@@ -235,10 +235,13 @@ func Test_ConfigMap_newUpdateChange(t *testing.T) {
 	}
 
 	c := Config{
-		Guest:          &guestMock{},
-		Logger:         microloggertest.New(),
-		ProjectName:    "cluster-operator",
-		RegistryDomain: "quay.io",
+		Guest:              &guestMock{},
+		Logger:             microloggertest.New(),
+		CalicoAddress:      "172.20.0.0",
+		CalicoPrefixLength: "16",
+		ClusterIPRange:     "172.31.0.0/16",
+		ProjectName:        "cluster-operator",
+		RegistryDomain:     "quay.io",
 	}
 	newService, err := New(c)
 	if err != nil {

--- a/service/controller/aws/cluster.go
+++ b/service/controller/aws/cluster.go
@@ -38,8 +38,11 @@ type ClusterConfig struct {
 	K8sExtClient      apiextensionsclient.Interface
 	Logger            micrologger.Logger
 
-	ProjectName    string
-	RegistryDomain string
+	CalicoAddress      string
+	CalicoPrefixLength string
+	ClusterIPRange     string
+	ProjectName        string
+	RegistryDomain     string
 }
 
 type Cluster struct {
@@ -205,8 +208,12 @@ func NewCluster(config ClusterConfig) (*Cluster, error) {
 			G8sClient:         config.G8sClient,
 			K8sClient:         config.K8sClient,
 			Logger:            config.Logger,
-			ProjectName:       config.ProjectName,
-			RegistryDomain:    config.RegistryDomain,
+
+			CalicoAddress:      config.CalicoAddress,
+			CalicoPrefixLength: config.CalicoPrefixLength,
+			ClusterIPRange:     config.ClusterIPRange,
+			ProjectName:        config.ProjectName,
+			RegistryDomain:     config.RegistryDomain,
 		}
 
 		v7ResourceSet, err = v7.NewResourceSet(c)

--- a/service/controller/aws/v7/resource_set.go
+++ b/service/controller/aws/v7/resource_set.go
@@ -41,6 +41,9 @@ type ResourceSetConfig struct {
 	K8sClient         kubernetes.Interface
 	Logger            micrologger.Logger
 
+	CalicoAddress         string
+	CalicoPrefixLength    string
+	ClusterIPRange        string
 	HandledVersionBundles []string
 	ProjectName           string
 	RegistryDomain        string
@@ -190,10 +193,14 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var configMapService configmapservice.Interface
 	{
 		c := configmapservice.Config{
-			Guest:          guestClusterService,
-			Logger:         config.Logger,
-			ProjectName:    config.ProjectName,
-			RegistryDomain: config.RegistryDomain,
+			Guest:  guestClusterService,
+			Logger: config.Logger,
+
+			CalicoAddress:      config.CalicoAddress,
+			CalicoPrefixLength: config.CalicoPrefixLength,
+			ClusterIPRange:     config.ClusterIPRange,
+			ProjectName:        config.ProjectName,
+			RegistryDomain:     config.RegistryDomain,
 		}
 
 		configMapService, err = configmapservice.New(c)

--- a/service/controller/azure/cluster.go
+++ b/service/controller/azure/cluster.go
@@ -36,8 +36,11 @@ type ClusterConfig struct {
 	K8sExtClient      apiextensionsclient.Interface
 	Logger            micrologger.Logger
 
-	ProjectName    string
-	RegistryDomain string
+	CalicoAddress      string
+	CalicoPrefixLength string
+	ClusterIPRange     string
+	ProjectName        string
+	RegistryDomain     string
 }
 
 type Cluster struct {
@@ -199,8 +202,12 @@ func NewCluster(config ClusterConfig) (*Cluster, error) {
 			G8sClient:         config.G8sClient,
 			K8sClient:         config.K8sClient,
 			Logger:            config.Logger,
-			ProjectName:       config.ProjectName,
-			RegistryDomain:    config.RegistryDomain,
+
+			CalicoAddress:      config.CalicoAddress,
+			CalicoPrefixLength: config.CalicoPrefixLength,
+			ClusterIPRange:     config.ClusterIPRange,
+			ProjectName:        config.ProjectName,
+			RegistryDomain:     config.RegistryDomain,
 		}
 
 		v7ResourceSet, err = v7.NewResourceSet(c)

--- a/service/controller/azure/v7/resource_set.go
+++ b/service/controller/azure/v7/resource_set.go
@@ -42,6 +42,9 @@ type ResourceSetConfig struct {
 	K8sClient         kubernetes.Interface
 	Logger            micrologger.Logger
 
+	CalicoAddress         string
+	CalicoPrefixLength    string
+	ClusterIPRange        string
 	HandledVersionBundles []string
 	ProjectName           string
 	RegistryDomain        string
@@ -191,10 +194,14 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var configMapService configmapservice.Interface
 	{
 		c := configmapservice.Config{
-			Guest:          guestClusterService,
-			Logger:         config.Logger,
-			ProjectName:    config.ProjectName,
-			RegistryDomain: config.RegistryDomain,
+			Guest:  guestClusterService,
+			Logger: config.Logger,
+
+			CalicoAddress:      config.CalicoAddress,
+			CalicoPrefixLength: config.CalicoPrefixLength,
+			ClusterIPRange:     config.ClusterIPRange,
+			ProjectName:        config.ProjectName,
+			RegistryDomain:     config.RegistryDomain,
 		}
 
 		configMapService, err = configmapservice.New(c)

--- a/service/controller/kvm/cluster.go
+++ b/service/controller/kvm/cluster.go
@@ -36,8 +36,11 @@ type ClusterConfig struct {
 	K8sExtClient      apiextensionsclient.Interface
 	Logger            micrologger.Logger
 
-	ProjectName    string
-	RegistryDomain string
+	CalicoAddress      string
+	CalicoPrefixLength string
+	ClusterIPRange     string
+	ProjectName        string
+	RegistryDomain     string
 }
 
 type Cluster struct {
@@ -200,8 +203,12 @@ func NewCluster(config ClusterConfig) (*Cluster, error) {
 			G8sClient:         config.G8sClient,
 			K8sClient:         config.K8sClient,
 			Logger:            config.Logger,
-			ProjectName:       config.ProjectName,
-			RegistryDomain:    config.RegistryDomain,
+
+			CalicoAddress:      config.CalicoAddress,
+			CalicoPrefixLength: config.CalicoPrefixLength,
+			ClusterIPRange:     config.ClusterIPRange,
+			ProjectName:        config.ProjectName,
+			RegistryDomain:     config.RegistryDomain,
 		}
 
 		v7ResourceSet, err = v7.NewResourceSet(c)

--- a/service/controller/kvm/v7/resource_set.go
+++ b/service/controller/kvm/v7/resource_set.go
@@ -42,6 +42,9 @@ type ResourceSetConfig struct {
 	K8sClient         kubernetes.Interface
 	Logger            micrologger.Logger
 
+	CalicoAddress         string
+	CalicoPrefixLength    string
+	ClusterIPRange        string
 	HandledVersionBundles []string
 	ProjectName           string
 	RegistryDomain        string
@@ -190,10 +193,14 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var configMapService configmapservice.Interface
 	{
 		c := configmapservice.Config{
-			Guest:          guestClusterService,
-			Logger:         config.Logger,
-			ProjectName:    config.ProjectName,
-			RegistryDomain: config.RegistryDomain,
+			Guest:  guestClusterService,
+			Logger: config.Logger,
+
+			CalicoAddress:      config.CalicoAddress,
+			CalicoPrefixLength: config.CalicoPrefixLength,
+			ClusterIPRange:     config.ClusterIPRange,
+			ProjectName:        config.ProjectName,
+			RegistryDomain:     config.RegistryDomain,
 		}
 
 		configMapService, err = configmapservice.New(c)

--- a/service/service.go
+++ b/service/service.go
@@ -194,10 +194,13 @@ func New(config Config) (*Service, error) {
 			G8sClient:         g8sClient,
 			K8sClient:         k8sClient,
 			K8sExtClient:      k8sExtClient,
+			Logger:            config.Logger,
 
-			Logger:         config.Logger,
-			ProjectName:    config.ProjectName,
-			RegistryDomain: registryDomain,
+			ClusterIPRange:     clusterIPRange,
+			CalicoAddress:      calicoAddress,
+			CalicoPrefixLength: calicoPrefixLength,
+			ProjectName:        config.ProjectName,
+			RegistryDomain:     registryDomain,
 		}
 
 		azureClusterController, err = azure.NewCluster(c)
@@ -234,10 +237,13 @@ func New(config Config) (*Service, error) {
 			G8sClient:         g8sClient,
 			K8sClient:         k8sClient,
 			K8sExtClient:      k8sExtClient,
+			Logger:            config.Logger,
 
-			Logger:         config.Logger,
-			ProjectName:    config.ProjectName,
-			RegistryDomain: registryDomain,
+			ClusterIPRange:     clusterIPRange,
+			CalicoAddress:      calicoAddress,
+			CalicoPrefixLength: calicoPrefixLength,
+			ProjectName:        config.ProjectName,
+			RegistryDomain:     registryDomain,
 		}
 
 		kvmClusterController, err = kvm.NewCluster(c)

--- a/service/service.go
+++ b/service/service.go
@@ -78,6 +78,9 @@ func New(config Config) (*Service, error) {
 	var err error
 
 	registryDomain := config.Viper.GetString(config.Flag.Service.RegistryDomain)
+	clusterIPRange := config.Viper.GetString(config.Flag.Guest.Cluster.Kubernetes.API.ClusterIPRange)
+	calicoAddress := config.Viper.GetString(config.Flag.Guest.Cluster.Calico.Subnet)
+	calicoPrefixLength := config.Viper.GetString(config.Flag.Guest.Cluster.Calico.CIDR)
 
 	var restConfig *rest.Config
 	{
@@ -161,10 +164,13 @@ func New(config Config) (*Service, error) {
 			G8sClient:         g8sClient,
 			K8sClient:         k8sClient,
 			K8sExtClient:      k8sExtClient,
+			Logger:            config.Logger,
 
-			Logger:         config.Logger,
-			ProjectName:    config.ProjectName,
-			RegistryDomain: registryDomain,
+			ClusterIPRange:     clusterIPRange,
+			CalicoAddress:      calicoAddress,
+			CalicoPrefixLength: calicoPrefixLength,
+			ProjectName:        config.ProjectName,
+			RegistryDomain:     registryDomain,
 		}
 
 		awsClusterController, err = aws.NewCluster(c)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -39,6 +39,8 @@ func Test_Service_New(t *testing.T) {
 				config.ProjectName = "test"
 				config.Source = "test"
 
+				config.Viper.Set(config.Flag.Guest.Cluster.Calico.CIDR, "16")
+				config.Viper.Set(config.Flag.Guest.Cluster.Calico.Subnet, "172.26.0.0")
 				config.Viper.Set(config.Flag.Guest.Cluster.Kubernetes.API.ClusterIPRange, "172.31.0.0/16")
 				config.Viper.Set(config.Flag.Service.Kubernetes.Address, "http://127.0.0.1:6443")
 				config.Viper.Set(config.Flag.Service.Kubernetes.InCluster, "false")


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1902

Makes the required params available to the configmap resource for setting coredns in aws, the actual CM will be configured in the next PR.