### PR TITLE
set tiller namespace to giantswarm on tenant clusters

### DIFF
--- a/pkg/v8/resource/chart/create.go
+++ b/pkg/v8/resource/chart/create.go
@@ -78,6 +78,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 			Image: Image{
 				Registry: r.registryDomain,
 			},
+			TillerNamespace: chartOperatorNamespace,
 		}
 		b, err := json.Marshal(v)
 		if err != nil {

--- a/pkg/v8/resource/chart/resource.go
+++ b/pkg/v8/resource/chart/resource.go
@@ -23,7 +23,7 @@ const (
 	Name = "chartv8"
 
 	chartOperatorChart         = "chart-operator-chart"
-	chartOperatorChannel       = "0-3-stable"
+	chartOperatorChannel       = "5fd8c9cb311b538547b7c371b71d7449731b96de"
 	chartOperatorRelease       = "chart-operator"
 	chartOperatorNamespace     = "giantswarm"
 	chartOperatorDesiredStatus = "DEPLOYED"

--- a/pkg/v8/resource/chart/resource.go
+++ b/pkg/v8/resource/chart/resource.go
@@ -23,7 +23,7 @@ const (
 	Name = "chartv8"
 
 	chartOperatorChart         = "chart-operator-chart"
-	chartOperatorChannel       = "5fd8c9cb311b538547b7c371b71d7449731b96de"
+	chartOperatorChannel       = "0-3-stable"
 	chartOperatorRelease       = "chart-operator"
 	chartOperatorNamespace     = "giantswarm"
 	chartOperatorDesiredStatus = "DEPLOYED"

--- a/pkg/v8/resource/chart/spec.go
+++ b/pkg/v8/resource/chart/spec.go
@@ -19,8 +19,9 @@ type ResourceState struct {
 // Values represents the values to be passed to Helm commands related to
 // chart-operator chart.
 type Values struct {
-	ClusterDNSIP string `json:"clusterDNSIP"`
-	Image        Image  `json:"image"`
+	ClusterDNSIP    string `json:"clusterDNSIP"`
+	Image           Image  `json:"image"`
+	TillerNamespace string `json:"tillerNamespace"`
 }
 
 // Image holds the image settings for chart-operator chart.


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/4537

Point chart-operator to tiller in `giantswarm` namespace on tenant clusters.