### PR TITLE
On delete cancel resources that interact with tenant clusters

### DIFF
--- a/pkg/v11/resource/chartoperator/create_test.go
+++ b/pkg/v11/resource/chartoperator/create_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/giantswarm/helmclient/helmclienttest"
 	"github.com/giantswarm/micrologger/microloggertest"
 	"github.com/spf13/afero"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientgofake "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/giantswarm/cluster-operator/pkg/cluster"
@@ -97,6 +98,9 @@ func Test_Resource_Chart_newCreate(t *testing.T) {
 				},
 				ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
 					return v.(v1alpha1.ClusterGuestConfig), nil
+				},
+				ToClusterObjectMetaFunc: func(v interface{}) (metav1.ObjectMeta, error) {
+					return metav1.ObjectMeta{}, nil
 				},
 			}
 

--- a/pkg/v11/resource/chartoperator/current_test.go
+++ b/pkg/v11/resource/chartoperator/current_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/giantswarm/helmclient/helmclienttest"
 	"github.com/giantswarm/micrologger/microloggertest"
 	"github.com/spf13/afero"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientgofake "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/giantswarm/cluster-operator/pkg/cluster"
@@ -134,6 +135,9 @@ func Test_Chart_GetCurrentState(t *testing.T) {
 				},
 				ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
 					return v.(v1alpha1.ClusterGuestConfig), nil
+				},
+				ToClusterObjectMetaFunc: func(v interface{}) (metav1.ObjectMeta, error) {
+					return metav1.ObjectMeta{}, nil
 				},
 			}
 

--- a/pkg/v11/resource/chartoperator/delete_test.go
+++ b/pkg/v11/resource/chartoperator/delete_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/giantswarm/helmclient/helmclienttest"
 	"github.com/giantswarm/micrologger/microloggertest"
 	"github.com/spf13/afero"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientgofake "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/giantswarm/cluster-operator/pkg/cluster"
@@ -97,6 +98,9 @@ func Test_Resource_Chart_newDelete(t *testing.T) {
 				},
 				ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
 					return v.(v1alpha1.ClusterGuestConfig), nil
+				},
+				ToClusterObjectMetaFunc: func(v interface{}) (metav1.ObjectMeta, error) {
+					return metav1.ObjectMeta{}, nil
 				},
 			}
 

--- a/pkg/v11/resource/chartoperator/desired_test.go
+++ b/pkg/v11/resource/chartoperator/desired_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/giantswarm/apprclient/apprclienttest"
 	"github.com/giantswarm/micrologger/microloggertest"
 	"github.com/spf13/afero"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientgofake "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/giantswarm/cluster-operator/pkg/cluster"
@@ -64,6 +65,9 @@ func Test_Chart_GetDesiredState(t *testing.T) {
 				Tenant:         &tenantMock{},
 				ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
 					return v.(v1alpha1.ClusterGuestConfig), nil
+				},
+				ToClusterObjectMetaFunc: func(v interface{}) (metav1.ObjectMeta, error) {
+					return metav1.ObjectMeta{}, nil
 				},
 			}
 

--- a/pkg/v11/resource/chartoperator/resource.go
+++ b/pkg/v11/resource/chartoperator/resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/tenantcluster"
 	"github.com/spf13/afero"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/giantswarm/cluster-operator/pkg/cluster"
@@ -42,6 +43,7 @@ type Config struct {
 	RegistryDomain           string
 	Tenant                   tenantcluster.Interface
 	ToClusterGuestConfigFunc func(obj interface{}) (v1alpha1.ClusterGuestConfig, error)
+	ToClusterObjectMetaFunc  func(obj interface{}) (metav1.ObjectMeta, error)
 }
 
 // Resource implements the chartoperator resource.
