### PR TITLE
Structure ConfigMapValues struct

### DIFF
--- a/pkg/v7/configmap/desired.go
+++ b/pkg/v7/configmap/desired.go
@@ -97,8 +97,8 @@ func (s *Service) hasLegacyIngressController(ctx context.Context, releaseName st
 }
 
 func coreDNSValues(configMapValues ConfigMapValues) ([]byte, error) {
-	calicoCIDRBlock := key.CIDRBlock(configMapValues.CalicoAddress, configMapValues.CalicoPrefixLength)
-	DNSIP, err := key.DNSIP(configMapValues.ClusterIPRange)
+	calicoCIDRBlock := key.CIDRBlock(configMapValues.CoreDNS.CalicoAddress, configMapValues.CoreDNS.CalicoPrefixLength)
+	DNSIP, err := key.DNSIP(configMapValues.CoreDNS.ClusterIPRange)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -110,7 +110,7 @@ func coreDNSValues(configMapValues ConfigMapValues) ([]byte, error) {
 			},
 			Kubernetes: CoreDNSClusterKubernetes{
 				API: CoreDNSClusterKubernetesAPI{
-					ClusterIPRange: configMapValues.ClusterIPRange,
+					ClusterIPRange: configMapValues.CoreDNS.ClusterIPRange,
 				},
 				DNS: CoreDNSClusterKubernetesDNS{
 					IP: DNSIP,
@@ -158,9 +158,9 @@ func exporterValues(configMapValues ConfigMapValues) ([]byte, error) {
 func ingressControllerValues(configMapValues ConfigMapValues, hasLegacyIngressController bool) ([]byte, error) {
 	// controllerServiceEnabled needs to be set separately for the chart
 	// migration logic but is the reverse of migration enabled.
-	controllerServiceEnabled := !configMapValues.IngressControllerMigrationEnabled
+	controllerServiceEnabled := !configMapValues.IngressController.MigrationEnabled
 
-	migrationEnabled := configMapValues.IngressControllerMigrationEnabled
+	migrationEnabled := configMapValues.IngressController.MigrationEnabled
 	if migrationEnabled {
 		// No legacy ingress controller. So no need for the migration process.
 		if hasLegacyIngressController == false {
@@ -185,7 +185,7 @@ func ingressControllerValues(configMapValues ConfigMapValues, hasLegacyIngressCo
 		Global: IngressControllerGlobal{
 			Controller: IngressControllerGlobalController{
 				TempReplicas:     tempReplicas,
-				UseProxyProtocol: configMapValues.IngressControllerUseProxyProtocol,
+				UseProxyProtocol: configMapValues.IngressController.UseProxyProtocol,
 			},
 			Migration: IngressControllerGlobalMigration{
 				Enabled: migrationEnabled,

--- a/pkg/v7/configmap/desired_test.go
+++ b/pkg/v7/configmap/desired_test.go
@@ -144,12 +144,9 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 				Namespaces: []string{},
 			},
 			configMapValues: ConfigMapValues{
-				ClusterID:                         "5xchu",
-				IngressControllerMigrationEnabled: true,
-				IngressControllerUseProxyProtocol: true,
-				Organization:                      "giantswarm",
-				RegistryDomain:                    "quay.io",
-				WorkerCount:                       3,
+				ClusterID:    "5xchu",
+				Organization: "giantswarm",
+				WorkerCount:  3,
 			},
 			expectedConfigMapSpecs: []ConfigMapSpec{
 				{
@@ -186,12 +183,9 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 				Namespaces: []string{},
 			},
 			configMapValues: ConfigMapValues{
-				ClusterID:                         "5xchu",
-				Organization:                      "giantswarm",
-				IngressControllerMigrationEnabled: true,
-				IngressControllerUseProxyProtocol: true,
-				RegistryDomain:                    "quay.io",
-				WorkerCount:                       7,
+				ClusterID:    "5xchu",
+				Organization: "giantswarm",
+				WorkerCount:  7,
 			},
 			providerChartSpecs: []key.ChartSpec{
 				{
@@ -235,12 +229,9 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 				Namespaces: []string{},
 			},
 			configMapValues: ConfigMapValues{
-				ClusterID:                         "5xchu",
-				Organization:                      "giantswarm",
-				IngressControllerMigrationEnabled: true,
-				IngressControllerUseProxyProtocol: true,
-				RegistryDomain:                    "quay.io",
-				WorkerCount:                       7,
+				ClusterID:    "5xchu",
+				Organization: "giantswarm",
+				WorkerCount:  7,
 			},
 			providerChartSpecs: []key.ChartSpec{
 				{
@@ -485,10 +476,12 @@ func Test_ConfigMap_coreDNSValues(t *testing.T) {
 		{
 			name: "case 0: basic match",
 			configMapValues: ConfigMapValues{
-				CalicoAddress:      "172.20.0.0",
-				CalicoPrefixLength: "16",
-				ClusterIPRange:     "172.31.0.0/16",
-				RegistryDomain:     "quay.io",
+				CoreDNS: CoreDNSValues{
+					CalicoAddress:      "172.20.0.0",
+					CalicoPrefixLength: "16",
+					ClusterIPRange:     "172.31.0.0/16",
+				},
+				RegistryDomain: "quay.io",
 			},
 			expectedValuesJSON: coreDNSJSON,
 		},
@@ -625,10 +618,12 @@ func Test_ConfigMap_ingressControllerValues(t *testing.T) {
 		{
 			name: "case 0: basic match",
 			configMapValues: ConfigMapValues{
-				IngressControllerMigrationEnabled: true,
-				IngressControllerUseProxyProtocol: true,
-				RegistryDomain:                    "quay.io",
-				WorkerCount:                       3,
+				IngressController: IngressControllerValues{
+					MigrationEnabled: true,
+					UseProxyProtocol: true,
+				},
+				RegistryDomain: "quay.io",
+				WorkerCount:    3,
 			},
 			hasLegacyIC:        true,
 			expectedValuesJSON: basicMatchJSON,
@@ -636,10 +631,12 @@ func Test_ConfigMap_ingressControllerValues(t *testing.T) {
 		{
 			name: "case 1: different worker count",
 			configMapValues: ConfigMapValues{
-				IngressControllerMigrationEnabled: true,
-				IngressControllerUseProxyProtocol: true,
-				RegistryDomain:                    "quay.io",
-				WorkerCount:                       7,
+				IngressController: IngressControllerValues{
+					MigrationEnabled: true,
+					UseProxyProtocol: true,
+				},
+				RegistryDomain: "quay.io",
+				WorkerCount:    7,
 			},
 			hasLegacyIC:        true,
 			expectedValuesJSON: differentWorkerCountJSON,
@@ -647,10 +644,12 @@ func Test_ConfigMap_ingressControllerValues(t *testing.T) {
 		{
 			name: "case 2: different settings",
 			configMapValues: ConfigMapValues{
-				IngressControllerMigrationEnabled: false,
-				IngressControllerUseProxyProtocol: false,
-				RegistryDomain:                    "quay.io",
-				WorkerCount:                       1,
+				IngressController: IngressControllerValues{
+					MigrationEnabled: false,
+					UseProxyProtocol: false,
+				},
+				RegistryDomain: "quay.io",
+				WorkerCount:    1,
 			},
 			hasLegacyIC:        true,
 			expectedValuesJSON: differentSettingsJSON,
@@ -658,10 +657,12 @@ func Test_ConfigMap_ingressControllerValues(t *testing.T) {
 		{
 			name: "case 3: already migrated",
 			configMapValues: ConfigMapValues{
-				IngressControllerMigrationEnabled: true,
-				IngressControllerUseProxyProtocol: false,
-				RegistryDomain:                    "quay.io",
-				WorkerCount:                       3,
+				IngressController: IngressControllerValues{
+					MigrationEnabled: true,
+					UseProxyProtocol: false,
+				},
+				RegistryDomain: "quay.io",
+				WorkerCount:    3,
 			},
 			hasLegacyIC:        false,
 			expectedValuesJSON: alreadyMigratedJSON,

--- a/pkg/v7/configmap/spec.go
+++ b/pkg/v7/configmap/spec.go
@@ -40,15 +40,26 @@ type ConfigMapSpec struct {
 // ConfigMapValues is used by the configmap resources to provide data to the
 // configmap service.
 type ConfigMapValues struct {
-	CalicoAddress                     string
-	CalicoPrefixLength                string
-	ClusterID                         string
-	ClusterIPRange                    string
-	Organization                      string
-	IngressControllerMigrationEnabled bool
-	IngressControllerUseProxyProtocol bool
-	RegistryDomain                    string
-	WorkerCount                       int
+	ClusterID         string
+	CoreDNS           CoreDNSValues
+	IngressController IngressControllerValues
+	Organization      string
+	RegistryDomain    string
+	WorkerCount       int
+}
+
+// CoreDNSValues provides values for generating the CoreDNS configmap.
+type CoreDNSValues struct {
+	CalicoAddress      string
+	CalicoPrefixLength string
+	ClusterIPRange     string
+}
+
+// IngressControllerValues provides values for generating the Ingress
+// Controller configmap.
+type IngressControllerValues struct {
+	MigrationEnabled bool
+	UseProxyProtocol bool
 }
 
 // Types below are used for generating values JSON for app configmaps.

--- a/service/controller/aws/v7/resource/configmap/desired.go
+++ b/service/controller/aws/v7/resource/configmap/desired.go
@@ -28,18 +28,22 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	}
 
 	configMapValues := configmap.ConfigMapValues{
-		CalicoAddress:      r.calicoAddress,
-		CalicoPrefixLength: r.calicoPrefixLength,
-		ClusterID:          key.ClusterID(clusterGuestConfig),
-		ClusterIPRange:     r.clusterIPRange,
-		// Migration is enabled so existing k8scloudconfig resources are
-		// replaced.
-		IngressControllerMigrationEnabled: true,
-		// Proxy protocol is enabled for AWS clusters.
-		IngressControllerUseProxyProtocol: true,
-		Organization:                      key.ClusterOrganization(clusterGuestConfig),
-		RegistryDomain:                    r.registryDomain,
-		WorkerCount:                       awskey.WorkerCount(customObject),
+		ClusterID: key.ClusterID(clusterGuestConfig),
+		CoreDNS: configmap.CoreDNSValues{
+			CalicoAddress:      r.calicoAddress,
+			CalicoPrefixLength: r.calicoPrefixLength,
+			ClusterIPRange:     r.clusterIPRange,
+		},
+		IngressController: configmap.IngressControllerValues{
+			// Migration is enabled so existing k8scloudconfig resources are
+			// replaced.
+			MigrationEnabled: true,
+			// Proxy protocol is enabled for AWS clusters.
+			UseProxyProtocol: true,
+		},
+		Organization:   key.ClusterOrganization(clusterGuestConfig),
+		RegistryDomain: r.registryDomain,
+		WorkerCount:    awskey.WorkerCount(customObject),
 	}
 	desiredConfigMaps, err := r.configMap.GetDesiredState(ctx, clusterConfig, configMapValues, awskey.ChartSpecs())
 	if err != nil {

--- a/service/controller/azure/v7/resource/configmap/desired.go
+++ b/service/controller/azure/v7/resource/configmap/desired.go
@@ -28,17 +28,21 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	}
 
 	configMapValues := configmap.ConfigMapValues{
-		CalicoAddress:      r.calicoAddress,
-		CalicoPrefixLength: r.calicoPrefixLength,
-		ClusterID:          key.ClusterID(clusterGuestConfig),
-		ClusterIPRange:     r.clusterIPRange,
-		// Migration is disabled because Azure is already migrated.
-		IngressControllerMigrationEnabled: false,
-		// Proxy protocol is disabled for Azure clusters.
-		IngressControllerUseProxyProtocol: false,
-		Organization:                      key.ClusterOrganization(clusterGuestConfig),
-		RegistryDomain:                    r.registryDomain,
-		WorkerCount:                       azurekey.WorkerCount(customObject),
+		ClusterID: key.ClusterID(clusterGuestConfig),
+		CoreDNS: configmap.CoreDNSValues{
+			CalicoAddress:      r.calicoAddress,
+			CalicoPrefixLength: r.calicoPrefixLength,
+			ClusterIPRange:     r.clusterIPRange,
+		},
+		IngressController: configmap.IngressControllerValues{
+			// Migration is disabled because Azure is already migrated.
+			MigrationEnabled: false,
+			// Proxy protocol is disabled for Azure clusters.
+			UseProxyProtocol: false,
+		},
+		Organization:   key.ClusterOrganization(clusterGuestConfig),
+		RegistryDomain: r.registryDomain,
+		WorkerCount:    azurekey.WorkerCount(customObject),
 	}
 	desiredConfigMaps, err := r.configMap.GetDesiredState(ctx, clusterConfig, configMapValues, azurekey.ChartSpecs())
 	if err != nil {

--- a/service/controller/kvm/v7/resource/configmap/desired.go
+++ b/service/controller/kvm/v7/resource/configmap/desired.go
@@ -28,18 +28,22 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	}
 
 	configMapValues := configmap.ConfigMapValues{
-		CalicoAddress:      r.calicoAddress,
-		CalicoPrefixLength: r.calicoPrefixLength,
-		ClusterID:          key.ClusterID(clusterGuestConfig),
-		ClusterIPRange:     r.clusterIPRange,
-		// Migration is enabled so existing k8scloudconfig resources are
-		// replaced.
-		IngressControllerMigrationEnabled: true,
-		// Proxy protocol is disabled for KVM clusters.
-		IngressControllerUseProxyProtocol: false,
-		Organization:                      key.ClusterOrganization(clusterGuestConfig),
-		RegistryDomain:                    r.registryDomain,
-		WorkerCount:                       kvmkey.WorkerCount(customObject),
+		ClusterID: key.ClusterID(clusterGuestConfig),
+		CoreDNS: configmap.CoreDNSValues{
+			CalicoAddress:      r.calicoAddress,
+			CalicoPrefixLength: r.calicoPrefixLength,
+			ClusterIPRange:     r.clusterIPRange,
+		},
+		IngressController: configmap.IngressControllerValues{
+			// Migration is enabled so existing k8scloudconfig resources are
+			// replaced.
+			MigrationEnabled: true,
+			// Proxy protocol is disabled for KVM clusters.
+			UseProxyProtocol: false,
+		},
+		Organization:   key.ClusterOrganization(clusterGuestConfig),
+		RegistryDomain: r.registryDomain,
+		WorkerCount:    kvmkey.WorkerCount(customObject),
 	}
 	desiredConfigMaps, err := r.configMap.GetDesiredState(ctx, clusterConfig, configMapValues, kvmkey.ChartSpecs())
 	if err != nil {


### PR DESCRIPTION
Towards giantswarm/giantswarm#4040

The ConfigMapValues already is quite big and we'll likely have to add more in future. This splits out the CoreDNS and Ingress Controller values. We can use the same approach for new configmaps.