### PR TITLE
Add tiller resource

### DIFF
--- a/pkg/v11/resource/chartoperator/resource.go
+++ b/pkg/v11/resource/chartoperator/resource.go
@@ -138,11 +138,6 @@ func (r *Resource) getTenantHelmClient(ctx context.Context, obj interface{}) (he
 		return nil, microerror.Mask(err)
 	}
 
-	err = tenantHelmClient.EnsureTillerInstalled(ctx)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
 	return tenantHelmClient, nil
 }
 

--- a/pkg/v11/resource/tiller/create.go
+++ b/pkg/v11/resource/tiller/create.go
@@ -1,0 +1,21 @@
+package tiller
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	clusterGuestConfig, err := r.toClusterGuestConfigFunc(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.ensureTillerInstalled(ctx, clusterGuestConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/pkg/v11/resource/tiller/delete.go
+++ b/pkg/v11/resource/tiller/delete.go
@@ -1,0 +1,21 @@
+package tiller
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	clusterGuestConfig, err := r.toClusterGuestConfigFunc(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.ensureTillerInstalled(ctx, clusterGuestConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/pkg/v11/resource/tiller/error.go
+++ b/pkg/v11/resource/tiller/error.go
@@ -1,0 +1,14 @@
+package tiller
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/pkg/v11/resource/tiller/resource.go
+++ b/pkg/v11/resource/tiller/resource.go
@@ -52,9 +52,9 @@ func New(config Config) (*Resource, error) {
 	}
 
 	r := &Resource{
-		baseClusterConfig: config.BaseClusterConfig,
-		logger:            config.Logger,
-		tenant:            config.Tenant,
+		baseClusterConfig:        config.BaseClusterConfig,
+		logger:                   config.Logger,
+		tenant:                   config.Tenant,
 		toClusterGuestConfigFunc: config.ToClusterGuestConfigFunc,
 	}
 

--- a/pkg/v11/resource/tiller/resource.go
+++ b/pkg/v11/resource/tiller/resource.go
@@ -9,7 +9,7 @@ import (
 	"github.com/giantswarm/helmclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
 	"github.com/giantswarm/tenantcluster"
 
 	"github.com/giantswarm/cluster-operator/pkg/cluster"
@@ -91,8 +91,8 @@ func (r *Resource) ensureTillerInstalled(ctx context.Context, clusterGuestConfig
 		// for the current guest cluster was not found. We can't continue
 		// without a Helm client. We will retry during the next execution, when
 		// the certificate might be available.
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+		reconciliationcanceledcontext.SetCanceled(ctx)
 
 		return nil
 	} else if helmclient.IsTillerInstallationFailed(err) {
@@ -100,8 +100,8 @@ func (r *Resource) ensureTillerInstalled(ctx context.Context, clusterGuestConfig
 
 		// Tiller installation can fail during guest cluster setup. We will
 		// retry on next reconciliation loop.
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+		reconciliationcanceledcontext.SetCanceled(ctx)
 
 		return nil
 	} else if guest.IsAPINotAvailable(err) {
@@ -110,8 +110,8 @@ func (r *Resource) ensureTillerInstalled(ctx context.Context, clusterGuestConfig
 		// We should not hammer guest API if it is not available, the guest
 		// cluster might be initializing. We will retry on next reconciliation
 		// loop.
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+		reconciliationcanceledcontext.SetCanceled(ctx)
 
 		return nil
 	} else if err != nil {

--- a/pkg/v11/resource/tiller/resource.go
+++ b/pkg/v11/resource/tiller/resource.go
@@ -52,41 +52,13 @@ func New(config Config) (*Resource, error) {
 	}
 
 	r := &Resource{
-		baseClusterConfig:        config.BaseClusterConfig,
-		logger:                   config.Logger,
-		tenant:                   config.Tenant,
+		baseClusterConfig: config.BaseClusterConfig,
+		logger:            config.Logger,
+		tenant:            config.Tenant,
 		toClusterGuestConfigFunc: config.ToClusterGuestConfigFunc,
 	}
 
 	return r, nil
-}
-
-func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
-	clusterGuestConfig, err := r.toClusterGuestConfigFunc(obj)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	err = r.ensureTillerInstalled(ctx, clusterGuestConfig)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	return nil
-}
-
-func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
-	clusterGuestConfig, err := r.toClusterGuestConfigFunc(obj)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	err = r.ensureTillerInstalled(ctx, clusterGuestConfig)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	return nil
 }
 
 func (r *Resource) Name() string {

--- a/pkg/v11/resource/tiller/tiller.go
+++ b/pkg/v11/resource/tiller/tiller.go
@@ -1,0 +1,168 @@
+package tiller
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/errors/guest"
+	"github.com/giantswarm/helmclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	"github.com/giantswarm/tenantcluster"
+
+	"github.com/giantswarm/cluster-operator/pkg/cluster"
+	"github.com/giantswarm/cluster-operator/pkg/v10/key"
+)
+
+const (
+	Name = "tillerv11"
+)
+
+// Config represents the configuration used to create a new tiller resource.
+type Config struct {
+	BaseClusterConfig        cluster.Config
+	Logger                   micrologger.Logger
+	Tenant                   tenantcluster.Interface
+	ToClusterGuestConfigFunc func(obj interface{}) (v1alpha1.ClusterGuestConfig, error)
+}
+
+// Resource implements the tiller resource.
+type Resource struct {
+	baseClusterConfig        cluster.Config
+	logger                   micrologger.Logger
+	tenant                   tenantcluster.Interface
+	toClusterGuestConfigFunc func(obj interface{}) (v1alpha1.ClusterGuestConfig, error)
+}
+
+// New creates a new configured tiller resource.
+func New(config Config) (*Resource, error) {
+	if reflect.DeepEqual(config.BaseClusterConfig, cluster.Config{}) {
+		return nil, microerror.Maskf(invalidConfigError, "%T.BaseClusterConfig must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Tenant == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Tenant must not be empty", config)
+	}
+	if config.ToClusterGuestConfigFunc == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ToClusterGuestConfigFunc must not be empty", config)
+	}
+
+	r := &Resource{
+		baseClusterConfig:        config.BaseClusterConfig,
+		logger:                   config.Logger,
+		tenant:                   config.Tenant,
+		toClusterGuestConfigFunc: config.ToClusterGuestConfigFunc,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	clusterGuestConfig, err := r.toClusterGuestConfigFunc(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.ensureTillerInstalled(ctx, clusterGuestConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	clusterGuestConfig, err := r.toClusterGuestConfigFunc(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.ensureTillerInstalled(ctx, clusterGuestConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func (r *Resource) ensureTillerInstalled(ctx context.Context, clusterGuestConfig v1alpha1.ClusterGuestConfig) error {
+	r.logger.LogCtx(ctx, "level", "debug", "message", "ensuring tiller is installed")
+
+	clusterConfig, err := prepareClusterConfig(r.baseClusterConfig, clusterGuestConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	tenantAPIDomain, err := key.APIDomain(clusterGuestConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	tenantHelmClient, err := r.tenant.NewHelmClient(ctx, clusterConfig.ClusterID, tenantAPIDomain)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = tenantHelmClient.EnsureTillerInstalled(ctx)
+	if tenantcluster.IsTimeout(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "timeout fetching certificates")
+
+		// A timeout error here means that the cluster-operator certificate
+		// for the current guest cluster was not found. We can't continue
+		// without a Helm client. We will retry during the next execution, when
+		// the certificate might be available.
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+
+		return nil
+	} else if helmclient.IsTillerInstallationFailed(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "Tiller installation failed")
+
+		// Tiller installation can fail during guest cluster setup. We will
+		// retry on next reconciliation loop.
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+
+		return nil
+	} else if guest.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "guest API not available")
+
+		// We should not hammer guest API if it is not available, the guest
+		// cluster might be initializing. We will retry on next reconciliation
+		// loop.
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "ensured tiller is installed")
+
+	return nil
+}
+
+func prepareClusterConfig(baseClusterConfig cluster.Config, clusterGuestConfig v1alpha1.ClusterGuestConfig) (cluster.Config, error) {
+	var err error
+
+	// Use baseClusterConfig as a basis and supplement it with information from
+	// clusterGuestConfig.
+	clusterConfig := baseClusterConfig
+
+	clusterConfig.ClusterID = key.ClusterID(clusterGuestConfig)
+	clusterConfig.Domain.API, err = key.APIDomain(clusterGuestConfig)
+	if err != nil {
+		return cluster.Config{}, microerror.Mask(err)
+	}
+
+	return clusterConfig, nil
+}

--- a/service/controller/aws/v11/resource_set.go
+++ b/service/controller/aws/v11/resource_set.go
@@ -25,6 +25,7 @@ import (
 	"github.com/giantswarm/cluster-operator/pkg/v11/resource/chartoperator"
 	"github.com/giantswarm/cluster-operator/pkg/v11/resource/encryptionkey"
 	"github.com/giantswarm/cluster-operator/pkg/v11/resource/namespace"
+	"github.com/giantswarm/cluster-operator/pkg/v11/resource/tiller"
 	"github.com/giantswarm/cluster-operator/service/controller/aws/v11/key"
 	"github.com/giantswarm/cluster-operator/service/controller/aws/v11/resource/awsconfig"
 	"github.com/giantswarm/cluster-operator/service/controller/aws/v11/resource/chartconfig"
@@ -266,6 +267,21 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		}
 	}
 
+	var tillerResource controller.Resource
+	{
+		c := tiller.Config{
+			BaseClusterConfig:        *config.BaseClusterConfig,
+			Logger:                   config.Logger,
+			Tenant:                   tenantClusterService,
+			ToClusterGuestConfigFunc: toClusterGuestConfig,
+		}
+
+		tillerResource, err = tiller.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	resources := []controller.Resource{
 		// Put encryptionKeyResource first because it executes faster than
 		// awsConfigResource and could introduce dependency during cluster
@@ -273,9 +289,10 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		encryptionKeyResource,
 		certConfigResource,
 		awsConfigResource,
-		// namespace, chartoperator, configmap and chartconfig resources manage
-		// resources in tenant clusters so they should be executed last.
+		// Following resources manage resources in tenant clusters so they
+		// should be executed last.
 		namespaceResource,
+		tillerResource,
 		chartOperatorResource,
 		configMapResource,
 		chartConfigResource,

--- a/service/controller/azure/v11/resource_set.go
+++ b/service/controller/azure/v11/resource_set.go
@@ -25,6 +25,7 @@ import (
 	"github.com/giantswarm/cluster-operator/pkg/v11/resource/chartoperator"
 	"github.com/giantswarm/cluster-operator/pkg/v11/resource/encryptionkey"
 	"github.com/giantswarm/cluster-operator/pkg/v11/resource/namespace"
+	"github.com/giantswarm/cluster-operator/pkg/v11/resource/tiller"
 	"github.com/giantswarm/cluster-operator/service/controller/azure/v11/key"
 	"github.com/giantswarm/cluster-operator/service/controller/azure/v11/resource/azureconfig"
 	"github.com/giantswarm/cluster-operator/service/controller/azure/v11/resource/chartconfig"
@@ -266,6 +267,21 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		}
 	}
 
+	var tillerResource controller.Resource
+	{
+		c := tiller.Config{
+			BaseClusterConfig:        *config.BaseClusterConfig,
+			Logger:                   config.Logger,
+			Tenant:                   tenantClusterService,
+			ToClusterGuestConfigFunc: toClusterGuestConfig,
+		}
+
+		tillerResource, err = tiller.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	resources := []controller.Resource{
 		// Put encryptionKeyResource first because it executes faster than
 		// azureConfigResource and could introduce dependency during cluster
@@ -273,9 +289,10 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		encryptionKeyResource,
 		certConfigResource,
 		azureConfigResource,
-		// namespace, chartoperator, configmap and chartconfig resources manage
-		// resources in tenant clusters so they should be executed last.
+		// Following resources manage resources in tenant clusters so they
+		// should be executed last
 		namespaceResource,
+		tillerResource,
 		chartOperatorResource,
 		configMapResource,
 		chartConfigResource,


### PR DESCRIPTION
Adds the `tiller` resource and removes calling `EnsureTillerInstalled` from the `chartoperator` resource. This means we only call `EnsureTillerInstalled` once per reconciliation loop.