### PR TITLE
Updated check for whether Ingress Controller chart is migrated

### DIFF
--- a/pkg/v7/configmap/configmap.go
+++ b/pkg/v7/configmap/configmap.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/giantswarm/helmclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/tenantcluster"
@@ -49,15 +48,6 @@ func New(config Config) (*Service, error) {
 	}
 
 	return s, nil
-}
-
-func (s *Service) newTenantHelmClient(ctx context.Context, clusterConfig ClusterConfig) (helmclient.Interface, error) {
-	tenantK8sClient, err := s.tenant.NewHelmClient(ctx, clusterConfig.ClusterID, clusterConfig.APIDomain)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	return tenantK8sClient, nil
 }
 
 func (s *Service) newTenantK8sClient(ctx context.Context, clusterConfig ClusterConfig) (kubernetes.Interface, error) {

--- a/pkg/v7/configmap/desired.go
+++ b/pkg/v7/configmap/desired.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 	"math"
 
-	"github.com/giantswarm/helmclient"
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/cluster-operator/pkg/label"
@@ -44,12 +44,12 @@ func (s *Service) GetDesiredState(ctx context.Context, clusterConfig ClusterConf
 					return nil, microerror.Mask(err)
 				}
 			case "nginx-ingress-controller":
-				releaseExists, err := s.checkHelmReleaseExists(ctx, spec.ReleaseName, clusterConfig)
+				hasLegacyIC, err := s.hasLegacyIngressController(ctx, spec.ReleaseName, clusterConfig)
 				if err != nil {
 					return nil, microerror.Mask(err)
 				}
 
-				values, err = ingressControllerValues(configMapValues, releaseExists)
+				values, err = ingressControllerValues(configMapValues, hasLegacyIC)
 				if err != nil {
 					return nil, microerror.Mask(err)
 				}
@@ -69,20 +69,31 @@ func (s *Service) GetDesiredState(ctx context.Context, clusterConfig ClusterConf
 	return desiredConfigMaps, nil
 }
 
-func (s *Service) checkHelmReleaseExists(ctx context.Context, releaseName string, clusterConfig ClusterConfig) (bool, error) {
-	tenantHelmClient, err := s.newTenantHelmClient(ctx, clusterConfig)
+// hasLegacyIngressController checks if the Ingress Controller deployment
+// exists and was created via k8scloudconfig. If so the chart migration
+// logic must be enabled.
+func (s *Service) hasLegacyIngressController(ctx context.Context, releaseName string, clusterConfig ClusterConfig) (bool, error) {
+	tenantK8sClient, err := s.newTenantK8sClient(ctx, clusterConfig)
 	if err != nil {
 		return false, microerror.Mask(err)
 	}
 
-	_, err = tenantHelmClient.GetReleaseContent(releaseName)
-	if helmclient.IsReleaseNotFound(err) {
+	ingressControllerDeploy, err := tenantK8sClient.Extensions().Deployments(metav1.NamespaceSystem).Get("nginx-ingress-controller", metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		// No deployment. So nothing to migrate.
 		return false, nil
 	} else if err != nil {
 		return false, microerror.Mask(err)
 	}
 
-	return true, nil
+	// ServiceType label is only present on deployments created via
+	// chart-operator.
+	serviceType, ok := ingressControllerDeploy.Labels[label.ServiceType]
+	if !ok || serviceType != label.ServiceTypeManaged {
+		return true, nil
+	}
+
+	return false, nil
 }
 
 func coreDNSValues(configMapValues ConfigMapValues) ([]byte, error) {
@@ -144,15 +155,15 @@ func exporterValues(configMapValues ConfigMapValues) ([]byte, error) {
 	return json, nil
 }
 
-func ingressControllerValues(configMapValues ConfigMapValues, releaseExists bool) ([]byte, error) {
+func ingressControllerValues(configMapValues ConfigMapValues, hasLegacyIngressController bool) ([]byte, error) {
 	// controllerServiceEnabled needs to be set separately for the chart
 	// migration logic but is the reverse of migration enabled.
 	controllerServiceEnabled := !configMapValues.IngressControllerMigrationEnabled
 
 	migrationEnabled := configMapValues.IngressControllerMigrationEnabled
 	if migrationEnabled {
-		// Release exists so don't repeat the migration process.
-		if releaseExists {
+		// No legacy ingress controller. So no need for the migration process.
+		if hasLegacyIngressController == false {
 			migrationEnabled = false
 		}
 	}

--- a/pkg/v7/configmap/desired_test.go
+++ b/pkg/v7/configmap/desired_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/giantswarm/micrologger/microloggertest"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientgofake "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/giantswarm/cluster-operator/pkg/label"
 	"github.com/giantswarm/cluster-operator/pkg/v7/key"
@@ -284,10 +285,12 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			fakeTenantK8sClient := clientgofake.NewSimpleClientset()
+
 			c := Config{
 				Logger: microloggertest.New(),
 				Tenant: &tenantMock{
-					fakeTenantHelmClient: &helmMock{},
+					fakeTenantK8sClient: fakeTenantK8sClient,
 				},
 
 				ProjectName: "cluster-operator",
@@ -615,7 +618,7 @@ func Test_ConfigMap_ingressControllerValues(t *testing.T) {
 	testCases := []struct {
 		name               string
 		configMapValues    ConfigMapValues
-		releaseExists      bool
+		hasLegacyIC        bool
 		errorMatcher       func(error) bool
 		expectedValuesJSON string
 	}{
@@ -627,7 +630,7 @@ func Test_ConfigMap_ingressControllerValues(t *testing.T) {
 				RegistryDomain:                    "quay.io",
 				WorkerCount:                       3,
 			},
-			releaseExists:      false,
+			hasLegacyIC:        true,
 			expectedValuesJSON: basicMatchJSON,
 		},
 		{
@@ -638,7 +641,7 @@ func Test_ConfigMap_ingressControllerValues(t *testing.T) {
 				RegistryDomain:                    "quay.io",
 				WorkerCount:                       7,
 			},
-			releaseExists:      false,
+			hasLegacyIC:        true,
 			expectedValuesJSON: differentWorkerCountJSON,
 		},
 		{
@@ -649,7 +652,7 @@ func Test_ConfigMap_ingressControllerValues(t *testing.T) {
 				RegistryDomain:                    "quay.io",
 				WorkerCount:                       1,
 			},
-			releaseExists:      false,
+			hasLegacyIC:        true,
 			expectedValuesJSON: differentSettingsJSON,
 		},
 		{
@@ -660,14 +663,14 @@ func Test_ConfigMap_ingressControllerValues(t *testing.T) {
 				RegistryDomain:                    "quay.io",
 				WorkerCount:                       3,
 			},
-			releaseExists:      true,
+			hasLegacyIC:        false,
 			expectedValuesJSON: alreadyMigratedJSON,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			values, err := ingressControllerValues(tc.configMapValues, tc.releaseExists)
+			values, err := ingressControllerValues(tc.configMapValues, tc.hasLegacyIC)
 
 			switch {
 			case err == nil && tc.errorMatcher == nil:


### PR DESCRIPTION
Currently we run the Ingress Controller migration once per cluster including for new clusters. This was to ensure all clusters were migrated.

This is causing problems with the CoreDNS migration. This updates the logic so we only run the migration if the cluster has a legacy ingress-controller deployment.