### PR TITLE
Take into account empty address and prefix on CIDRBlock

### DIFF
--- a/pkg/v7/key/key.go
+++ b/pkg/v7/key/key.go
@@ -41,6 +41,9 @@ func CertConfigVersionBundleVersion(customObject v1alpha1.CertConfig) string {
 
 // CIDRBlock returns a CIDR block for the given address and prefix.
 func CIDRBlock(address, prefix string) string {
+	if address == "" && prefix == "" {
+		return ""
+	}
 	return fmt.Sprintf("%s/%s", address, prefix)
 }
 

--- a/pkg/v7/key/key_test.go
+++ b/pkg/v7/key/key_test.go
@@ -152,6 +152,12 @@ func Test_CIDRBlock(t *testing.T) {
 			prefix:            "32",
 			expectedCIDRBlock: "127.0.0.0/32",
 		},
+		{
+			description:       "empty address and prefix",
+			address:           "",
+			prefix:            "",
+			expectedCIDRBlock: "",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1902

Do not try to generate a CIDR block when network address and prefix length are empty (which happens on Azure, see https://gigantic.slack.com/archives/C2MS2VB37/p1537337880000100).