### PR TITLE
Revert "Add provider param to configmap"

### DIFF
--- a/pkg/v7/configmap/configmap.go
+++ b/pkg/v7/configmap/configmap.go
@@ -7,8 +7,6 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/tenantcluster"
 	corev1 "k8s.io/api/core/v1"
-
-	"github.com/giantswarm/cluster-operator/pkg/label"
 )
 
 // Config represents the configuration used to create a new configmap service.
@@ -20,7 +18,6 @@ type Config struct {
 	CalicoPrefixLength string
 	ClusterIPRange     string
 	ProjectName        string
-	Provider           string
 	RegistryDomain     string
 }
 
@@ -33,7 +30,6 @@ type Service struct {
 	calicoPrefixLength string
 	clusterIPRange     string
 	projectName        string
-	provider           string
 	registryDomain     string
 }
 
@@ -46,29 +42,12 @@ func New(config Config) (*Service, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Tenant must not be empty", config)
 	}
 
-	// Azure manages Calico CIDR blocks differently, and the installations
-	// settings can be empty.
-	if config.Provider != label.ProviderAzure {
-		if config.CalicoAddress == "" {
-			return nil, microerror.Maskf(invalidConfigError, "%T.CalicoAddress must not be empty", config)
-		}
-		if config.CalicoPrefixLength == "" {
-			return nil, microerror.Maskf(invalidConfigError, "%T.CalicoPrefixLength must not be empty", config)
-		}
-	}
-
 	if config.ClusterIPRange == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ClusterIPRange must not be empty", config)
 	}
-
 	if config.ProjectName == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ProjectName must not be empty", config)
 	}
-
-	if config.Provider == "" {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Provider must not be empty", config)
-	}
-
 	if config.RegistryDomain == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.RegistryDomain must not be empty", config)
 	}
@@ -81,7 +60,6 @@ func New(config Config) (*Service, error) {
 		calicoPrefixLength: config.CalicoPrefixLength,
 		clusterIPRange:     config.ClusterIPRange,
 		projectName:        config.ProjectName,
-		provider:           config.Provider,
 		registryDomain:     config.RegistryDomain,
 	}
 

--- a/pkg/v7/configmap/create_test.go
+++ b/pkg/v7/configmap/create_test.go
@@ -162,7 +162,6 @@ func Test_ConfigMap_newCreateChange(t *testing.T) {
 		CalicoPrefixLength: "16",
 		ClusterIPRange:     "172.31.0.0/16",
 		ProjectName:        "cluster-operator",
-		Provider:           "aws",
 		RegistryDomain:     "quay.io",
 	}
 	newService, err := New(c)

--- a/pkg/v7/configmap/current_test.go
+++ b/pkg/v7/configmap/current_test.go
@@ -416,7 +416,6 @@ func Test_ConfigMap_GetCurrentState(t *testing.T) {
 				CalicoPrefixLength: "16",
 				ClusterIPRange:     "172.31.0.0/16",
 				ProjectName:        "cluster-operator",
-				Provider:           "aws",
 				RegistryDomain:     "quay.io",
 			}
 			newService, err := New(c)

--- a/pkg/v7/configmap/delete_test.go
+++ b/pkg/v7/configmap/delete_test.go
@@ -226,7 +226,6 @@ func Test_ConfigMap_newDeleteChangeForDeletePatch(t *testing.T) {
 		CalicoPrefixLength: "16",
 		ClusterIPRange:     "172.31.0.0/16",
 		ProjectName:        "cluster-operator",
-		Provider:           "aws",
 		RegistryDomain:     "quay.io",
 	}
 	newService, err := New(c)

--- a/pkg/v7/configmap/desired_test.go
+++ b/pkg/v7/configmap/desired_test.go
@@ -608,7 +608,6 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 				CalicoPrefixLength: "16",
 				ClusterIPRange:     "172.31.0.0/16",
 				ProjectName:        "cluster-operator",
-				Provider:           "aws",
 				RegistryDomain:     "quay.io",
 			}
 			newService, err := New(c)

--- a/pkg/v7/configmap/update_test.go
+++ b/pkg/v7/configmap/update_test.go
@@ -242,7 +242,6 @@ func Test_ConfigMap_newUpdateChange(t *testing.T) {
 		CalicoPrefixLength: "16",
 		ClusterIPRange:     "172.31.0.0/16",
 		ProjectName:        "cluster-operator",
-		Provider:           "aws",
 		RegistryDomain:     "quay.io",
 	}
 	newService, err := New(c)

--- a/service/controller/aws/v7/resource_set.go
+++ b/service/controller/aws/v7/resource_set.go
@@ -201,7 +201,6 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			CalicoPrefixLength: config.CalicoPrefixLength,
 			ClusterIPRange:     config.ClusterIPRange,
 			ProjectName:        config.ProjectName,
-			Provider:           label.ProviderAWS,
 			RegistryDomain:     config.RegistryDomain,
 		}
 

--- a/service/controller/azure/v7/resource_set.go
+++ b/service/controller/azure/v7/resource_set.go
@@ -202,7 +202,6 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			CalicoPrefixLength: config.CalicoPrefixLength,
 			ClusterIPRange:     config.ClusterIPRange,
 			ProjectName:        config.ProjectName,
-			Provider:           label.ProviderAzure,
 			RegistryDomain:     config.RegistryDomain,
 		}
 

--- a/service/controller/kvm/v7/resource_set.go
+++ b/service/controller/kvm/v7/resource_set.go
@@ -201,7 +201,6 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			CalicoPrefixLength: config.CalicoPrefixLength,
 			ClusterIPRange:     config.ClusterIPRange,
 			ProjectName:        config.ProjectName,
-			Provider:           label.ProviderKVM,
 			RegistryDomain:     config.RegistryDomain,
 		}
 


### PR DESCRIPTION
Reverts giantswarm/cluster-operator#255

Besides the problems raised by @xh3b4sd there are another issues with the aws and kvm code paths that are actually executed on azure, reverting the changes now.