### PR TITLE
Move CoreDNS chartconfig to common key package

### DIFF
--- a/pkg/v10/chartconfig/desired_test.go
+++ b/pkg/v10/chartconfig/desired_test.go
@@ -19,6 +19,7 @@ import (
 func Test_ChartConfig_GetDesiredState(t *testing.T) {
 	commonChartConfigNames := []string{
 		"cert-exporter-chart",
+		"kubernetes-coredns-chart",
 		"kubernetes-kube-state-metrics-chart",
 		"kubernetes-metrics-server-chart",
 		"kubernetes-nginx-ingress-controller-chart",

--- a/pkg/v10/configmap/desired_test.go
+++ b/pkg/v10/configmap/desired_test.go
@@ -315,7 +315,7 @@ func Test_ConfigMap_newConfigMap(t *testing.T) {
 				Name:      "test-app-values",
 				Namespace: metav1.NamespaceSystem,
 				Labels: map[string]string{
-					"app": "test-app",
+					"app":                   "test-app",
 					"giantswarm.io/cluster": "5xchu",
 				},
 			},
@@ -324,7 +324,7 @@ func Test_ConfigMap_newConfigMap(t *testing.T) {
 					Name:      "test-app-values",
 					Namespace: metav1.NamespaceSystem,
 					Labels: map[string]string{
-						"app": "test-app",
+						"app":                   "test-app",
 						"giantswarm.io/cluster": "5xchu",
 					},
 				},
@@ -338,7 +338,7 @@ func Test_ConfigMap_newConfigMap(t *testing.T) {
 				Name:      "test-app-values",
 				Namespace: metav1.NamespaceSystem,
 				Labels: map[string]string{
-					"app": "test-app",
+					"app":                   "test-app",
 					"giantswarm.io/cluster": "5xchu",
 				},
 				ValuesJSON: "{\"image\":{\"registry\":\"quay.io\"}}",
@@ -348,7 +348,7 @@ func Test_ConfigMap_newConfigMap(t *testing.T) {
 					Name:      "test-app-values",
 					Namespace: metav1.NamespaceSystem,
 					Labels: map[string]string{
-						"app": "test-app",
+						"app":                   "test-app",
 						"giantswarm.io/cluster": "5xchu",
 					},
 				},

--- a/pkg/v10/configmap/desired_test.go
+++ b/pkg/v10/configmap/desired_test.go
@@ -135,6 +135,14 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 			Namespace: metav1.NamespaceSystem,
 		},
 		{
+			Name:      "coredns-values",
+			Namespace: metav1.NamespaceSystem,
+		},
+		{
+			Name:      "coredns-user-values",
+			Namespace: metav1.NamespaceSystem,
+		},
+		{
 			Name:      "kube-state-metrics-values",
 			Namespace: metav1.NamespaceSystem,
 		},
@@ -175,7 +183,10 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 				Namespaces: []string{},
 			},
 			configMapValues: ConfigMapValues{
-				ClusterID:    "5xchu",
+				ClusterID: "5xchu",
+				CoreDNS: CoreDNSValues{
+					ClusterIPRange: "172.20.0.0/16",
+				},
 				Organization: "giantswarm",
 				WorkerCount:  3,
 			},
@@ -189,7 +200,10 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 				Namespaces: []string{},
 			},
 			configMapValues: ConfigMapValues{
-				ClusterID:    "5xchu",
+				ClusterID: "5xchu",
+				CoreDNS: CoreDNSValues{
+					ClusterIPRange: "172.20.0.0/16",
+				},
 				Organization: "giantswarm",
 				WorkerCount:  7,
 			},
@@ -210,7 +224,10 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 				Namespaces: []string{},
 			},
 			configMapValues: ConfigMapValues{
-				ClusterID:    "5xchu",
+				ClusterID: "5xchu",
+				CoreDNS: CoreDNSValues{
+					ClusterIPRange: "172.20.0.0/16",
+				},
 				Organization: "giantswarm",
 				WorkerCount:  7,
 			},
@@ -298,7 +315,7 @@ func Test_ConfigMap_newConfigMap(t *testing.T) {
 				Name:      "test-app-values",
 				Namespace: metav1.NamespaceSystem,
 				Labels: map[string]string{
-					"app":                   "test-app",
+					"app": "test-app",
 					"giantswarm.io/cluster": "5xchu",
 				},
 			},
