### PR TITLE
Add chartconfig service and key helpers

### DIFF
--- a/pkg/v7/chartconfig/chartconfig.go
+++ b/pkg/v7/chartconfig/chartconfig.go
@@ -1,0 +1,69 @@
+package chartconfig
+
+import (
+	"context"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/tenantcluster"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Config represents the configuration used to create a new chartconfig service.
+type Config struct {
+	Logger micrologger.Logger
+	Tenant tenantcluster.Interface
+
+	ProjectName string
+}
+
+// Service provides shared functionality for managing chartconfigs.
+type Service struct {
+	logger micrologger.Logger
+	tenant tenantcluster.Interface
+
+	projectName string
+}
+
+// New creates a new chartconfig service.
+func New(config Config) (*Service, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Tenant == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Guest must not be empty", config)
+	}
+
+	if config.ProjectName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ProjectName must not be empty", config)
+	}
+
+	s := &Service{
+		logger: config.Logger,
+		tenant: config.Tenant,
+
+		projectName: config.ProjectName,
+	}
+
+	return s, nil
+}
+
+func getChartConfigByName(list []*v1alpha1.ChartConfig, name string) (*v1alpha1.ChartConfig, error) {
+	for _, l := range list {
+		if l.Name == name {
+			return l, nil
+		}
+	}
+
+	return nil, microerror.Mask(notFoundError)
+}
+
+func (s *Service) getTenantK8sClient(ctx context.Context, clusterConfig ClusterConfig) (kubernetes.Interface, error) {
+	tenantK8sClient, err := s.tenant.NewK8sClient(ctx, clusterConfig.ClusterID, clusterConfig.APIDomain)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return tenantK8sClient, nil
+}

--- a/pkg/v7/chartconfig/error.go
+++ b/pkg/v7/chartconfig/error.go
@@ -1,0 +1,23 @@
+package chartconfig
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}

--- a/pkg/v7/chartconfig/spec.go
+++ b/pkg/v7/chartconfig/spec.go
@@ -1,0 +1,21 @@
+package chartconfig
+
+import (
+	"context"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+
+	"github.com/giantswarm/cluster-operator/pkg/v7/key"
+)
+
+type Interface interface {
+	GetDesiredState(ctx context.Context, clusterConfig ClusterConfig, providerChartSpecs []key.ChartSpec) ([]*v1alpha1.ChartConfig, error)
+}
+
+// ClusterConfig is used by the chartconfig service to provide config to
+// connect to the tenant cluster.
+type ClusterConfig struct {
+	APIDomain    string
+	ClusterID    string
+	Organization string
+}

--- a/pkg/v7/key/key.go
+++ b/pkg/v7/key/key.go
@@ -9,7 +9,7 @@ import (
 	"github.com/giantswarm/certs"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/versionbundle"
-	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -54,6 +54,62 @@ func ClusterOrganization(clusterGuestConfig v1alpha1.ClusterGuestConfig) string 
 	return clusterGuestConfig.Owner
 }
 
