### PR TITLE
Wire azure chartconfig

### DIFF
--- a/pkg/v7/chartconfig/desired_test.go
+++ b/pkg/v7/chartconfig/desired_test.go
@@ -31,7 +31,6 @@ func Test_ChartConfig_GetDesiredState(t *testing.T) {
 			},
 			expectedChartConfigNames: []string{
 				"cert-exporter-chart",
-				"kubernetes-coredns-chart",
 				"kubernetes-kube-state-metrics-chart",
 				"kubernetes-nginx-ingress-controller-chart",
 				"kubernetes-node-exporter-chart",
@@ -56,7 +55,6 @@ func Test_ChartConfig_GetDesiredState(t *testing.T) {
 			},
 			expectedChartConfigNames: []string{
 				"cert-exporter-chart",
-				"kubernetes-coredns-chart",
 				"kubernetes-kube-state-metrics-chart",
 				"kubernetes-nginx-ingress-controller-chart",
 				"kubernetes-node-exporter-chart",
@@ -83,7 +81,6 @@ func Test_ChartConfig_GetDesiredState(t *testing.T) {
 			},
 			expectedChartConfigNames: []string{
 				"cert-exporter-chart",
-				"kubernetes-coredns-chart",
 				"kubernetes-kube-state-metrics-chart",
 				"kubernetes-nginx-ingress-controller-chart",
 				"kubernetes-node-exporter-chart",
@@ -118,7 +115,6 @@ func Test_ChartConfig_GetDesiredState(t *testing.T) {
 			},
 			expectedChartConfigNames: []string{
 				"cert-exporter-chart",
-				"kubernetes-coredns-chart",
 				"kubernetes-kube-state-metrics-chart",
 				"kubernetes-nginx-ingress-controller-chart",
 				"kubernetes-node-exporter-chart",

--- a/pkg/v7/key/key.go
+++ b/pkg/v7/key/key.go
@@ -71,14 +71,6 @@ func CommonChartSpecs() []ChartSpec {
 			ReleaseName:   "cert-exporter",
 		},
 		{
-			AppName:       "coredns",
-			ChannelName:   "0-1-stable",
-			ChartName:     "kubernetes-coredns-chart",
-			ConfigMapName: "coredns-values",
-			Namespace:     metav1.NamespaceSystem,
-			ReleaseName:   "coredns",
-		},
-		{
 			AppName:       "kube-state-metrics",
 			ChannelName:   "0-1-stable",
 			ChartName:     "kubernetes-kube-state-metrics-chart",


### PR DESCRIPTION
Towards giantswarm/giantswarm#4040

Uses the new chartconfig service. Going to wire changes per provider as they are tested.