### PR TITLE
Disable coredns components

### DIFF
--- a/pkg/v7/configmap/desired.go
+++ b/pkg/v7/configmap/desired.go
@@ -99,7 +99,7 @@ func (s *Service) GetDesiredState(ctx context.Context, configMapConfig ConfigMap
 	desiredConfigMaps = append(desiredConfigMaps, configMap)
 	generators := []configMapGenerator{
 		s.newCertExporterConfigMap,
-		s.newCoreDNSConfigMap,
+		// s.newCoreDNSConfigMap,
 		s.newKubeStateMetricsConfigMap,
 		s.newNetExporterConfigMap,
 		s.newNodeExporterConfigMap,

--- a/pkg/v7/configmap/desired_test.go
+++ b/pkg/v7/configmap/desired_test.go
@@ -166,22 +166,24 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 						"values.json": "{\"namespace\":\"kube-system\"}",
 					},
 				},
-				&corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "coredns-values",
-						Namespace: metav1.NamespaceSystem,
-						Labels: map[string]string{
-							label.App:          "coredns",
-							label.Cluster:      "5xchu",
-							label.ManagedBy:    "cluster-operator",
-							label.Organization: "giantswarm",
-							label.ServiceType:  "managed",
+				/*
+					&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "coredns-values",
+							Namespace: metav1.NamespaceSystem,
+							Labels: map[string]string{
+								label.App:          "coredns",
+								label.Cluster:      "5xchu",
+								label.ManagedBy:    "cluster-operator",
+								label.Organization: "giantswarm",
+								label.ServiceType:  "managed",
+							},
+						},
+						Data: map[string]string{
+							"values.json": coreDNSJSON,
 						},
 					},
-					Data: map[string]string{
-						"values.json": coreDNSJSON,
-					},
-				},
+				*/
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "nginx-ingress-controller-values",
@@ -280,22 +282,24 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 						"values.json": "{\"namespace\":\"kube-system\"}",
 					},
 				},
-				&corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "coredns-values",
-						Namespace: metav1.NamespaceSystem,
-						Labels: map[string]string{
-							label.App:          "coredns",
-							label.Cluster:      "5xchu",
-							label.ManagedBy:    "cluster-operator",
-							label.Organization: "giantswarm",
-							label.ServiceType:  "managed",
+				/*
+					&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "coredns-values",
+							Namespace: metav1.NamespaceSystem,
+							Labels: map[string]string{
+								label.App:          "coredns",
+								label.Cluster:      "5xchu",
+								label.ManagedBy:    "cluster-operator",
+								label.Organization: "giantswarm",
+								label.ServiceType:  "managed",
+							},
+						},
+						Data: map[string]string{
+							"values.json": coreDNSJSON,
 						},
 					},
-					Data: map[string]string{
-						"values.json": coreDNSJSON,
-					},
-				},
+				*/
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "nginx-ingress-controller-values",
@@ -394,22 +398,24 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 						"values.json": "{\"namespace\":\"kube-system\"}",
 					},
 				},
-				&corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "coredns-values",
-						Namespace: metav1.NamespaceSystem,
-						Labels: map[string]string{
-							label.App:          "coredns",
-							label.Cluster:      "5xchu",
-							label.ManagedBy:    "cluster-operator",
-							label.Organization: "giantswarm",
-							label.ServiceType:  "managed",
+				/*
+					&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "coredns-values",
+							Namespace: metav1.NamespaceSystem,
+							Labels: map[string]string{
+								label.App:          "coredns",
+								label.Cluster:      "5xchu",
+								label.ManagedBy:    "cluster-operator",
+								label.Organization: "giantswarm",
+								label.ServiceType:  "managed",
+							},
+						},
+						Data: map[string]string{
+							"values.json": coreDNSJSON,
 						},
 					},
-					Data: map[string]string{
-						"values.json": coreDNSJSON,
-					},
-				},
+				*/
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "nginx-ingress-controller-values",
@@ -507,22 +513,24 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 						"values.json": "{\"namespace\":\"kube-system\"}",
 					},
 				},
-				&corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "coredns-values",
-						Namespace: metav1.NamespaceSystem,
-						Labels: map[string]string{
-							label.App:          "coredns",
-							label.Cluster:      "5xchu",
-							label.ManagedBy:    "cluster-operator",
-							label.Organization: "giantswarm",
-							label.ServiceType:  "managed",
+				/*
+					&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "coredns-values",
+							Namespace: metav1.NamespaceSystem,
+							Labels: map[string]string{
+								label.App:          "coredns",
+								label.Cluster:      "5xchu",
+								label.ManagedBy:    "cluster-operator",
+								label.Organization: "giantswarm",
+								label.ServiceType:  "managed",
+							},
+						},
+						Data: map[string]string{
+							"values.json": coreDNSJSON,
 						},
 					},
-					Data: map[string]string{
-						"values.json": coreDNSJSON,
-					},
-				},
+				*/
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "nginx-ingress-controller-values",

--- a/pkg/v7/resource/chartconfig/desired.go
+++ b/pkg/v7/resource/chartconfig/desired.go
@@ -36,7 +36,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	desiredChartConfigs := make([]*v1alpha1.ChartConfig, 0)
 	generators := []chartConfigGenerator{
 		r.newCertExporterChartConfig,
-		r.newCoreDNSChartConfig,
+		// r.newCoreDNSChartConfig,
 		r.newIngressControllerChartConfig,
 		r.newKubeStateMetricsChartConfig,
 		r.newNetExporterChartConfig,

--- a/pkg/v7/resource/chartconfig/desired_test.go
+++ b/pkg/v7/resource/chartconfig/desired_test.go
@@ -34,7 +34,7 @@ func Test_ChartConfig_GetDesiredState(t *testing.T) {
 			provider: label.ProviderAWS,
 			expectedChartConfigNames: []string{
 				"cert-exporter-chart",
-				"kubernetes-coredns-chart",
+				// "kubernetes-coredns-chart",
 				"kubernetes-kube-state-metrics-chart",
 				"kubernetes-nginx-ingress-controller-chart",
 				"kubernetes-node-exporter-chart",
@@ -51,7 +51,7 @@ func Test_ChartConfig_GetDesiredState(t *testing.T) {
 			provider: label.ProviderKVM,
 			expectedChartConfigNames: []string{
 				"cert-exporter-chart",
-				"kubernetes-coredns-chart",
+				// "kubernetes-coredns-chart",
 				"kubernetes-kube-state-metrics-chart",
 				"kubernetes-nginx-ingress-controller-chart",
 				"kubernetes-node-exporter-chart",
@@ -68,7 +68,7 @@ func Test_ChartConfig_GetDesiredState(t *testing.T) {
 			provider: label.ProviderAzure,
 			expectedChartConfigNames: []string{
 				"cert-exporter-chart",
-				"kubernetes-coredns-chart",
+				// "kubernetes-coredns-chart",
 				"kubernetes-external-dns-chart",
 				"kubernetes-kube-state-metrics-chart",
 				"kubernetes-nginx-ingress-controller-chart",


### PR DESCRIPTION
We are having issues on WIP with DNS after the coredns managed component has been added, disabling it while determining the root cause.