@@ -57,6 +59,7 @@ type Resource struct {
 	registryDomain           string
 	tenant                   tenantcluster.Interface
 	toClusterGuestConfigFunc func(obj interface{}) (v1alpha1.ClusterGuestConfig, error)
+	toClusterObjectMetaFunc  func(obj interface{}) (metav1.ObjectMeta, error)
 }
 
 // New creates a new configured chartoperator resource.
@@ -94,19 +97,23 @@ func New(config Config) (*Resource, error) {
 	if config.ToClusterGuestConfigFunc == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ToClusterGuestConfigFunc must not be empty", config)
 	}
+	if config.ToClusterObjectMetaFunc == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ToClusterObjectMetaFunc must not be empty", config)
+	}
 
 	newResource := &Resource{
-		apprClient:               config.ApprClient,
-		baseClusterConfig:        config.BaseClusterConfig,
-		clusterIPRange:           config.ClusterIPRange,
-		fs:                       config.Fs,
-		g8sClient:                config.G8sClient,
-		k8sClient:                config.K8sClient,
-		logger:                   config.Logger,
-		projectName:              config.ProjectName,
-		registryDomain:           config.RegistryDomain,
-		tenant:                   config.Tenant,
+		apprClient:        config.ApprClient,
+		baseClusterConfig: config.BaseClusterConfig,
+		clusterIPRange:    config.ClusterIPRange,
+		fs:                config.Fs,
+		g8sClient:         config.G8sClient,
+		k8sClient:         config.K8sClient,
+		logger:            config.Logger,
+		projectName:       config.ProjectName,
+		registryDomain:    config.RegistryDomain,
+		tenant:            config.Tenant,
 		toClusterGuestConfigFunc: config.ToClusterGuestConfigFunc,
+		toClusterObjectMetaFunc:  config.ToClusterObjectMetaFunc,
 	}
 
 	return newResource, nil

--- a/pkg/v11/resource/chartoperator/resource.go
+++ b/pkg/v11/resource/chartoperator/resource.go
@@ -102,16 +102,16 @@ func New(config Config) (*Resource, error) {
 	}
 
 	newResource := &Resource{
-		apprClient:        config.ApprClient,
-		baseClusterConfig: config.BaseClusterConfig,
-		clusterIPRange:    config.ClusterIPRange,
-		fs:                config.Fs,
-		g8sClient:         config.G8sClient,
-		k8sClient:         config.K8sClient,
-		logger:            config.Logger,
-		projectName:       config.ProjectName,
-		registryDomain:    config.RegistryDomain,
-		tenant:            config.Tenant,
+		apprClient:               config.ApprClient,
+		baseClusterConfig:        config.BaseClusterConfig,
+		clusterIPRange:           config.ClusterIPRange,
+		fs:                       config.Fs,
+		g8sClient:                config.G8sClient,
+		k8sClient:                config.K8sClient,
+		logger:                   config.Logger,
+		projectName:              config.ProjectName,
+		registryDomain:           config.RegistryDomain,
+		tenant:                   config.Tenant,
 		toClusterGuestConfigFunc: config.ToClusterGuestConfigFunc,
 		toClusterObjectMetaFunc:  config.ToClusterObjectMetaFunc,
 	}

--- a/pkg/v11/resource/chartoperator/update_test.go
+++ b/pkg/v11/resource/chartoperator/update_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/giantswarm/helmclient/helmclienttest"
 	"github.com/giantswarm/micrologger/microloggertest"
 	"github.com/spf13/afero"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientgofake "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/giantswarm/cluster-operator/pkg/cluster"
@@ -100,6 +101,9 @@ func Test_Resource_Chart_newUpdate(t *testing.T) {
 				},
 				ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
 					return v.(v1alpha1.ClusterGuestConfig), nil
+				},
+				ToClusterObjectMetaFunc: func(v interface{}) (metav1.ObjectMeta, error) {
+					return metav1.ObjectMeta{}, nil
 				},
 			}
 

--- a/pkg/v11/resource/namespace/current.go
+++ b/pkg/v11/resource/namespace/current.go
@@ -10,7 +10,7 @@ import (
 	"github.com/giantswarm/tenantcluster"
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/cluster-operator/pkg/v11/key"
 )
