### PR TITLE
Implement create and update support for chartconfig service

### DIFF
--- a/pkg/v7/chartconfig/chartconfig.go
+++ b/pkg/v7/chartconfig/chartconfig.go
@@ -2,12 +2,19 @@ package chartconfig
 
 import (
 	"context"
+	"reflect"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/tenantcluster"
 	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// resourceNamespace is the namespace where the chartconfig CRs are created.
+	resourceNamespace = "giantswarm"
 )
 
 // Config represents the configuration used to create a new chartconfig service.
@@ -49,6 +56,15 @@ func New(config Config) (*ChartConfig, error) {
 	return s, nil
 }
 
+func (c *ChartConfig) newTenantG8sClient(ctx context.Context, clusterConfig ClusterConfig) (versioned.Interface, error) {
+	tenantG8sClient, err := c.tenant.NewG8sClient(ctx, clusterConfig.ClusterID, clusterConfig.APIDomain)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return tenantG8sClient, nil
+}
+
 func (c *ChartConfig) newTenantK8sClient(ctx context.Context, clusterConfig ClusterConfig) (kubernetes.Interface, error) {
 	tenantK8sClient, err := c.tenant.NewK8sClient(ctx, clusterConfig.ClusterID, clusterConfig.APIDomain)
 	if err != nil {
@@ -56,6 +72,16 @@ func (c *ChartConfig) newTenantK8sClient(ctx context.Context, clusterConfig Clus
 	}
 
 	return tenantK8sClient, nil
+}
+
+func containsChartConfig(list []*v1alpha1.ChartConfig, item *v1alpha1.ChartConfig) bool {
+	for _, l := range list {
+		if reflect.DeepEqual(item, l) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func getChartConfigByName(list []*v1alpha1.ChartConfig, name string) (*v1alpha1.ChartConfig, error) {
@@ -66,4 +92,17 @@ func getChartConfigByName(list []*v1alpha1.ChartConfig, name string) (*v1alpha1.
 	}
 
 	return nil, microerror.Mask(notFoundError)
+}
+
+func isChartConfigModified(a, b *v1alpha1.ChartConfig) bool {
+	// If the Spec section has changed we need to update.
+	if !reflect.DeepEqual(a.Spec, b.Spec) {
+		return true
+	}
+	// If the Labels have changed we also need to update.
+	if !reflect.DeepEqual(a.Labels, b.Labels) {
+		return true
+	}
+
+	return false
 }

--- a/pkg/v7/chartconfig/create.go
+++ b/pkg/v7/chartconfig/create.go
@@ -1,0 +1,57 @@
+package chartconfig
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/microerror"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func (c *ChartConfig) ApplyCreateChange(ctx context.Context, clusterConfig ClusterConfig, chartConfigsToCreate []*v1alpha1.ChartConfig) error {
+	if len(chartConfigsToCreate) > 0 {
+		c.logger.LogCtx(ctx, "level", "debug", "message", "creating chartconfigs")
+
+		tenantG8sClient, err := c.newTenantG8sClient(ctx, clusterConfig)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		for _, chartConfigToCreate := range chartConfigsToCreate {
+			c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating chartconfig %#q", chartConfigToCreate.Name))
+
+			_, err := tenantG8sClient.CoreV1alpha1().ChartConfigs(resourceNamespace).Create(chartConfigToCreate)
+			if apierrors.IsAlreadyExists(err) {
+				c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not create chartconfig %#q", chartConfigToCreate.Name))
+				c.logger.LogCtx(ctx, "level", "debug", "message", "chartconfig already exists")
+			} else if err != nil {
+				return microerror.Mask(err)
+			}
+
+			c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created chartconfig %#q", chartConfigToCreate.Name))
+		}
+
+		c.logger.LogCtx(ctx, "level", "debug", "message", "created chartconfigs")
+	} else {
+		c.logger.LogCtx(ctx, "level", "debug", "message", "no need to create chartconfigs")
+	}
+
+	return nil
+}
+
+func (c *ChartConfig) newCreateChange(ctx context.Context, currentChartConfigs, desiredChartConfigs []*v1alpha1.ChartConfig) ([]*v1alpha1.ChartConfig, error) {
+	c.logger.LogCtx(ctx, "level", "debug", "message", "finding out which chartconfigs have to be created")
+
+	chartConfigsToCreate := make([]*v1alpha1.ChartConfig, 0)
+
+	for _, desiredChartConfig := range desiredChartConfigs {
+		if !containsChartConfig(currentChartConfigs, desiredChartConfig) {
+			chartConfigsToCreate = append(chartConfigsToCreate, desiredChartConfig)
+		}
+	}
+
+	c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d chartconfigs that have to be created", len(chartConfigsToCreate)))
+
+	return chartConfigsToCreate, nil
+}

--- a/pkg/v7/chartconfig/create_test.go
+++ b/pkg/v7/chartconfig/create_test.go
@@ -1,0 +1,174 @@
+package chartconfig
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+)
+
+func Test_ChartConfig_newCreateChange(t *testing.T) {
+	testCases := []struct {
+		description          string
+		currentChartConfigs  []*v1alpha1.ChartConfig
+		desiredChartConfigs  []*v1alpha1.ChartConfig
+		expectedChartConfigs []*v1alpha1.ChartConfig
+		errorMatcher         func(error) bool
+	}{
+		{
+			description:          "case 0: empty current and desired, expected empty",
+			currentChartConfigs:  []*v1alpha1.ChartConfig{},
+			desiredChartConfigs:  []*v1alpha1.ChartConfig{},
+			expectedChartConfigs: []*v1alpha1.ChartConfig{},
+			errorMatcher:         nil,
+		},
+		{
+			description: "case 1: non-empty current, empty desired, expected empty",
+			currentChartConfigs: []*v1alpha1.ChartConfig{
+				{
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name: "test-chart",
+						},
+					},
+				},
+			},
+			desiredChartConfigs:  []*v1alpha1.ChartConfig{},
+			expectedChartConfigs: []*v1alpha1.ChartConfig{},
+			errorMatcher:         nil,
+		},
+		{
+			description: "case 2: equal non-empty current and desired, expected empty",
+			currentChartConfigs: []*v1alpha1.ChartConfig{
+				{
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name: "test-chart",
+						},
+					},
+				},
+			},
+			desiredChartConfigs: []*v1alpha1.ChartConfig{
+				{
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name: "test-chart",
+						},
+					},
+				},
+			},
+			expectedChartConfigs: []*v1alpha1.ChartConfig{},
+			errorMatcher:         nil,
+		},
+		{
+			description:         "case 3: empty current and non-empty desired, expected desired",
+			currentChartConfigs: []*v1alpha1.ChartConfig{},
+			desiredChartConfigs: []*v1alpha1.ChartConfig{
+				{
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name: "test-chart",
+						},
+					},
+				},
+			},
+			expectedChartConfigs: []*v1alpha1.ChartConfig{
+				{
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name: "test-chart",
+						},
+					},
+				},
+			},
+			errorMatcher: nil,
+		},
+		{
+			description: "case 4: different non-empty current and desired, expected desired",
+			currentChartConfigs: []*v1alpha1.ChartConfig{
+				{
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name: "test-chart-2",
+						},
+					},
+				},
+			},
+			desiredChartConfigs: []*v1alpha1.ChartConfig{
+				{
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name: "test-chart",
+						},
+					},
+				},
+				{
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name: "test-chart-2",
+						},
+					},
+				},
+				{
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name: "test-chart-3",
+						},
+					},
+				},
+			},
+			expectedChartConfigs: []*v1alpha1.ChartConfig{
+				{
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name: "test-chart",
+						},
+					},
+				},
+				{
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name: "test-chart-3",
+						},
+					},
+				},
+			},
+			errorMatcher: nil,
+		},
+	}
+
+	c := Config{
+		Logger: microloggertest.New(),
+		Tenant: &tenantMock{},
+
+		ProjectName: "cluster-operator",
+	}
+	cc, err := New(c)
+	if err != nil {
+		t.Fatal("expected", nil, "got", err)
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := cc.newCreateChange(context.TODO(), tc.currentChartConfigs, tc.desiredChartConfigs)
+
+			if err != nil {
+				switch {
+				case err == nil && tc.errorMatcher == nil: // correct; carry on
+				case err != nil && tc.errorMatcher != nil:
+					if !tc.errorMatcher(err) {
+						t.Fatalf("error == %#v, want matching", err)
+					}
+				case err != nil && tc.errorMatcher == nil:
+					t.Fatalf("error == %#v, want nil", err)
+				case err == nil && tc.errorMatcher != nil:
+					t.Fatalf("error == nil, want non-nil")
+				}
+			} else if !reflect.DeepEqual(result, tc.expectedChartConfigs) {
+				t.Fatalf("expected %#v got %#v", tc.expectedChartConfigs, result)
+			}
+		})
+	}
+}

