### PR TITLE
Improve chartconfig and configmap tests

### DIFF
--- a/pkg/v7/configmap/desired_test.go
+++ b/pkg/v7/configmap/desired_test.go
@@ -128,12 +128,39 @@ const (
 )
 
 func Test_ConfigMap_GetDesiredState(t *testing.T) {
+	commonConfigMapSpecs := []ConfigMapSpec{
+		{
+			Name:      "cert-exporter-values",
+			Namespace: metav1.NamespaceSystem,
+		},
+		{
+			Name:      "kube-state-metrics-values",
+			Namespace: metav1.NamespaceSystem,
+		},
+		{
+			Name:      "net-exporter-values",
+			Namespace: metav1.NamespaceSystem,
+		},
+		{
+			Name:      "nginx-ingress-controller-values",
+			Namespace: metav1.NamespaceSystem,
+		},
+		{
+			Name:      "nginx-ingress-controller-user-values",
+			Namespace: metav1.NamespaceSystem,
+		},
+		{
+			Name:      "node-exporter-values",
+			Namespace: metav1.NamespaceSystem,
+		},
+	}
+
 	testCases := []struct {
-		name                   string
-		clusterConfig          ClusterConfig
-		configMapValues        ConfigMapValues
-		providerChartSpecs     []key.ChartSpec
-		expectedConfigMapSpecs []ConfigMapSpec
+		name                  string
+		clusterConfig         ClusterConfig
+		configMapValues       ConfigMapValues
+		providerChartSpecs    []key.ChartSpec
+		expectedProviderSpecs []ConfigMapSpec
 	}{
 		{
 			name: "case 0: basic match",
@@ -150,32 +177,7 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 				RegistryDomain:                    "quay.io",
 				WorkerCount:                       3,
 			},
-			expectedConfigMapSpecs: []ConfigMapSpec{
-				{
-					Name:      "cert-exporter-values",
-					Namespace: metav1.NamespaceSystem,
-				},
-				{
-					Name:      "kube-state-metrics-values",
-					Namespace: metav1.NamespaceSystem,
-				},
-				{
-					Name:      "net-exporter-values",
-					Namespace: metav1.NamespaceSystem,
-				},
-				{
-					Name:      "nginx-ingress-controller-values",
-					Namespace: metav1.NamespaceSystem,
-				},
-				{
-					Name:      "nginx-ingress-controller-user-values",
-					Namespace: metav1.NamespaceSystem,
-				},
-				{
-					Name:      "node-exporter-values",
-					Namespace: metav1.NamespaceSystem,
-				},
-			},
+			expectedProviderSpecs: []ConfigMapSpec{},
 		},
 		{
 			name: "case 1: provider chart without configmap",
@@ -199,32 +201,7 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 					Namespace: metav1.NamespaceSystem,
 				},
 			},
-			expectedConfigMapSpecs: []ConfigMapSpec{
-				{
-					Name:      "cert-exporter-values",
-					Namespace: metav1.NamespaceSystem,
-				},
-				{
-					Name:      "kube-state-metrics-values",
-					Namespace: metav1.NamespaceSystem,
-				},
-				{
-					Name:      "net-exporter-values",
-					Namespace: metav1.NamespaceSystem,
-				},
-				{
-					Name:      "nginx-ingress-controller-values",
-					Namespace: metav1.NamespaceSystem,
-				},
-				{
-					Name:      "nginx-ingress-controller-user-values",
-					Namespace: metav1.NamespaceSystem,
-				},
-				{
-					Name:      "node-exporter-values",
-					Namespace: metav1.NamespaceSystem,
-				},
-			},
+			expectedProviderSpecs: []ConfigMapSpec{},
 		},
 		{
 			name: "case 2: provider chart with configmap in different namespace",
@@ -249,31 +226,7 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 					Namespace:     "giantswarm",
 				},
 			},
-			expectedConfigMapSpecs: []ConfigMapSpec{
-				{
-					Name:      "cert-exporter-values",
-					Namespace: metav1.NamespaceSystem,
-				},
-				{
-					Name:      "kube-state-metrics-values",
-					Namespace: metav1.NamespaceSystem,
-				},
-				{
-					Name:      "net-exporter-values",
-					Namespace: metav1.NamespaceSystem,
-				},
-				{
-					Name:      "nginx-ingress-controller-values",
-					Namespace: metav1.NamespaceSystem,
-				},
-				{
-					Name:      "nginx-ingress-controller-user-values",
-					Namespace: metav1.NamespaceSystem,
-				},
-				{
-					Name:      "node-exporter-values",
-					Namespace: metav1.NamespaceSystem,
-				},
+			expectedProviderSpecs: []ConfigMapSpec{
 				{
 					Name:      "test-app-values",
 					Namespace: "giantswarm",
@@ -302,11 +255,12 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 				t.Fatal("expected", nil, "got", err)
 			}
 
-			if len(configMaps) != len(tc.expectedConfigMapSpecs) {
-				t.Fatal("expected", len(tc.expectedConfigMapSpecs), "got", len(configMaps))
+			expectedConfigMapSpecs := append(commonConfigMapSpecs, tc.expectedProviderSpecs...)
+			if len(configMaps) != len(expectedConfigMapSpecs) {
+				t.Fatal("expected", len(expectedConfigMapSpecs), "got", len(configMaps))
 			}
 
-			for _, expectedSpec := range tc.expectedConfigMapSpecs {
+			for _, expectedSpec := range expectedConfigMapSpecs {
 				_, err := getConfigMapByNameAndNamespace(configMaps, expectedSpec.Name, expectedSpec.Namespace)
 				if IsNotFound(err) {
 					t.Fatalf("expected chart %#q/%#q not found", expectedSpec.Namespace, expectedSpec.Name)

--- a/pkg/v7/key/key.go
+++ b/pkg/v7/key/key.go
@@ -59,7 +59,7 @@ func ClusterOrganization(clusterGuestConfig v1alpha1.ClusterGuestConfig) string 
 
 // CommonChartSpecs returns charts installed for all providers.
 // Note: When adding chart specs you also need to add the chart name to the
-// desired state test in the chartconfig service.
+// desired state tests in the chartconfig and configmap services.
 func CommonChartSpecs() []ChartSpec {
 	return []ChartSpec{
 		{


### PR DESCRIPTION
Towards giantswarm/giantswarm#4040

Last 2 PRs before closing the refactoring issue. This PR aligns the tests for both services and makes them easier to work with.