@@ -21,8 +21,8 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
-	// Guest cluster namespace is not deleted so cancel the reconcilation. The
-	// namespace will be deleted when the guest cluster resources are deleted.
+	// Tenant cluster namespace is not deleted so cancel the resource. The
+	// namespace will be deleted when the tenant cluster resources are deleted.
 	if key.IsDeleted(objectMeta) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "redirecting namespace deletion to provider operators")
 		resourcecanceledcontext.SetCanceled(ctx)
@@ -50,7 +50,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	// Lookup the current state of the namespace.
 	var namespace *apiv1.Namespace
 	{
-		manifest, err := tenantK8sClient.CoreV1().Namespaces().Get(namespaceName, apismetav1.GetOptions{})
+		manifest, err := tenantK8sClient.CoreV1().Namespaces().Get(namespaceName, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the namespace in the guest cluster")
 			// fall through

--- a/pkg/v11/resource/namespace/desired_test.go
+++ b/pkg/v11/resource/namespace/desired_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/micrologger/microloggertest"
 	apiv1 "k8s.io/api/core/v1"
-	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/cluster-operator/pkg/cluster"
 )
@@ -44,12 +44,12 @@ func Test_Resource_Namespace_GetDesiredState(t *testing.T) {
 				},
 				Logger:      microloggertest.New(),
 				ProjectName: "cluster-operator",
+				Tenant:      &tenantMock{},
 				ToClusterGuestConfigFunc: func(v interface{}) (v1alpha1.ClusterGuestConfig, error) {
 					return v.(v1alpha1.ClusterGuestConfig), nil
 				},
-				Tenant: &tenantMock{},
-				ToClusterObjectMetaFunc: func(v interface{}) (apismetav1.ObjectMeta, error) {
-					return v.(apismetav1.ObjectMeta), nil
+				ToClusterObjectMetaFunc: func(v interface{}) (metav1.ObjectMeta, error) {
+					return v.(metav1.ObjectMeta), nil
 				},
 			}
 			newResource, err := New(c)

--- a/pkg/v11/resource/tiller/delete.go
+++ b/pkg/v11/resource/tiller/delete.go
@@ -2,20 +2,10 @@ package tiller
 
 import (
 	"context"
-
-	"github.com/giantswarm/microerror"
 )
 
+// EnsureDeleted is not implemented for the tiller resource. Tiller will be
+// deleted when the tenant cluster resources are deleted.
 func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
-	clusterGuestConfig, err := r.toClusterGuestConfigFunc(obj)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	err = r.ensureTillerInstalled(ctx, clusterGuestConfig)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
 	return nil
 }

--- a/service/controller/aws/v11/resource/chartconfig/current.go
+++ b/service/controller/aws/v11/resource/chartconfig/current.go
@@ -6,6 +6,7 @@ import (
 	"github.com/giantswarm/errors/guest"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/giantswarm/cluster-operator/pkg/v11/chartconfig"
@@ -17,6 +18,14 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	customObject, err := awskey.ToCustomObject(obj)
 	if err != nil {
 		return nil, microerror.Mask(err)
+	}
+
+	if key.IsDeleted(customObject.ObjectMeta) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "redirecting chartconfig deletion to provider operators")
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+		return nil, nil
 	}
 
 	clusterGuestConfig := awskey.ClusterGuestConfig(customObject)

--- a/service/controller/aws/v11/resource/configmap/current.go
+++ b/service/controller/aws/v11/resource/configmap/current.go
@@ -6,6 +6,7 @@ import (
 	"github.com/giantswarm/errors/guest"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 
 	"github.com/giantswarm/cluster-operator/pkg/v11/configmap"
 	"github.com/giantswarm/cluster-operator/pkg/v11/key"
@@ -16,6 +17,14 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	customObject, err := awskey.ToCustomObject(obj)
 	if err != nil {
 		return nil, microerror.Mask(err)
+	}
+
+	if key.IsDeleted(customObject.ObjectMeta) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "redirecting configmap deletion to provider operators")
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+		return nil, nil
 	}
 
 	clusterGuestConfig := awskey.ClusterGuestConfig(customObject)

