### PR TITLE
set tiller namespace to chart-operator namespace (v7, v7patch1)

### DIFF
--- a/pkg/v7/resource/chart/create.go
+++ b/pkg/v7/resource/chart/create.go
@@ -78,6 +78,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 			Image: Image{
 				Registry: r.registryDomain,
 			},
+			TillerNamespace: chartOperatorNamespace,
 		}
 		b, err := json.Marshal(v)
 		if err != nil {

--- a/pkg/v7/resource/chart/spec.go
+++ b/pkg/v7/resource/chart/spec.go
@@ -19,8 +19,9 @@ type ResourceState struct {
 // Values represents the values to be passed to Helm commands related to
 // chart-operator chart.
 type Values struct {
-	ClusterDNSIP string `json:"clusterDNSIP"`
-	Image        Image  `json:"image"`
+	ClusterDNSIP    string `json:"clusterDNSIP"`
+	Image           Image  `json:"image"`
+	TillerNamespace string `json:"tillerNamespace"`
 }
 
 // Image holds the image settings for chart-operator chart.

--- a/pkg/v7patch1/resource/chart/create.go
+++ b/pkg/v7patch1/resource/chart/create.go
@@ -78,6 +78,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 			Image: Image{
 				Registry: r.registryDomain,
 			},
+			TillerNamespace: chartOperatorNamespace,
 		}
 		b, err := json.Marshal(v)
 		if err != nil {

--- a/pkg/v7patch1/resource/chart/spec.go
+++ b/pkg/v7patch1/resource/chart/spec.go
@@ -19,8 +19,9 @@ type ResourceState struct {
 // Values represents the values to be passed to Helm commands related to
 // chart-operator chart.
 type Values struct {
-	ClusterDNSIP string `json:"clusterDNSIP"`
-	Image        Image  `json:"image"`
+	ClusterDNSIP    string `json:"clusterDNSIP"`
+	Image           Image  `json:"image"`
+	TillerNamespace string `json:"tillerNamespace"`
 }
 
 // Image holds the image settings for chart-operator chart.


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/4537

Enforce tiller namespace to align with chart-operator namespace on every controller version deploying chart-operator 0-3-stable.

see https://github.com/giantswarm/giantswarm/issues/4691#issuecomment-439964341