+// CommonChartSpecs returns charts installed for all providers.
+// Note: When adding chart specs you also need to add the chart name to the
+// desired state test in the chartconfig service.
+func CommonChartSpecs() []ChartSpec {
+	return []ChartSpec{
+		{
+			AppName:       "cert-exporter",
+			ChannelName:   "stable",
+			ChartName:     "cert-exporter-chart",
+			ConfigMapName: "cert-exporter-values",
+			Namespace:     metav1.NamespaceSystem,
+			ReleaseName:   "cert-exporter",
+		},
+		{
+			AppName:       "coredns",
+			ChannelName:   "0-1-stable",
+			ChartName:     "kubernetes-coredns-chart",
+			ConfigMapName: "coredns-values",
+			Namespace:     metav1.NamespaceSystem,
+			ReleaseName:   "coredns",
+		},
+		{
+			AppName:       "kube-state-metrics",
+			ChannelName:   "0-1-stable",
+			ChartName:     "kubernetes-kube-state-metrics-chart",
+			ConfigMapName: "kube-state-metrics-values",
+			Namespace:     metav1.NamespaceSystem,
+			ReleaseName:   "kube-state-metrics",
+		},
+		{
+			AppName:       "net-exporter",
+			ChannelName:   "stable",
+			ChartName:     "net-exporter-chart",
+			ConfigMapName: "net-exporter-values",
+			Namespace:     metav1.NamespaceSystem,
+			ReleaseName:   "net-exporter",
+		},
+		{
+			AppName:       "nginx-ingress-controller",
+			ChannelName:   "0-2-stable",
+			ChartName:     "kubernetes-nginx-ingress-controller-chart",
+			ConfigMapName: "nginx-ingress-controller-values",
+			Namespace:     metav1.NamespaceSystem,
+			ReleaseName:   "nginx-ingress-controller",
+		},
+		{
+			AppName:       "node-exporter",
+			ChannelName:   "0-1-stable",
+			ChartName:     "kubernetes-node-exporter-chart",
+			ConfigMapName: "node-exporter-values",
+			Namespace:     metav1.NamespaceSystem,
+			ReleaseName:   "node-exporter",
+		},
+	}
+}
+
 // DNSIP returns the IP of the DNS service given a cluster IP range.
 func DNSIP(clusterIPRange string) (string, error) {
 	ip, _, err := net.ParseCIDR(clusterIPRange)
@@ -90,7 +146,7 @@ func EncryptionKeySecretName(clusterGuestConfig v1alpha1.ClusterGuestConfig) str
 
 // IsDeleted returns true if the Kubernetes resource has been marked for
 // deletion.
-func IsDeleted(objectMeta apismetav1.ObjectMeta) bool {
+func IsDeleted(objectMeta metav1.ObjectMeta) bool {
 	return objectMeta.DeletionTimestamp != nil
 }
 

--- a/pkg/v7/key/spec.go
+++ b/pkg/v7/key/spec.go
@@ -1,0 +1,11 @@
+package key
+
+// ChartSpec is used to define chartconfig custom resources.
+type ChartSpec struct {
+	AppName       string
+	ChannelName   string
+	ChartName     string
+	ConfigMapName string
+	Namespace     string
+	ReleaseName   string
+}

--- a/service/controller/aws/v7/key/key.go
+++ b/service/controller/aws/v7/key/key.go
@@ -3,7 +3,15 @@ package key
 import (
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/cluster-operator/pkg/v7/key"
 )
+
+// ChartSpecs returns charts installed only for AWS.
+func ChartSpecs() []key.ChartSpec {
+	// Add any provider specific charts here.
+	return []key.ChartSpec{}
+}
 
 // ClusterGuestConfig extracts ClusterGuestConfig from AWSClusterConfig.
 func ClusterGuestConfig(awsClusterConfig v1alpha1.AWSClusterConfig) v1alpha1.ClusterGuestConfig {

--- a/service/controller/aws/v7/resource/chartconfig/error.go
+++ b/service/controller/aws/v7/resource/chartconfig/error.go
@@ -1,0 +1,12 @@
+package chartconfig
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/aws/v7/resource/chartconfig/resource.go
+++ b/service/controller/aws/v7/resource/chartconfig/resource.go
@@ -1,0 +1,58 @@
+package chartconfig
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/cluster-operator/pkg/v7/chartconfig"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "chartconfigv7"
+)
+
+// Config represents the configuration used to create a new chartconfig resource.
+type Config struct {
+	ChartConfig chartconfig.Interface
+	Logger      micrologger.Logger
+
+	ProjectName string
+}
+
+// Resource implements the chart config resource.
+type Resource struct {
+	chartConfig chartconfig.Interface
+	logger      micrologger.Logger
+
+	projectName string
+}
+
+// New creates a new configured chartconfig resource.
+func New(config Config) (*Resource, error) {
+	if config.ChartConfig == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ChartConfig must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	if config.ProjectName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ProjectName must not be empty", config)
+	}
+
+	r := &Resource{
+		chartConfig: config.ChartConfig,
+		k8sClient:   config.K8sClient,
+		logger:      config.Logger,
+
+		projectName: config.ProjectName,
+	}
+
+	return r, nil
+}
+
+// Name returns name of the Resource.
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/aws/v7/resource/chartconfig/resource.go
+++ b/service/controller/aws/v7/resource/chartconfig/resource.go
@@ -43,7 +43,6 @@ func New(config Config) (*Resource, error) {
 
 	r := &Resource{
 		chartConfig: config.ChartConfig,
-		k8sClient:   config.K8sClient,
 		logger:      config.Logger,
 
 		projectName: config.ProjectName,

--- a/service/controller/azure/v7/key/key.go
+++ b/service/controller/azure/v7/key/key.go
@@ -3,7 +3,22 @@ package key
 import (
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/cluster-operator/pkg/v7/key"
 )
+
+// ChartSpecs returns charts installed only for Azure.
+func ChartSpecs() []key.ChartSpec {
+	return []key.ChartSpec{
+		{
+			AppName:     "external-dns",
+			ChannelName: "0-1-stable",
+			ChartName:   "kubernetes-external-dns-chart",
+			Namespace:   metav1.NamespaceSystem,
+			ReleaseName: "external-dns",
+		},
+	}
+}
 
 // ClusterGuestConfig extracts ClusterGuestConfig from AzureClusterConfig.
 func ClusterGuestConfig(azureClusterConfig v1alpha1.AzureClusterConfig) v1alpha1.ClusterGuestConfig {

--- a/service/controller/azure/v7/key/key.go
+++ b/service/controller/azure/v7/key/key.go
@@ -3,6 +3,7 @@ package key
 import (
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/microerror"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/cluster-operator/pkg/v7/key"
 )

--- a/service/controller/azure/v7/resource/chartconfig/error.go
+++ b/service/controller/azure/v7/resource/chartconfig/error.go
@@ -1,0 +1,12 @@
+package chartconfig
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/azure/v7/resource/chartconfig/resource.go
+++ b/service/controller/azure/v7/resource/chartconfig/resource.go
@@ -1,0 +1,57 @@
+package chartconfig
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/cluster-operator/pkg/v7/chartconfig"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "chartconfigv7"
+)
+
+// Config represents the configuration used to create a new chartconfig resource.
+type Config struct {
+	ChartConfig chartconfig.Interface
+	Logger      micrologger.Logger
+
+	ProjectName string
+}
+
+// Resource implements the chart config resource.
+type Resource struct {
+	chartConfig chartconfig.Interface
+	logger      micrologger.Logger
+
+	projectName string
+}
+
+// New creates a new configured chartconfig resource.
+func New(config Config) (*Resource, error) {
+	if config.ChartConfig == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ChartConfig must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	if config.ProjectName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ProjectName must not be empty", config)
+	}
+
+	r := &Resource{
+		chartConfig: config.ChartConfig,
+		logger:      config.Logger,
+
+		projectName: config.ProjectName,
+	}
+
+	return r, nil
+}
+
+// Name returns name of the Resource.
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/kvm/v7/key/key.go
+++ b/service/controller/kvm/v7/key/key.go
@@ -3,7 +3,15 @@ package key
 import (
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/cluster-operator/pkg/v7/key"
 )
+
+// ChartSpecs returns charts installed only for KVM.
+func ChartSpecs() []key.ChartSpec {
+	// Add any provider specific charts here.
+	return []key.ChartSpec{}
+}
 
 // ClusterGuestConfig extracts ClusterGuestConfig from KVMClusterConfig.
 func ClusterGuestConfig(kvmClusterConfig v1alpha1.KVMClusterConfig) v1alpha1.ClusterGuestConfig {

--- a/service/controller/kvm/v7/resource/chartconfig/error.go
+++ b/service/controller/kvm/v7/resource/chartconfig/error.go
@@ -1,0 +1,12 @@
+package chartconfig
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/kvm/v7/resource/chartconfig/resource.go
+++ b/service/controller/kvm/v7/resource/chartconfig/resource.go
@@ -1,0 +1,57 @@
+package chartconfig
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/cluster-operator/pkg/v7/chartconfig"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "chartconfigv7"
+)
+
+// Config represents the configuration used to create a new chartconfig resource.
+type Config struct {
+	ChartConfig chartconfig.Interface
+	Logger      micrologger.Logger
+
+	ProjectName string
+}
+
+// Resource implements the chart config resource.
+type Resource struct {
+	chartConfig chartconfig.Interface
+	logger      micrologger.Logger
+
+	projectName string
+}
+
+// New creates a new configured chartconfig resource.
+func New(config Config) (*Resource, error) {
+	if config.ChartConfig == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ChartConfig must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	if config.ProjectName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ProjectName must not be empty", config)
+	}
+
+	r := &Resource{
+		chartConfig: config.ChartConfig,
+		logger:      config.Logger,
+
+		projectName: config.ProjectName,
+	}
+
+	return r, nil
+}
+
+// Name returns name of the Resource.
+func (r *Resource) Name() string {
+	return Name
+}


### PR DESCRIPTION
Towards giantswarm/giantswarm#4040

- Adds the chartconfig service and resources structure as well as the key helpers with the desired state.
- Idea is editing the key helpers is easier than the current approach. Where each CR is defined in a Go function.
- Later when we add the service catalog config management it can replace the key functions.
