### PR TITLE
add missing e2e template values

### DIFF
--- a/integration/template/cluster_operator_chart_values.go
+++ b/integration/template/cluster_operator_chart_values.go
@@ -5,6 +5,9 @@ package template
 const ClusterOperatorChartValues = `Installation:
   V1:
     Guest:
+      Calico:
+        CIDR: 16
+        Subnet: 10.20.0.0
       Kubernetes:
         API:
           ClusterIPRange: 10.0.0.0/16


### PR DESCRIPTION
Fixes this error from e2e tests:
```
2018/09/18 16:11:21 Running command "helm registry install quay.io/giantswarm/cluster-operator-chart@1.0.0-${CIRCLE_SHA1} -- -n default-cluster-operator --namespace default --values /tmp/cluster-operator-values111460699 --set namespace=default"
usage: appr [-h]
            {pull,run-server,show,inspect,list,delete-package,helm,version,logout,deploy,plugins,push,login,config,channel,jsonnet}
            ...
appr: error: 
message: 'Error: render error in "cluster-operator-chart/templates/configmap.yaml": template: cluster-operator-chart/templates/configmap.yaml:17:29: executing "cluster-operator-chart/templates/configmap.yaml" at <.Values.Installation...>: can''t evaluate field Subnet in type interface {}
```