--- a/pkg/v7/chartconfig/spec.go
+++ b/pkg/v7/chartconfig/spec.go
@@ -4,13 +4,16 @@ import (
 	"context"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/operatorkit/controller"
 
 	"github.com/giantswarm/cluster-operator/pkg/v7/key"
 )
 
 type Interface interface {
 	ApplyCreateChange(ctx context.Context, clusterConfig ClusterConfig, chartConfigsToCreate []*v1alpha1.ChartConfig) error
+	ApplyUpdateChange(ctx context.Context, clusterConfig ClusterConfig, chartConfigsToUpdate []*v1alpha1.ChartConfig) error
 	GetDesiredState(ctx context.Context, clusterConfig ClusterConfig, providerChartSpecs []key.ChartSpec) ([]*v1alpha1.ChartConfig, error)
+	NewUpdatePatch(ctx context.Context, currentState, desiredState []*v1alpha1.ChartConfig) (*controller.Patch, error)
 }
 
 // ClusterConfig is used by the chartconfig service to provide config to

--- a/pkg/v7/chartconfig/spec.go
+++ b/pkg/v7/chartconfig/spec.go
@@ -9,6 +9,7 @@ import (
 )
 
 type Interface interface {
+	ApplyCreateChange(ctx context.Context, clusterConfig ClusterConfig, chartConfigsToCreate []*v1alpha1.ChartConfig) error
 	GetDesiredState(ctx context.Context, clusterConfig ClusterConfig, providerChartSpecs []key.ChartSpec) ([]*v1alpha1.ChartConfig, error)
 }
 

