### PR TITLE
Add azure v8 CoreDNS changelog

### DIFF
--- a/service/controller/azure/v8/version_bundle.go
+++ b/service/controller/azure/v8/version_bundle.go
@@ -9,7 +9,7 @@ func VersionBundle() versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "cluster-operator",
-				Description: "Add your changes here.",
+				Description: "Allow advanced CoreDNS configuration. See https://docs.giantswarm.io/guides/advanced-coredns-configuration",
 				Kind:        versionbundle.KindAdded,
 			},
 		},


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/4452

Add changelog message about configurable CoreDNS in azure v8