### PR TITLE
Rename chart resource to chartoperator

### DIFF
--- a/pkg/v10/resource/chartoperator/create.go
+++ b/pkg/v10/resource/chartoperator/create.go
@@ -1,4 +1,4 @@
-package chart
+package chartoperator
 
 import (
 	"context"

--- a/pkg/v10/resource/chartoperator/create_test.go
+++ b/pkg/v10/resource/chartoperator/create_test.go
@@ -1,4 +1,4 @@
-package chart
+package chartoperator
 
 import (
 	"context"
@@ -16,7 +16,7 @@ import (
 	"github.com/giantswarm/cluster-operator/pkg/cluster"
 )
 
-func Test_Resource_Chart_newDelete(t *testing.T) {
+func Test_Resource_Chart_newCreate(t *testing.T) {
 	obj := v1alpha1.ClusterGuestConfig{
 		DNSZone: "5xchu.aws.giantswarm.io",
 		ID:      "5xchu",
@@ -33,7 +33,7 @@ func Test_Resource_Chart_newDelete(t *testing.T) {
 			name:          "case 0: empty current and desired, expected empty",
 			currentState:  &ResourceState{},
 			desiredState:  &ResourceState{},
-			expectedState: nil,
+			expectedState: &ResourceState{},
 		},
 		{
 			name: "case 1: non-empty current, empty desired, expected empty",
@@ -41,28 +41,28 @@ func Test_Resource_Chart_newDelete(t *testing.T) {
 				ChartName: "current",
 			},
 			desiredState:  &ResourceState{},
-			expectedState: nil,
+			expectedState: &ResourceState{},
 		},
 
 		{
-			name:         "case 2: empty current, non-empty desired, expected empty",
+			name:         "case 2: empty current, non-empty desired, expected desired",
 			currentState: &ResourceState{},
-			desiredState: &ResourceState{
-				ChartName: "desired",
-			},
-			expectedState: nil,
-		},
-		{
-			name: "case 3: equal non-empty current and desired, expected desired",
-			currentState: &ResourceState{
-				ChartName: "desired",
-			},
 			desiredState: &ResourceState{
 				ChartName: "desired",
 			},
 			expectedState: &ResourceState{
 				ChartName: "desired",
 			},
+		},
+		{
+			name: "case 3: equal non-empty current and desired, expected empty",
+			currentState: &ResourceState{
+				ChartName: "desired",
+			},
+			desiredState: &ResourceState{
+				ChartName: "desired",
+			},
+			expectedState: &ResourceState{},
 		},
 		{
 			name: "case 4: different non-empty current and desired, expected empty",
@@ -72,7 +72,7 @@ func Test_Resource_Chart_newDelete(t *testing.T) {
 			desiredState: &ResourceState{
 				ChartName: "desired",
 			},
-			expectedState: nil,
+			expectedState: &ResourceState{},
 		},
 	}
 
@@ -105,21 +105,16 @@ func Test_Resource_Chart_newDelete(t *testing.T) {
 				t.Fatalf("error == %#v, want nil", err)
 			}
 
-			result, err := newResource.newDeleteChange(context.TODO(), obj, tc.currentState, tc.desiredState)
+			result, err := newResource.newCreateChange(context.TODO(), obj, tc.currentState, tc.desiredState)
 			if err != nil {
 				t.Fatal("expected", nil, "got", err)
 			}
-			if tc.expectedState == nil && result != nil {
-				t.Fatal("expected", nil, "got", result)
+			createChange, ok := result.(*ResourceState)
+			if !ok {
+				t.Fatalf("expected '%T', got '%T'", createChange, result)
 			}
-			if result != nil {
-				deleteChange, ok := result.(*ResourceState)
-				if !ok {
-					t.Fatalf("expected '%T', got '%T'", deleteChange, result)
-				}
-				if !reflect.DeepEqual(deleteChange, tc.expectedState) {
-					t.Fatalf("ChartState == %q, want %q", deleteChange, tc.expectedState)
-				}
+			if !reflect.DeepEqual(createChange, tc.expectedState) {
+				t.Fatalf("ChartState == %q, want %q", createChange, tc.expectedState)
 			}
 		})
 	}

--- a/pkg/v10/resource/chartoperator/current.go
+++ b/pkg/v10/resource/chartoperator/current.go
@@ -1,4 +1,4 @@
-package chart
+package chartoperator
 
 import (
 	"context"

--- a/pkg/v10/resource/chartoperator/current_test.go
+++ b/pkg/v10/resource/chartoperator/current_test.go
@@ -1,4 +1,4 @@
-package chart
+package chartoperator
 
 import (
 	"context"

--- a/pkg/v10/resource/chartoperator/delete.go
+++ b/pkg/v10/resource/chartoperator/delete.go
@@ -1,4 +1,4 @@
-package chart
+package chartoperator
 
 import (
 	"context"

--- a/pkg/v10/resource/chartoperator/delete_test.go
+++ b/pkg/v10/resource/chartoperator/delete_test.go
@@ -1,4 +1,4 @@
-package chart
+package chartoperator
 
 import (
 	"context"
@@ -16,7 +16,7 @@ import (
 	"github.com/giantswarm/cluster-operator/pkg/cluster"
 )
 
-func Test_Resource_Chart_newCreate(t *testing.T) {
+func Test_Resource_Chart_newDelete(t *testing.T) {
 	obj := v1alpha1.ClusterGuestConfig{
 		DNSZone: "5xchu.aws.giantswarm.io",
 		ID:      "5xchu",
@@ -33,7 +33,7 @@ func Test_Resource_Chart_newCreate(t *testing.T) {
 			name:          "case 0: empty current and desired, expected empty",
 			currentState:  &ResourceState{},
 			desiredState:  &ResourceState{},
-			expectedState: &ResourceState{},
+			expectedState: nil,
 		},
 		{
 			name: "case 1: non-empty current, empty desired, expected empty",
@@ -41,28 +41,28 @@ func Test_Resource_Chart_newCreate(t *testing.T) {
 				ChartName: "current",
 			},
 			desiredState:  &ResourceState{},
-			expectedState: &ResourceState{},
+			expectedState: nil,
 		},
 
 		{
-			name:         "case 2: empty current, non-empty desired, expected desired",
+			name:         "case 2: empty current, non-empty desired, expected empty",
 			currentState: &ResourceState{},
 			desiredState: &ResourceState{
 				ChartName: "desired",
 			},
-			expectedState: &ResourceState{
-				ChartName: "desired",
-			},
+			expectedState: nil,
 		},
 		{
-			name: "case 3: equal non-empty current and desired, expected empty",
+			name: "case 3: equal non-empty current and desired, expected desired",
 			currentState: &ResourceState{
 				ChartName: "desired",
 			},
 			desiredState: &ResourceState{
 				ChartName: "desired",
 			},
-			expectedState: &ResourceState{},
+			expectedState: &ResourceState{
+				ChartName: "desired",
+			},
 		},
 		{
 			name: "case 4: different non-empty current and desired, expected empty",
@@ -72,7 +72,7 @@ func Test_Resource_Chart_newCreate(t *testing.T) {
 			desiredState: &ResourceState{
 				ChartName: "desired",
 			},
-			expectedState: &ResourceState{},
+			expectedState: nil,
 		},
 	}
 
@@ -105,16 +105,21 @@ func Test_Resource_Chart_newCreate(t *testing.T) {
 				t.Fatalf("error == %#v, want nil", err)
 			}
 
-			result, err := newResource.newCreateChange(context.TODO(), obj, tc.currentState, tc.desiredState)
+			result, err := newResource.newDeleteChange(context.TODO(), obj, tc.currentState, tc.desiredState)
 			if err != nil {
 				t.Fatal("expected", nil, "got", err)
 			}
-			createChange, ok := result.(*ResourceState)
-			if !ok {
-				t.Fatalf("expected '%T', got '%T'", createChange, result)
+			if tc.expectedState == nil && result != nil {
+				t.Fatal("expected", nil, "got", result)
 			}
-			if !reflect.DeepEqual(createChange, tc.expectedState) {
-				t.Fatalf("ChartState == %q, want %q", createChange, tc.expectedState)
+			if result != nil {
+				deleteChange, ok := result.(*ResourceState)
+				if !ok {
+					t.Fatalf("expected '%T', got '%T'", deleteChange, result)
+				}
+				if !reflect.DeepEqual(deleteChange, tc.expectedState) {
+					t.Fatalf("ChartState == %q, want %q", deleteChange, tc.expectedState)
+				}
 			}
 		})
 	}

--- a/pkg/v10/resource/chartoperator/desired.go
+++ b/pkg/v10/resource/chartoperator/desired.go
@@ -1,4 +1,4 @@
-package chart
+package chartoperator
 
 import (
 	"context"

--- a/pkg/v10/resource/chartoperator/desired_test.go
+++ b/pkg/v10/resource/chartoperator/desired_test.go
@@ -1,4 +1,4 @@
-package chart
+package chartoperator
 
 import (
 	"context"

--- a/pkg/v10/resource/chartoperator/error.go
+++ b/pkg/v10/resource/chartoperator/error.go
@@ -1,4 +1,4 @@
-package chart
+package chartoperator
 
 import "github.com/giantswarm/microerror"
 

--- a/pkg/v10/resource/chartoperator/mock_test.go
+++ b/pkg/v10/resource/chartoperator/mock_test.go
@@ -1,4 +1,4 @@
-package chart
+package chartoperator
 
 import (
 	"context"

--- a/pkg/v10/resource/chartoperator/resource.go
+++ b/pkg/v10/resource/chartoperator/resource.go
@@ -96,16 +96,16 @@ func New(config Config) (*Resource, error) {
 	}
 
 	newResource := &Resource{
-		apprClient:        config.ApprClient,
-		baseClusterConfig: config.BaseClusterConfig,
-		clusterIPRange:    config.ClusterIPRange,
-		fs:                config.Fs,
-		g8sClient:         config.G8sClient,
-		k8sClient:         config.K8sClient,
-		logger:            config.Logger,
-		projectName:       config.ProjectName,
-		registryDomain:    config.RegistryDomain,
-		tenant:            config.Tenant,
+		apprClient:               config.ApprClient,
+		baseClusterConfig:        config.BaseClusterConfig,
+		clusterIPRange:           config.ClusterIPRange,
+		fs:                       config.Fs,
+		g8sClient:                config.G8sClient,
+		k8sClient:                config.K8sClient,
+		logger:                   config.Logger,
+		projectName:              config.ProjectName,
+		registryDomain:           config.RegistryDomain,
+		tenant:                   config.Tenant,
 		toClusterGuestConfigFunc: config.ToClusterGuestConfigFunc,
 	}
 

--- a/pkg/v10/resource/chartoperator/resource.go
+++ b/pkg/v10/resource/chartoperator/resource.go
@@ -1,4 +1,4 @@
-package chart
+package chartoperator
 
 import (
 	"context"
@@ -20,7 +20,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "chartv10"
+	Name = "chartoperatorv10"
 
 	chartOperatorChart         = "chart-operator-chart"
 	chartOperatorChannel       = "0-3-stable"
@@ -29,7 +29,7 @@ const (
 	chartOperatorDesiredStatus = "DEPLOYED"
 )
 
-// Config represents the configuration used to create a new chart config resource.
+// Config represents the configuration used to create a new chartoperator resource.
 type Config struct {
 	ApprClient               apprclient.Interface
 	BaseClusterConfig        cluster.Config
@@ -44,7 +44,7 @@ type Config struct {
 	ToClusterGuestConfigFunc func(obj interface{}) (v1alpha1.ClusterGuestConfig, error)
 }
 
-// Resource implements the chart resource.
+// Resource implements the chartoperator resource.
 type Resource struct {
 	apprClient               apprclient.Interface
 	baseClusterConfig        cluster.Config
@@ -59,7 +59,7 @@ type Resource struct {
 	toClusterGuestConfigFunc func(obj interface{}) (v1alpha1.ClusterGuestConfig, error)
 }
 
-// New creates a new configured chart resource.
+// New creates a new configured chartoperator resource.
 func New(config Config) (*Resource, error) {
 	if config.ApprClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ApprClient must not be empty", config)
@@ -96,16 +96,16 @@ func New(config Config) (*Resource, error) {
 	}
 
 	newResource := &Resource{
-		apprClient:               config.ApprClient,
-		baseClusterConfig:        config.BaseClusterConfig,
-		clusterIPRange:           config.ClusterIPRange,
-		fs:                       config.Fs,
-		g8sClient:                config.G8sClient,
-		k8sClient:                config.K8sClient,
-		logger:                   config.Logger,
-		projectName:              config.ProjectName,
-		registryDomain:           config.RegistryDomain,
-		tenant:                   config.Tenant,
+		apprClient:        config.ApprClient,
+		baseClusterConfig: config.BaseClusterConfig,
+		clusterIPRange:    config.ClusterIPRange,
+		fs:                config.Fs,
+		g8sClient:         config.G8sClient,
+		k8sClient:         config.K8sClient,
+		logger:            config.Logger,
+		projectName:       config.ProjectName,
+		registryDomain:    config.RegistryDomain,
+		tenant:            config.Tenant,
 		toClusterGuestConfigFunc: config.ToClusterGuestConfigFunc,
 	}
 

--- a/pkg/v10/resource/chartoperator/spec.go
+++ b/pkg/v10/resource/chartoperator/spec.go
@@ -1,4 +1,4 @@
-package chart
+package chartoperator
 
 // ResourceState holds the state of the chart to be reconciled.
 type ResourceState struct {

--- a/pkg/v10/resource/chartoperator/update.go
+++ b/pkg/v10/resource/chartoperator/update.go
@@ -1,4 +1,4 @@
-package chart
+package chartoperator
 
 import (
 	"context"

--- a/pkg/v10/resource/chartoperator/update_test.go
+++ b/pkg/v10/resource/chartoperator/update_test.go
@@ -1,4 +1,4 @@
-package chart
+package chartoperator
 
 import (
 	"context"

--- a/service/controller/aws/v10/resource_set.go
+++ b/service/controller/aws/v10/resource_set.go
@@ -22,7 +22,7 @@ import (
 	chartconfigservice "github.com/giantswarm/cluster-operator/pkg/v10/chartconfig"
 	configmapservice "github.com/giantswarm/cluster-operator/pkg/v10/configmap"
 	"github.com/giantswarm/cluster-operator/pkg/v10/resource/certconfig"
-	"github.com/giantswarm/cluster-operator/pkg/v10/resource/chart"
+	"github.com/giantswarm/cluster-operator/pkg/v10/resource/chartoperator"
 	"github.com/giantswarm/cluster-operator/pkg/v10/resource/encryptionkey"
 	"github.com/giantswarm/cluster-operator/pkg/v10/resource/namespace"
 	"github.com/giantswarm/cluster-operator/service/controller/aws/v10/key"
@@ -146,10 +146,10 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var namespaceResource controller.Resource
 	{
 		c := namespace.Config{
-			BaseClusterConfig:        *config.BaseClusterConfig,
-			Logger:                   config.Logger,
-			ProjectName:              config.ProjectName,
-			Tenant:                   tenantClusterService,
+			BaseClusterConfig: *config.BaseClusterConfig,
+			Logger:            config.Logger,
+			ProjectName:       config.ProjectName,
+			Tenant:            tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -165,28 +165,28 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		}
 	}
 
-	var chartResource controller.Resource
+	var chartOperatorResource controller.Resource
 	{
-		c := chart.Config{
-			ApprClient:               config.ApprClient,
-			BaseClusterConfig:        *config.BaseClusterConfig,
-			ClusterIPRange:           config.ClusterIPRange,
-			Fs:                       config.Fs,
-			G8sClient:                config.G8sClient,
-			K8sClient:                config.K8sClient,
-			Logger:                   config.Logger,
-			ProjectName:              config.ProjectName,
-			RegistryDomain:           config.RegistryDomain,
-			Tenant:                   tenantClusterService,
+		c := chartoperator.Config{
+			ApprClient:        config.ApprClient,
+			BaseClusterConfig: *config.BaseClusterConfig,
+			ClusterIPRange:    config.ClusterIPRange,
+			Fs:                config.Fs,
+			G8sClient:         config.G8sClient,
+			K8sClient:         config.K8sClient,
+			Logger:            config.Logger,
+			ProjectName:       config.ProjectName,
+			RegistryDomain:    config.RegistryDomain,
+			Tenant:            tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 		}
 
-		ops, err := chart.New(c)
+		ops, err := chartoperator.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 
-		chartResource, err = toCRUDResource(config.Logger, ops)
+		chartOperatorResource, err = toCRUDResource(config.Logger, ops)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -273,10 +273,10 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		encryptionKeyResource,
 		certConfigResource,
 		awsConfigResource,
-		// namespace, chart, configmap and chartconfig resources manage resources in
-		// guest clusters so they should be executed last.
+		// namespace, chartoperator, configmap and chartconfig resources manage
+		// resources in tenant clusters so they should be executed last.
 		namespaceResource,
-		chartResource,
+		chartOperatorResource,
 		configMapResource,
 		chartConfigResource,
 	}

--- a/service/controller/aws/v10/resource_set.go
+++ b/service/controller/aws/v10/resource_set.go
@@ -146,10 +146,10 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var namespaceResource controller.Resource
 	{
 		c := namespace.Config{
-			BaseClusterConfig: *config.BaseClusterConfig,
-			Logger:            config.Logger,
-			ProjectName:       config.ProjectName,
-			Tenant:            tenantClusterService,
+			BaseClusterConfig:        *config.BaseClusterConfig,
+			Logger:                   config.Logger,
+			ProjectName:              config.ProjectName,
+			Tenant:                   tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -168,16 +168,16 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var chartOperatorResource controller.Resource
 	{
 		c := chartoperator.Config{
-			ApprClient:        config.ApprClient,
-			BaseClusterConfig: *config.BaseClusterConfig,
-			ClusterIPRange:    config.ClusterIPRange,
-			Fs:                config.Fs,
-			G8sClient:         config.G8sClient,
-			K8sClient:         config.K8sClient,
-			Logger:            config.Logger,
-			ProjectName:       config.ProjectName,
-			RegistryDomain:    config.RegistryDomain,
-			Tenant:            tenantClusterService,
+			ApprClient:               config.ApprClient,
+			BaseClusterConfig:        *config.BaseClusterConfig,
+			ClusterIPRange:           config.ClusterIPRange,
+			Fs:                       config.Fs,
+			G8sClient:                config.G8sClient,
+			K8sClient:                config.K8sClient,
+			Logger:                   config.Logger,
+			ProjectName:              config.ProjectName,
+			RegistryDomain:           config.RegistryDomain,
+			Tenant:                   tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 		}
 

--- a/service/controller/azure/v10/resource_set.go
+++ b/service/controller/azure/v10/resource_set.go
@@ -146,10 +146,10 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var namespaceResource controller.Resource
 	{
 		c := namespace.Config{
-			BaseClusterConfig: *config.BaseClusterConfig,
-			Logger:            config.Logger,
-			ProjectName:       config.ProjectName,
-			Tenant:            tenantClusterService,
+			BaseClusterConfig:        *config.BaseClusterConfig,
+			Logger:                   config.Logger,
+			ProjectName:              config.ProjectName,
+			Tenant:                   tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -168,16 +168,16 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var chartOperatorResource controller.Resource
 	{
 		c := chartoperator.Config{
-			ApprClient:        config.ApprClient,
-			BaseClusterConfig: *config.BaseClusterConfig,
-			ClusterIPRange:    config.ClusterIPRange,
-			Fs:                config.Fs,
-			G8sClient:         config.G8sClient,
-			K8sClient:         config.K8sClient,
-			Logger:            config.Logger,
-			ProjectName:       config.ProjectName,
-			RegistryDomain:    config.RegistryDomain,
-			Tenant:            tenantClusterService,
+			ApprClient:               config.ApprClient,
+			BaseClusterConfig:        *config.BaseClusterConfig,
+			ClusterIPRange:           config.ClusterIPRange,
+			Fs:                       config.Fs,
+			G8sClient:                config.G8sClient,
+			K8sClient:                config.K8sClient,
+			Logger:                   config.Logger,
+			ProjectName:              config.ProjectName,
+			RegistryDomain:           config.RegistryDomain,
+			Tenant:                   tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 		}
 

--- a/service/controller/azure/v10/resource_set.go
+++ b/service/controller/azure/v10/resource_set.go
@@ -22,7 +22,7 @@ import (
 	chartconfigservice "github.com/giantswarm/cluster-operator/pkg/v10/chartconfig"
 	configmapservice "github.com/giantswarm/cluster-operator/pkg/v10/configmap"
 	"github.com/giantswarm/cluster-operator/pkg/v10/resource/certconfig"
-	"github.com/giantswarm/cluster-operator/pkg/v10/resource/chart"
+	"github.com/giantswarm/cluster-operator/pkg/v10/resource/chartoperator"
 	"github.com/giantswarm/cluster-operator/pkg/v10/resource/encryptionkey"
 	"github.com/giantswarm/cluster-operator/pkg/v10/resource/namespace"
 	"github.com/giantswarm/cluster-operator/service/controller/azure/v10/key"
@@ -146,10 +146,10 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var namespaceResource controller.Resource
 	{
 		c := namespace.Config{
-			BaseClusterConfig:        *config.BaseClusterConfig,
-			Logger:                   config.Logger,
-			ProjectName:              config.ProjectName,
-			Tenant:                   tenantClusterService,
+			BaseClusterConfig: *config.BaseClusterConfig,
+			Logger:            config.Logger,
+			ProjectName:       config.ProjectName,
+			Tenant:            tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -165,28 +165,28 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		}
 	}
 
-	var chartResource controller.Resource
+	var chartOperatorResource controller.Resource
 	{
-		c := chart.Config{
-			ApprClient:               config.ApprClient,
-			BaseClusterConfig:        *config.BaseClusterConfig,
-			ClusterIPRange:           config.ClusterIPRange,
-			Fs:                       config.Fs,
-			G8sClient:                config.G8sClient,
-			K8sClient:                config.K8sClient,
-			Logger:                   config.Logger,
-			ProjectName:              config.ProjectName,
-			RegistryDomain:           config.RegistryDomain,
-			Tenant:                   tenantClusterService,
+		c := chartoperator.Config{
+			ApprClient:        config.ApprClient,
+			BaseClusterConfig: *config.BaseClusterConfig,
+			ClusterIPRange:    config.ClusterIPRange,
+			Fs:                config.Fs,
+			G8sClient:         config.G8sClient,
+			K8sClient:         config.K8sClient,
+			Logger:            config.Logger,
+			ProjectName:       config.ProjectName,
+			RegistryDomain:    config.RegistryDomain,
+			Tenant:            tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 		}
 
-		ops, err := chart.New(c)
+		ops, err := chartoperator.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 
-		chartResource, err = toCRUDResource(config.Logger, ops)
+		chartOperatorResource, err = toCRUDResource(config.Logger, ops)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -273,10 +273,10 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		encryptionKeyResource,
 		certConfigResource,
 		azureConfigResource,
-		// namespace, chart, configmap and chartconfig resources manage resources
-		// in guest clusters so they should be executed last.
+		// namespace, chartoperator, configmap and chartconfig resources manage
+		// resources in tenant clusters so they should be executed last.
 		namespaceResource,
-		chartResource,
+		chartOperatorResource,
 		configMapResource,
 		chartConfigResource,
 	}

--- a/service/controller/kvm/v10/resource_set.go
+++ b/service/controller/kvm/v10/resource_set.go
@@ -145,10 +145,10 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var namespaceResource controller.Resource
 	{
 		c := namespace.Config{
-			BaseClusterConfig: *config.BaseClusterConfig,
-			Logger:            config.Logger,
-			ProjectName:       config.ProjectName,
-			Tenant:            tenantClusterService,
+			BaseClusterConfig:        *config.BaseClusterConfig,
+			Logger:                   config.Logger,
+			ProjectName:              config.ProjectName,
+			Tenant:                   tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -167,16 +167,16 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var chartOperatorResource controller.Resource
 	{
 		c := chartoperator.Config{
-			ApprClient:        config.ApprClient,
-			BaseClusterConfig: *config.BaseClusterConfig,
-			ClusterIPRange:    config.ClusterIPRange,
-			Fs:                config.Fs,
-			G8sClient:         config.G8sClient,
-			K8sClient:         config.K8sClient,
-			Logger:            config.Logger,
-			ProjectName:       config.ProjectName,
-			RegistryDomain:    config.RegistryDomain,
-			Tenant:            tenantClusterService,
+			ApprClient:               config.ApprClient,
+			BaseClusterConfig:        *config.BaseClusterConfig,
+			ClusterIPRange:           config.ClusterIPRange,
+			Fs:                       config.Fs,
+			G8sClient:                config.G8sClient,
+			K8sClient:                config.K8sClient,
+			Logger:                   config.Logger,
+			ProjectName:              config.ProjectName,
+			RegistryDomain:           config.RegistryDomain,
+			Tenant:                   tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 		}
 

--- a/service/controller/kvm/v10/resource_set.go
+++ b/service/controller/kvm/v10/resource_set.go
@@ -22,7 +22,7 @@ import (
 	chartconfigservice "github.com/giantswarm/cluster-operator/pkg/v10/chartconfig"
 	configmapservice "github.com/giantswarm/cluster-operator/pkg/v10/configmap"
 	"github.com/giantswarm/cluster-operator/pkg/v10/resource/certconfig"
-	"github.com/giantswarm/cluster-operator/pkg/v10/resource/chart"
+	"github.com/giantswarm/cluster-operator/pkg/v10/resource/chartoperator"
 	"github.com/giantswarm/cluster-operator/pkg/v10/resource/encryptionkey"
 	"github.com/giantswarm/cluster-operator/pkg/v10/resource/namespace"
 	"github.com/giantswarm/cluster-operator/service/controller/kvm/v10/key"
@@ -145,10 +145,10 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var namespaceResource controller.Resource
 	{
 		c := namespace.Config{
-			BaseClusterConfig:        *config.BaseClusterConfig,
-			Logger:                   config.Logger,
-			ProjectName:              config.ProjectName,
-			Tenant:                   tenantClusterService,
+			BaseClusterConfig: *config.BaseClusterConfig,
+			Logger:            config.Logger,
+			ProjectName:       config.ProjectName,
+			Tenant:            tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -164,28 +164,28 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		}
 	}
 
-	var chartResource controller.Resource
+	var chartOperatorResource controller.Resource
 	{
-		c := chart.Config{
-			ApprClient:               config.ApprClient,
-			BaseClusterConfig:        *config.BaseClusterConfig,
-			ClusterIPRange:           config.ClusterIPRange,
-			Fs:                       config.Fs,
-			G8sClient:                config.G8sClient,
-			K8sClient:                config.K8sClient,
-			Logger:                   config.Logger,
-			ProjectName:              config.ProjectName,
-			RegistryDomain:           config.RegistryDomain,
-			Tenant:                   tenantClusterService,
+		c := chartoperator.Config{
+			ApprClient:        config.ApprClient,
+			BaseClusterConfig: *config.BaseClusterConfig,
+			ClusterIPRange:    config.ClusterIPRange,
+			Fs:                config.Fs,
+			G8sClient:         config.G8sClient,
+			K8sClient:         config.K8sClient,
+			Logger:            config.Logger,
+			ProjectName:       config.ProjectName,
+			RegistryDomain:    config.RegistryDomain,
+			Tenant:            tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 		}
 
-		ops, err := chart.New(c)
+		ops, err := chartoperator.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 
-		chartResource, err = toCRUDResource(config.Logger, ops)
+		chartOperatorResource, err = toCRUDResource(config.Logger, ops)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -272,10 +272,10 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		encryptionKeyResource,
 		certConfigResource,
 		kvmConfigResource,
-		// namespace, chart, configmap and chartconfig resources manage resources in
-		// guest clusters so they should be executed last.
+		// namespace, chartoperator, configmap and chartconfig resources manage
+		// resources in tenant clusters so they should be executed last.
 		namespaceResource,
-		chartResource,
+		chartOperatorResource,
 		configMapResource,
 		chartConfigResource,
 	}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5218

Some prep for the linked PM. As @xh3b4sd pointed out the name of the `chart` resource should be `chartoperator`.  As its job is to bootstrap chart-operator in tenant clusters.

The name is also confusing now we have chartconfig and chart CRDs.
