### PR TITLE
Do not create already existing configmap

### DIFF
--- a/pkg/v8/configmap/configmap.go
+++ b/pkg/v8/configmap/configmap.go
@@ -59,9 +59,11 @@ func (s *Service) newTenantK8sClient(ctx context.Context, clusterConfig ClusterC
 	return tenantK8sClient, nil
 }
 
+// containsConfigMap checks if item is present within list
+// by comparing ObjectMeta Name and Namespace property between item and list objects.
 func containsConfigMap(list []*corev1.ConfigMap, item *corev1.ConfigMap) bool {
 	for _, l := range list {
-		if reflect.DeepEqual(item, l) {
+		if item.Name == l.Name && item.Namespace == l.Namespace {
 			return true
 		}
 	}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/4310

Goes in the same direction as https://github.com/giantswarm/cluster-operator/pull/311

Fixes an issue where cluster-operator always tries to create new configmap even if they already exist.
This was due to the comparison in containsConfigMap being too strict; it compare entire CR objects.

This PRs fix this by comparing only chartconfig names and namespaces.

Difference in labels or data are handled by update.