### PR TITLE
Add provider param to configmap

### DIFF
--- a/pkg/v7/configmap/configmap.go
+++ b/pkg/v7/configmap/configmap.go
@@ -3,6 +3,7 @@ package configmap
 import (
 	"reflect"
 
+	"github.com/giantswarm/cluster-operator/pkg/label"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/tenantcluster"
@@ -18,6 +19,7 @@ type Config struct {
 	CalicoPrefixLength string
 	ClusterIPRange     string
 	ProjectName        string
+	Provider           string
 	RegistryDomain     string
 }
 
@@ -30,6 +32,7 @@ type Service struct {
 	calicoPrefixLength string
 	clusterIPRange     string
 	projectName        string
+	provider           string
 	registryDomain     string
 }
 
@@ -42,12 +45,29 @@ func New(config Config) (*Service, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Tenant must not be empty", config)
 	}
 
+	// Azure manages Calico CIDR blocks differently, and the installations
+	// settings can be empty.
+	if config.Provider != label.ProviderAzure {
+		if config.CalicoAddress == "" {
+			return nil, microerror.Maskf(invalidConfigError, "%T.CalicoAddress must not be empty", config)
+		}
+		if config.CalicoPrefixLength == "" {
+			return nil, microerror.Maskf(invalidConfigError, "%T.CalicoPrefixLength must not be empty", config)
+		}
+	}
+
 	if config.ClusterIPRange == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ClusterIPRange must not be empty", config)
 	}
+
 	if config.ProjectName == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ProjectName must not be empty", config)
 	}
+
+	if config.Provider == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Provider must not be empty", config)
+	}
+
 	if config.RegistryDomain == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.RegistryDomain must not be empty", config)
 	}
@@ -60,6 +80,7 @@ func New(config Config) (*Service, error) {
 		calicoPrefixLength: config.CalicoPrefixLength,
 		clusterIPRange:     config.ClusterIPRange,
 		projectName:        config.ProjectName,
+		provider:           config.Provider,
 		registryDomain:     config.RegistryDomain,
 	}
 

--- a/pkg/v7/configmap/configmap.go
+++ b/pkg/v7/configmap/configmap.go
@@ -3,11 +3,12 @@ package configmap
 import (
 	"reflect"
 
-	"github.com/giantswarm/cluster-operator/pkg/label"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/tenantcluster"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/giantswarm/cluster-operator/pkg/label"
 )
 
 // Config represents the configuration used to create a new configmap service.

--- a/pkg/v7/configmap/create_test.go
+++ b/pkg/v7/configmap/create_test.go
@@ -162,6 +162,7 @@ func Test_ConfigMap_newCreateChange(t *testing.T) {
 		CalicoPrefixLength: "16",
 		ClusterIPRange:     "172.31.0.0/16",
 		ProjectName:        "cluster-operator",
+		Provider:           "aws",
 		RegistryDomain:     "quay.io",
 	}
 	newService, err := New(c)

--- a/pkg/v7/configmap/current_test.go
+++ b/pkg/v7/configmap/current_test.go
@@ -416,6 +416,7 @@ func Test_ConfigMap_GetCurrentState(t *testing.T) {
 				CalicoPrefixLength: "16",
 				ClusterIPRange:     "172.31.0.0/16",
 				ProjectName:        "cluster-operator",
+				Provider:           "aws",
 				RegistryDomain:     "quay.io",
 			}
 			newService, err := New(c)

--- a/pkg/v7/configmap/delete_test.go
+++ b/pkg/v7/configmap/delete_test.go
@@ -226,6 +226,7 @@ func Test_ConfigMap_newDeleteChangeForDeletePatch(t *testing.T) {
 		CalicoPrefixLength: "16",
 		ClusterIPRange:     "172.31.0.0/16",
 		ProjectName:        "cluster-operator",
+		Provider:           "aws",
 		RegistryDomain:     "quay.io",
 	}
 	newService, err := New(c)

--- a/pkg/v7/configmap/desired_test.go
+++ b/pkg/v7/configmap/desired_test.go
@@ -608,6 +608,7 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 				CalicoPrefixLength: "16",
 				ClusterIPRange:     "172.31.0.0/16",
 				ProjectName:        "cluster-operator",
+				Provider:           "aws",
 				RegistryDomain:     "quay.io",
 			}
 			newService, err := New(c)

--- a/pkg/v7/configmap/update_test.go
+++ b/pkg/v7/configmap/update_test.go
@@ -242,6 +242,7 @@ func Test_ConfigMap_newUpdateChange(t *testing.T) {
 		CalicoPrefixLength: "16",
 		ClusterIPRange:     "172.31.0.0/16",
 		ProjectName:        "cluster-operator",
+		Provider:           "aws",
 		RegistryDomain:     "quay.io",
 	}
 	newService, err := New(c)

--- a/service/controller/aws/v7/resource_set.go
+++ b/service/controller/aws/v7/resource_set.go
@@ -201,6 +201,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			CalicoPrefixLength: config.CalicoPrefixLength,
 			ClusterIPRange:     config.ClusterIPRange,
 			ProjectName:        config.ProjectName,
+			Provider:           label.ProviderAWS,
 			RegistryDomain:     config.RegistryDomain,
 		}
 

--- a/service/controller/azure/v7/resource_set.go
+++ b/service/controller/azure/v7/resource_set.go
@@ -202,6 +202,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			CalicoPrefixLength: config.CalicoPrefixLength,
 			ClusterIPRange:     config.ClusterIPRange,
 			ProjectName:        config.ProjectName,
+			Provider:           label.ProviderAzure,
 			RegistryDomain:     config.RegistryDomain,
 		}
 

--- a/service/controller/kvm/v7/resource_set.go
+++ b/service/controller/kvm/v7/resource_set.go
@@ -201,6 +201,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			CalicoPrefixLength: config.CalicoPrefixLength,
 			ClusterIPRange:     config.ClusterIPRange,
 			ProjectName:        config.ProjectName,
+			Provider:           label.ProviderKVM,
 			RegistryDomain:     config.RegistryDomain,
 		}
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1902

Adds a `provider` field to the configmap resource, this will allow us to set different configuration to coredns depending on the provider (next PR). Full discussion here https://gigantic.slack.com/archives/C2MS2VB37/p1537337880000100