### PR TITLE
Add delete change to update patch

### DIFF
--- a/pkg/v7/chartconfig/update.go
+++ b/pkg/v7/chartconfig/update.go
@@ -44,11 +44,15 @@ func (c *ChartConfig) NewUpdatePatch(ctx context.Context, currentState, desiredS
 		return nil, microerror.Mask(err)
 	}
 
+	delete, err := c.newDeleteChangeForUpdatePatch(ctx, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
 	patch := controller.NewPatch()
 	patch.SetCreateChange(create)
 	patch.SetUpdateChange(update)
-	// TODO
-	// patch.SetDeleteChange(delete)
+	patch.SetDeleteChange(delete)
 
 	return patch, nil
 }


### PR DESCRIPTION
Towards giantswarm/giantswarm#4040

I kept `newDeleteChangeForUpdatePatch` out of the PR to implement update. So the PR didn't get too big. But I missed enabling it in the delete PR. This fixes it.