--- a/service/controller/aws/v11/resource_set.go
+++ b/service/controller/aws/v11/resource_set.go
@@ -180,6 +180,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			RegistryDomain:           config.RegistryDomain,
 			Tenant:                   tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
+			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
 
 		ops, err := chartoperator.New(c)

--- a/service/controller/azure/v11/resource/chartconfig/current.go
+++ b/service/controller/azure/v11/resource/chartconfig/current.go
@@ -6,6 +6,7 @@ import (
 	"github.com/giantswarm/errors/guest"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/giantswarm/cluster-operator/pkg/v11/chartconfig"
@@ -17,6 +18,14 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	customObject, err := azurekey.ToCustomObject(obj)
 	if err != nil {
 		return nil, microerror.Mask(err)
+	}
+
+	if key.IsDeleted(customObject.ObjectMeta) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "redirecting chartconfig deletion to provider operators")
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+		return nil, nil
 	}
 
 	clusterGuestConfig := azurekey.ClusterGuestConfig(customObject)

--- a/service/controller/azure/v11/resource/configmap/current.go
+++ b/service/controller/azure/v11/resource/configmap/current.go
@@ -6,6 +6,7 @@ import (
 	"github.com/giantswarm/errors/guest"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 
 	"github.com/giantswarm/cluster-operator/pkg/v11/configmap"
 	"github.com/giantswarm/cluster-operator/pkg/v11/key"
@@ -16,6 +17,14 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	customObject, err := azurekey.ToCustomObject(obj)
 	if err != nil {
 		return nil, microerror.Mask(err)
+	}
+
+	if key.IsDeleted(customObject.ObjectMeta) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "redirecting configmap deletion to provider operators")
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+		return nil, nil
 	}
 
 	clusterGuestConfig := azurekey.ClusterGuestConfig(customObject)

--- a/service/controller/azure/v11/resource_set.go
+++ b/service/controller/azure/v11/resource_set.go
@@ -180,6 +180,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			RegistryDomain:           config.RegistryDomain,
 			Tenant:                   tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
+			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
 
 		ops, err := chartoperator.New(c)

--- a/service/controller/kvm/v11/resource/configmap/current.go
+++ b/service/controller/kvm/v11/resource/configmap/current.go
@@ -6,6 +6,7 @@ import (
 	"github.com/giantswarm/errors/guest"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 
 	"github.com/giantswarm/cluster-operator/pkg/v11/configmap"
 	"github.com/giantswarm/cluster-operator/pkg/v11/key"
@@ -16,6 +17,14 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	customObject, err := kvmkey.ToCustomObject(obj)
 	if err != nil {
 		return nil, microerror.Mask(err)
+	}
+
+	if key.IsDeleted(customObject.ObjectMeta) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "redirecting configmap deletion to provider operators")
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+		return nil, nil
 	}
 
 	clusterGuestConfig := kvmkey.ClusterGuestConfig(customObject)