@@ -307,7 +324,7 @@ func Test_ConfigMap_newConfigMap(t *testing.T) {
 					Name:      "test-app-values",
 					Namespace: metav1.NamespaceSystem,
 					Labels: map[string]string{
-						"app":                   "test-app",
+						"app": "test-app",
 						"giantswarm.io/cluster": "5xchu",
 					},
 				},
@@ -321,7 +338,7 @@ func Test_ConfigMap_newConfigMap(t *testing.T) {
 				Name:      "test-app-values",
 				Namespace: metav1.NamespaceSystem,
 				Labels: map[string]string{
-					"app":                   "test-app",
+					"app": "test-app",
 					"giantswarm.io/cluster": "5xchu",
 				},
 				ValuesJSON: "{\"image\":{\"registry\":\"quay.io\"}}",
@@ -331,7 +348,7 @@ func Test_ConfigMap_newConfigMap(t *testing.T) {
 					Name:      "test-app-values",
 					Namespace: metav1.NamespaceSystem,
 					Labels: map[string]string{
-						"app":                   "test-app",
+						"app": "test-app",
 						"giantswarm.io/cluster": "5xchu",
 					},
 				},

--- a/pkg/v10/key/key.go
+++ b/pkg/v10/key/key.go
@@ -63,6 +63,15 @@ func ClusterOrganization(clusterGuestConfig v1alpha1.ClusterGuestConfig) string 
 func CommonChartSpecs() []ChartSpec {
 	return []ChartSpec{
 		{
+			AppName:           "coredns",
+			ChannelName:       "0-2-stable",
+			ChartName:         "kubernetes-coredns-chart",
+			ConfigMapName:     "coredns-values",
+			Namespace:         metav1.NamespaceSystem,
+			ReleaseName:       "coredns",
+			UserConfigMapName: "coredns-user-values",
+		},
+		{
 			AppName:       "cert-exporter",
 			ChannelName:   "stable",
 			ChartName:     "cert-exporter-chart",

--- a/service/controller/aws/v10/key/key.go
+++ b/service/controller/aws/v10/key/key.go
@@ -13,15 +13,6 @@ func ChartSpecs() []key.ChartSpec {
 	// Add any provider specific charts here.
 	return []key.ChartSpec{
 		{
-			AppName:           "coredns",
-			ChannelName:       "0-2-stable",
-			ChartName:         "kubernetes-coredns-chart",
-			ConfigMapName:     "coredns-values",
-			Namespace:         metav1.NamespaceSystem,
-			ReleaseName:       "coredns",
-			UserConfigMapName: "coredns-user-values",
-		},
-		{
 			AppName:           "cluster-autoscaler",
 			ChannelName:       "0-2-stable",
 			ChartName:         "kubernetes-cluster-autoscaler-chart",

--- a/service/controller/azure/v10/key/key.go
+++ b/service/controller/azure/v10/key/key.go
@@ -18,15 +18,6 @@ func ChartSpecs() []key.ChartSpec {
 			Namespace:   metav1.NamespaceSystem,
 			ReleaseName: "external-dns",
 		},
-		{
-			AppName:           "coredns",
-			ChannelName:       "0-2-stable",
-			ChartName:         "kubernetes-coredns-chart",
-			ConfigMapName:     "coredns-values",
-			Namespace:         metav1.NamespaceSystem,
-			ReleaseName:       "coredns",
-			UserConfigMapName: "coredns-user-values",
-		},
 	}
 }
 

--- a/service/controller/kvm/v10/key/key.go
+++ b/service/controller/kvm/v10/key/key.go
@@ -3,7 +3,6 @@ package key
 import (
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/microerror"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/cluster-operator/pkg/v10/key"
 )
@@ -11,17 +10,7 @@ import (
 // ChartSpecs returns charts installed only for KVM.
 func ChartSpecs() []key.ChartSpec {
 	// Add any provider specific charts here.
-	return []key.ChartSpec{
-		{
-			AppName:           "coredns",
-			ChannelName:       "0-2-stable",
-			ChartName:         "kubernetes-coredns-chart",
-			ConfigMapName:     "coredns-values",
-			Namespace:         metav1.NamespaceSystem,
-			ReleaseName:       "coredns",
-			UserConfigMapName: "coredns-user-values",
-		},
-	}
+	return []key.ChartSpec{}
 }
 
 // ClusterGuestConfig extracts ClusterGuestConfig from KVMClusterConfig.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5218

Some more cleanup. CoreDNS is enabled for all providers. So it should be under the shared key function in pkg.

This is the current solution until we move cluster apps to be part of the release CR in the next phase of the app catalog migration.