--- a/pkg/v7/chartconfig/update.go
+++ b/pkg/v7/chartconfig/update.go
@@ -1,0 +1,84 @@
+package chartconfig
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+)
+
+func (c *ChartConfig) ApplyUpdateChange(ctx context.Context, clusterConfig ClusterConfig, chartConfigsToUpdate []*v1alpha1.ChartConfig) error {
+	if len(chartConfigsToUpdate) > 0 {
+		c.logger.LogCtx(ctx, "level", "debug", "message", "updating chartconfigs")
+
+		tenantG8sClient, err := c.newTenantG8sClient(ctx, clusterConfig)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		for _, chartConfigToUpdate := range chartConfigsToUpdate {
+			_, err := tenantG8sClient.CoreV1alpha1().ChartConfigs(resourceNamespace).Update(chartConfigToUpdate)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		c.logger.LogCtx(ctx, "level", "debug", "message", "updated chartconfigs")
+	} else {
+		c.logger.LogCtx(ctx, "level", "debug", "message", "no need to update chartconfigs")
+	}
+
+	return nil
+}
+
+func (c *ChartConfig) NewUpdatePatch(ctx context.Context, currentState, desiredState []*v1alpha1.ChartConfig) (*controller.Patch, error) {
+	create, err := c.newCreateChange(ctx, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	update, err := c.newUpdateChange(ctx, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+	// TODO
+	// patch.SetDeleteChange(delete)
+
+	return patch, nil
+}
+
+func (c *ChartConfig) newUpdateChange(ctx context.Context, currentChartConfigs, desiredChartConfigs []*v1alpha1.ChartConfig) ([]*v1alpha1.ChartConfig, error) {
+	c.logger.LogCtx(ctx, "level", "debug", "message", "finding out which chartconfigs have to be updated")
+
+	chartConfigsToUpdate := make([]*v1alpha1.ChartConfig, 0)
+
+	for _, currentChartConfig := range currentChartConfigs {
+		desiredChartConfig, err := getChartConfigByName(desiredChartConfigs, currentChartConfig.Name)
+		if IsNotFound(err) {
+			// Ignore here. These are handled by newDeleteChangeForUpdatePatch().
+			continue
+		} else if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		if isChartConfigModified(desiredChartConfig, currentChartConfig) {
+			// Make a copy and set the resource version so the CR can be updated.
+			chartConfigToUpdate := desiredChartConfig.DeepCopy()
+			chartConfigToUpdate.ObjectMeta.ResourceVersion = currentChartConfig.ObjectMeta.ResourceVersion
+
+			chartConfigsToUpdate = append(chartConfigsToUpdate, chartConfigToUpdate)
+
+			c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found chartconfig '%s' that has to be updated", desiredChartConfig.GetName()))
+		}
+	}
+
+	c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d chartconfigs which have to be updated", len(chartConfigsToUpdate)))
+
+	return chartConfigsToUpdate, nil
+}

--- a/pkg/v7/chartconfig/update_test.go
+++ b/pkg/v7/chartconfig/update_test.go
@@ -1,0 +1,284 @@
+package chartconfig
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_ChartConfig_newUpdateChange(t *testing.T) {
+	testCases := []struct {
+		description          string
+		currentChartConfigs  []*v1alpha1.ChartConfig
+		desiredChartConfigs  []*v1alpha1.ChartConfig
+		expectedChartConfigs []*v1alpha1.ChartConfig
+		errorMatcher         func(error) bool
+	}{
+		{
+			description:          "case 0: empty current and desired, expected empty",
+			currentChartConfigs:  []*v1alpha1.ChartConfig{},
+			desiredChartConfigs:  []*v1alpha1.ChartConfig{},
+			expectedChartConfigs: []*v1alpha1.ChartConfig{},
+			errorMatcher:         nil,
+		},
+		{
+			description: "case 1: non-empty current and empty desired, expected empty",
+			currentChartConfigs: []*v1alpha1.ChartConfig{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-chart",
+					},
+				},
+			},
+			desiredChartConfigs:  []*v1alpha1.ChartConfig{},
+			expectedChartConfigs: []*v1alpha1.ChartConfig{},
+			errorMatcher:         nil,
+		},
+		{
+			description:         "case 2: empty current and noo-empty desired, expected empty",
+			currentChartConfigs: []*v1alpha1.ChartConfig{},
+			desiredChartConfigs: []*v1alpha1.ChartConfig{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-chart",
+					},
+				},
+			},
+			expectedChartConfigs: []*v1alpha1.ChartConfig{},
+			errorMatcher:         nil,
+		},
+		{
+			description: "case 3: equal current and desired, expected empty",
+			currentChartConfigs: []*v1alpha1.ChartConfig{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-chart",
+					},
+				},
+			},
+			desiredChartConfigs: []*v1alpha1.ChartConfig{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-chart",
+					},
+				},
+			},
+			expectedChartConfigs: []*v1alpha1.ChartConfig{},
+			errorMatcher:         nil,
+		},
+		{
+			description: "case 4: unequal spec, expected desired",
+			currentChartConfigs: []*v1alpha1.ChartConfig{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-chart",
+					},
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name:    "test-chart",
+							Channel: "0.1-beta",
+						},
+					},
+				},
+			},
+			desiredChartConfigs: []*v1alpha1.ChartConfig{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-chart",
+					},
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name:    "test-chart",
+							Channel: "0.2-beta",
+						},
+					},
+				},
+			},
+			expectedChartConfigs: []*v1alpha1.ChartConfig{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-chart",
+					},
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name:    "test-chart",
+							Channel: "0.2-beta",
+						},
+					},
+				},
+			},
+			errorMatcher: nil,
+		},
+		{
+			description: "case 5: unequal labels, expected desired",
+			currentChartConfigs: []*v1alpha1.ChartConfig{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-chart",
+						Labels: map[string]string{
+							"cluster": "test-cluster",
+						},
+					},
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name:    "test-chart",
+							Channel: "0.1-beta",
+						},
+					},
+				},
+			},
+			desiredChartConfigs: []*v1alpha1.ChartConfig{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-chart",
+						Labels: map[string]string{
+							"cluster": "test-cluster",
+							"extra":   "label",
+						},
+					},
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name:    "test-chart",
+							Channel: "0.1-beta",
+						},
+					},
+				},
+			},
+			expectedChartConfigs: []*v1alpha1.ChartConfig{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-chart",
+						Labels: map[string]string{
+							"cluster": "test-cluster",
+							"extra":   "label",
+						},
+					},
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name:    "test-chart",
+							Channel: "0.1-beta",
+						},
+					},
+				},
+			},
+			errorMatcher: nil,
+		},
+		{
+			description: "case 6: unequal current and desired, expected changed desired",
+			currentChartConfigs: []*v1alpha1.ChartConfig{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-chart",
+						Labels: map[string]string{
+							"cluster": "test-cluster",
+						},
+					},
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name:    "test-chart",
+							Channel: "0.1-beta",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-chart-2",
+						Labels: map[string]string{
+							"cluster": "test-cluster",
+						},
+					},
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name:    "test-chart",
+							Channel: "0.1-beta",
+						},
+					},
+				},
+			},
+			desiredChartConfigs: []*v1alpha1.ChartConfig{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-chart",
+						Labels: map[string]string{
+							"cluster": "test-cluster",
+						},
+					},
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name:    "test-chart",
+							Channel: "0.1-beta",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-chart-2",
+						Labels: map[string]string{
+							"cluster": "test-cluster",
+						},
+					},
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name:    "test-chart",
+							Channel: "0.2-beta",
+						},
+					},
+				},
+			},
+			expectedChartConfigs: []*v1alpha1.ChartConfig{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-chart-2",
+						Labels: map[string]string{
+							"cluster": "test-cluster",
+						},
+					},
+					Spec: v1alpha1.ChartConfigSpec{
+						Chart: v1alpha1.ChartConfigSpecChart{
+							Name:    "test-chart",
+							Channel: "0.2-beta",
+						},
+					},
+				},
+			},
+			errorMatcher: nil,
+		},
+	}
+
+	c := Config{
+		Logger: microloggertest.New(),
+		Tenant: &tenantMock{},
+
+		ProjectName: "cluster-operator",
+	}
+	cc, err := New(c)
+	if err != nil {
+		t.Fatal("expected", nil, "got", err)
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := cc.newUpdateChange(context.TODO(), tc.currentChartConfigs, tc.desiredChartConfigs)
+
+			if err != nil {
+				switch {
+				case err == nil && tc.errorMatcher == nil: // correct; carry on
+				case err != nil && tc.errorMatcher != nil:
+					if !tc.errorMatcher(err) {
+						t.Fatalf("error == %#v, want matching", err)
+					}
+				case err != nil && tc.errorMatcher == nil:
+					t.Fatalf("error == %#v, want nil", err)
+				case err == nil && tc.errorMatcher != nil:
+					t.Fatalf("error == nil, want non-nil")
+				}
+			} else if !reflect.DeepEqual(result, tc.expectedChartConfigs) {
+				t.Fatalf("expected %#v got %#v", tc.expectedChartConfigs, result)
+			}
+		})
+	}
+}