--- a/service/controller/kvm/v11/resource_set.go
+++ b/service/controller/kvm/v11/resource_set.go
@@ -146,10 +146,10 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var namespaceResource controller.Resource
 	{
 		c := namespace.Config{
-			BaseClusterConfig: *config.BaseClusterConfig,
-			Logger:            config.Logger,
-			ProjectName:       config.ProjectName,
-			Tenant:            tenantClusterService,
+			BaseClusterConfig:        *config.BaseClusterConfig,
+			Logger:                   config.Logger,
+			ProjectName:              config.ProjectName,
+			Tenant:                   tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -168,16 +168,16 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var chartOperatorResource controller.Resource
 	{
 		c := chartoperator.Config{
-			ApprClient:        config.ApprClient,
-			BaseClusterConfig: *config.BaseClusterConfig,
-			ClusterIPRange:    config.ClusterIPRange,
-			Fs:                config.Fs,
-			G8sClient:         config.G8sClient,
-			K8sClient:         config.K8sClient,
-			Logger:            config.Logger,
-			ProjectName:       config.ProjectName,
-			RegistryDomain:    config.RegistryDomain,
-			Tenant:            tenantClusterService,
+			ApprClient:               config.ApprClient,
+			BaseClusterConfig:        *config.BaseClusterConfig,
+			ClusterIPRange:           config.ClusterIPRange,
+			Fs:                       config.Fs,
+			G8sClient:                config.G8sClient,
+			K8sClient:                config.K8sClient,
+			Logger:                   config.Logger,
+			ProjectName:              config.ProjectName,
+			RegistryDomain:           config.RegistryDomain,
+			Tenant:                   tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -270,9 +270,9 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var tillerResource controller.Resource
 	{
 		c := tiller.Config{
-			BaseClusterConfig: *config.BaseClusterConfig,
-			Logger:            config.Logger,
-			Tenant:            tenantClusterService,
+			BaseClusterConfig:        *config.BaseClusterConfig,
+			Logger:                   config.Logger,
+			Tenant:                   tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 		}
 

--- a/service/controller/kvm/v11/resource_set.go
+++ b/service/controller/kvm/v11/resource_set.go
@@ -146,10 +146,10 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var namespaceResource controller.Resource
 	{
 		c := namespace.Config{
-			BaseClusterConfig:        *config.BaseClusterConfig,
-			Logger:                   config.Logger,
-			ProjectName:              config.ProjectName,
-			Tenant:                   tenantClusterService,
+			BaseClusterConfig: *config.BaseClusterConfig,
+			Logger:            config.Logger,
+			ProjectName:       config.ProjectName,
+			Tenant:            tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -168,17 +168,18 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var chartOperatorResource controller.Resource
 	{
 		c := chartoperator.Config{
-			ApprClient:               config.ApprClient,
-			BaseClusterConfig:        *config.BaseClusterConfig,
-			ClusterIPRange:           config.ClusterIPRange,
-			Fs:                       config.Fs,
-			G8sClient:                config.G8sClient,
-			K8sClient:                config.K8sClient,
-			Logger:                   config.Logger,
-			ProjectName:              config.ProjectName,
-			RegistryDomain:           config.RegistryDomain,
-			Tenant:                   tenantClusterService,
+			ApprClient:        config.ApprClient,
+			BaseClusterConfig: *config.BaseClusterConfig,
+			ClusterIPRange:    config.ClusterIPRange,
+			Fs:                config.Fs,
+			G8sClient:         config.G8sClient,
+			K8sClient:         config.K8sClient,
+			Logger:            config.Logger,
+			ProjectName:       config.ProjectName,
+			RegistryDomain:    config.RegistryDomain,
+			Tenant:            tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
+			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
 
 		ops, err := chartoperator.New(c)
@@ -269,9 +270,9 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var tillerResource controller.Resource
 	{
 		c := tiller.Config{
-			BaseClusterConfig:        *config.BaseClusterConfig,
-			Logger:                   config.Logger,
-			Tenant:                   tenantClusterService,
+			BaseClusterConfig: *config.BaseClusterConfig,
+			Logger:            config.Logger,
+			Tenant:            tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 		}
 


### PR DESCRIPTION
Fixes a problem I found while working on another PM. We aren't removing the finalizers correctly because the resources try to connect to the tenant cluster but we've already deleted the cluster-operator cert.

Now each affected resource is cancelled and the logs explain what is going on.

Once this is merged I'll backport to v10. For older versions I plan to take a shortcut and cancel the reconciliation in the namespace resource.

See https://gigantic.slack.com/archives/C2MS2VB37/p1550508165002400.