--- a/service/controller/aws/v7/resource/chartconfig/create.go
+++ b/service/controller/aws/v7/resource/chartconfig/create.go
@@ -1,0 +1,53 @@
+package chartconfig
+
+import (
+	"context"
+
+	"github.com/giantswarm/errors/guest"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+
+	"github.com/giantswarm/cluster-operator/pkg/v7/chartconfig"
+	"github.com/giantswarm/cluster-operator/pkg/v7/key"
+	awskey "github.com/giantswarm/cluster-operator/service/controller/aws/v7/key"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	customObject, err := awskey.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	chartConfigsToCreate, err := toChartConfigs(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	clusterGuestConfig := awskey.ClusterGuestConfig(customObject)
+	apiDomain, err := key.APIDomain(clusterGuestConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	clusterConfig := chartconfig.ClusterConfig{
+		APIDomain:    apiDomain,
+		ClusterID:    key.ClusterID(clusterGuestConfig),
+		Organization: key.ClusterOrganization(clusterGuestConfig),
+	}
+
+	err = r.chartConfig.ApplyCreateChange(ctx, clusterConfig, chartConfigsToCreate)
+	if guest.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
+
+		// We can't continue without a successful K8s connection. Cluster
+		// may not be up yet. We will retry during the next execution.
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/service/controller/aws/v7/resource/chartconfig/error.go
+++ b/service/controller/aws/v7/resource/chartconfig/error.go
@@ -10,3 +10,12 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongType asserts wrongTypeError.
+func IsWrongType(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/aws/v7/resource/chartconfig/resource.go
+++ b/service/controller/aws/v7/resource/chartconfig/resource.go
@@ -1,6 +1,7 @@
 package chartconfig
 
 import (
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 
@@ -54,4 +55,17 @@ func New(config Config) (*Resource, error) {
 // Name returns name of the Resource.
 func (r *Resource) Name() string {
 	return Name
+}
+
+func toChartConfigs(v interface{}) ([]*v1alpha1.ChartConfig, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	chartConfigs, ok := v.([]*v1alpha1.ChartConfig)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", []*v1alpha1.ChartConfig{}, v)
+	}
+
+	return chartConfigs, nil
 }

--- a/service/controller/aws/v7/resource/chartconfig/update.go
+++ b/service/controller/aws/v7/resource/chartconfig/update.go
@@ -1,0 +1,73 @@
+package chartconfig
+
+import (
+	"context"
+
+	"github.com/giantswarm/errors/guest"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+
+	"github.com/giantswarm/cluster-operator/pkg/v7/chartconfig"
+	"github.com/giantswarm/cluster-operator/pkg/v7/key"
+	awskey "github.com/giantswarm/cluster-operator/service/controller/aws/v7/key"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	customObject, err := awskey.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	chartConfigsToUpdate, err := toChartConfigs(updateChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	clusterGuestConfig := awskey.ClusterGuestConfig(customObject)
+	apiDomain, err := key.APIDomain(clusterGuestConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	clusterConfig := chartconfig.ClusterConfig{
+		APIDomain:    apiDomain,
+		ClusterID:    key.ClusterID(clusterGuestConfig),
+		Organization: key.ClusterOrganization(clusterGuestConfig),
+	}
+
+	err = r.chartConfig.ApplyUpdateChange(ctx, clusterConfig, chartConfigsToUpdate)
+	if guest.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
+
+		// We can't continue without a successful K8s connection. Cluster
+		// may not be up yet. We will retry during the next execution.
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	currentChartConfigs, err := toChartConfigs(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	desiredChartConfigs, err := toChartConfigs(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch, err := r.chartConfig.NewUpdatePatch(ctx, currentChartConfigs, desiredChartConfigs)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return patch, nil
+}

--- a/service/controller/azure/v7/resource/chartconfig/create.go
+++ b/service/controller/azure/v7/resource/chartconfig/create.go
@@ -1,0 +1,53 @@
+package chartconfig
+
+import (
+	"context"
+
+	"github.com/giantswarm/errors/guest"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+
+	"github.com/giantswarm/cluster-operator/pkg/v7/chartconfig"
+	"github.com/giantswarm/cluster-operator/pkg/v7/key"
+	azurekey "github.com/giantswarm/cluster-operator/service/controller/azure/v7/key"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	customObject, err := azurekey.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	chartConfigsToCreate, err := toChartConfigs(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	clusterGuestConfig := azurekey.ClusterGuestConfig(customObject)
+	apiDomain, err := key.APIDomain(clusterGuestConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	clusterConfig := chartconfig.ClusterConfig{
+		APIDomain:    apiDomain,
+		ClusterID:    key.ClusterID(clusterGuestConfig),
+		Organization: key.ClusterOrganization(clusterGuestConfig),
+	}
+
+	err = r.chartConfig.ApplyCreateChange(ctx, clusterConfig, chartConfigsToCreate)
+	if guest.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
+
+		// We can't continue without a successful K8s connection. Cluster
+		// may not be up yet. We will retry during the next execution.
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/service/controller/azure/v7/resource/chartconfig/error.go
+++ b/service/controller/azure/v7/resource/chartconfig/error.go
@@ -10,3 +10,12 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongType asserts wrongTypeError.
+func IsWrongType(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/azure/v7/resource/chartconfig/resource.go
+++ b/service/controller/azure/v7/resource/chartconfig/resource.go
@@ -1,6 +1,7 @@
 package chartconfig
 
 import (
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 
@@ -54,4 +55,17 @@ func New(config Config) (*Resource, error) {
 // Name returns name of the Resource.
 func (r *Resource) Name() string {
 	return Name
+}
+
+func toChartConfigs(v interface{}) ([]*v1alpha1.ChartConfig, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	chartConfigs, ok := v.([]*v1alpha1.ChartConfig)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", []*v1alpha1.ChartConfig{}, v)
+	}
+
+	return chartConfigs, nil
 }

--- a/service/controller/azure/v7/resource/chartconfig/update.go
+++ b/service/controller/azure/v7/resource/chartconfig/update.go
@@ -1,0 +1,73 @@
+package chartconfig
+
+import (
+	"context"
+
+	"github.com/giantswarm/errors/guest"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+
+	"github.com/giantswarm/cluster-operator/pkg/v7/chartconfig"
+	"github.com/giantswarm/cluster-operator/pkg/v7/key"
+	azurekey "github.com/giantswarm/cluster-operator/service/controller/azure/v7/key"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	customObject, err := azurekey.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	chartConfigsToUpdate, err := toChartConfigs(updateChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	clusterGuestConfig := azurekey.ClusterGuestConfig(customObject)
+	apiDomain, err := key.APIDomain(clusterGuestConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	clusterConfig := chartconfig.ClusterConfig{
+		APIDomain:    apiDomain,
+		ClusterID:    key.ClusterID(clusterGuestConfig),
+		Organization: key.ClusterOrganization(clusterGuestConfig),
+	}
+
+	err = r.chartConfig.ApplyUpdateChange(ctx, clusterConfig, chartConfigsToUpdate)
+	if guest.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
+
+		// We can't continue without a successful K8s connection. Cluster
+		// may not be up yet. We will retry during the next execution.
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	currentChartConfigs, err := toChartConfigs(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	desiredChartConfigs, err := toChartConfigs(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch, err := r.chartConfig.NewUpdatePatch(ctx, currentChartConfigs, desiredChartConfigs)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return patch, nil
+}

--- a/service/controller/kvm/v7/resource/chartconfig/create.go
+++ b/service/controller/kvm/v7/resource/chartconfig/create.go
@@ -1,0 +1,53 @@
+package chartconfig
+
+import (
+	"context"
+
+	"github.com/giantswarm/errors/guest"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+
+	"github.com/giantswarm/cluster-operator/pkg/v7/chartconfig"
+	"github.com/giantswarm/cluster-operator/pkg/v7/key"
+	kvmkey "github.com/giantswarm/cluster-operator/service/controller/kvm/v7/key"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	customObject, err := kvmkey.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	chartConfigsToCreate, err := toChartConfigs(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	clusterGuestConfig := kvmkey.ClusterGuestConfig(customObject)
+	apiDomain, err := key.APIDomain(clusterGuestConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	clusterConfig := chartconfig.ClusterConfig{
+		APIDomain:    apiDomain,
+		ClusterID:    key.ClusterID(clusterGuestConfig),
+		Organization: key.ClusterOrganization(clusterGuestConfig),
+	}
+
+	err = r.chartConfig.ApplyCreateChange(ctx, clusterConfig, chartConfigsToCreate)
+	if guest.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
+
+		// We can't continue without a successful K8s connection. Cluster
+		// may not be up yet. We will retry during the next execution.
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/service/controller/kvm/v7/resource/chartconfig/error.go
+++ b/service/controller/kvm/v7/resource/chartconfig/error.go
@@ -10,3 +10,12 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongType asserts wrongTypeError.
+func IsWrongType(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/kvm/v7/resource/chartconfig/resource.go
+++ b/service/controller/kvm/v7/resource/chartconfig/resource.go
@@ -1,6 +1,7 @@
 package chartconfig
 
 import (
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 
@@ -54,4 +55,17 @@ func New(config Config) (*Resource, error) {
 // Name returns name of the Resource.
 func (r *Resource) Name() string {
 	return Name
+}
+
+func toChartConfigs(v interface{}) ([]*v1alpha1.ChartConfig, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	chartConfigs, ok := v.([]*v1alpha1.ChartConfig)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", []*v1alpha1.ChartConfig{}, v)
+	}
+
+	return chartConfigs, nil
 }

--- a/service/controller/kvm/v7/resource/chartconfig/update.go
+++ b/service/controller/kvm/v7/resource/chartconfig/update.go
@@ -1,0 +1,73 @@
+package chartconfig
+
+import (
+	"context"
+
+	"github.com/giantswarm/errors/guest"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+
+	"github.com/giantswarm/cluster-operator/pkg/v7/chartconfig"
+	"github.com/giantswarm/cluster-operator/pkg/v7/key"
+	kvmkey "github.com/giantswarm/cluster-operator/service/controller/kvm/v7/key"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	customObject, err := kvmkey.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	chartConfigsToUpdate, err := toChartConfigs(updateChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	clusterGuestConfig := kvmkey.ClusterGuestConfig(customObject)
+	apiDomain, err := key.APIDomain(clusterGuestConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	clusterConfig := chartconfig.ClusterConfig{
+		APIDomain:    apiDomain,
+		ClusterID:    key.ClusterID(clusterGuestConfig),
+		Organization: key.ClusterOrganization(clusterGuestConfig),
+	}
+
+	err = r.chartConfig.ApplyUpdateChange(ctx, clusterConfig, chartConfigsToUpdate)
+	if guest.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
+
+		// We can't continue without a successful K8s connection. Cluster
+		// may not be up yet. We will retry during the next execution.
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	currentChartConfigs, err := toChartConfigs(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	desiredChartConfigs, err := toChartConfigs(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch, err := r.chartConfig.NewUpdatePatch(ctx, currentChartConfigs, desiredChartConfigs)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return patch, nil
+}


### PR DESCRIPTION
Towards giantswarm/giantswarm#4040

This is just moving code around with no changes in behavior. Next PR will add delete support and complete the  chartconfig service.