### PR TITLE
Fix finalizer problem with *clusterconfig CRs in existing resource sets

### DIFF
--- a/pkg/v10/resource/namespace/current.go
+++ b/pkg/v10/resource/namespace/current.go
@@ -6,7 +6,6 @@ import (
 	"github.com/giantswarm/errors/guest"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
-	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	"github.com/giantswarm/tenantcluster"
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -21,12 +20,12 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
-	// Guest cluster namespace is not deleted so cancel the reconcilation. The
-	// namespace will be deleted when the guest cluster resources are deleted.
+	// Tenant cluster resources are not deleted so cancel the reconcilation. They
+	// will be deleted when the tenant cluster is deleted.
 	if key.IsDeleted(objectMeta) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "redirecting namespace deletion to provider operators")
-		resourcecanceledcontext.SetCanceled(ctx)
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "redirecting deletion to provider operators")
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
 
 		return nil, nil
 	}

--- a/pkg/v6/resource/namespace/current.go
+++ b/pkg/v6/resource/namespace/current.go
@@ -7,7 +7,6 @@ import (
 	"github.com/giantswarm/errors/guest"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
-	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	"github.com/giantswarm/tenantcluster"
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -22,12 +21,12 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
-	// Guest cluster namespace is not deleted so cancel the reconcilation. The
-	// namespace will be deleted when the guest cluster resources are deleted.
+	// Tenant cluster resources are not deleted so cancel the reconcilation. They
+	// will be deleted when the tenant cluster is deleted.
 	if key.IsDeleted(objectMeta) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "redirecting namespace deletion to provider operators")
-		resourcecanceledcontext.SetCanceled(ctx)
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "redirecting deletion to provider operators")
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
 
 		return nil, nil
 	}

--- a/pkg/v6patch1/resource/namespace/current.go
+++ b/pkg/v6patch1/resource/namespace/current.go
@@ -7,7 +7,6 @@ import (
 	"github.com/giantswarm/errors/guest"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
-	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	"github.com/giantswarm/tenantcluster"
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -22,12 +21,12 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
-	// Guest cluster namespace is not deleted so cancel the reconcilation. The
-	// namespace will be deleted when the guest cluster resources are deleted.
+	// Tenant cluster resources are not deleted so cancel the reconcilation. They
+	// will be deleted when the tenant cluster is deleted.
 	if key.IsDeleted(objectMeta) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "redirecting namespace deletion to provider operators")
-		resourcecanceledcontext.SetCanceled(ctx)
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "redirecting deletion to provider operators")
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
 
 		return nil, nil
 	}

--- a/pkg/v7/resource/namespace/current.go
+++ b/pkg/v7/resource/namespace/current.go
@@ -7,7 +7,6 @@ import (
 	"github.com/giantswarm/errors/guest"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
-	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	"github.com/giantswarm/tenantcluster"
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -22,12 +21,12 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
-	// Guest cluster namespace is not deleted so cancel the reconcilation. The
-	// namespace will be deleted when the guest cluster resources are deleted.
+	// Tenant cluster resources are not deleted so cancel the reconcilation. They
+	// will be deleted when the tenant cluster is deleted.
 	if key.IsDeleted(objectMeta) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "redirecting namespace deletion to provider operators")
-		resourcecanceledcontext.SetCanceled(ctx)
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "redirecting deletion to provider operators")
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
 
 		return nil, nil
 	}

--- a/pkg/v7patch1/resource/namespace/current.go
+++ b/pkg/v7patch1/resource/namespace/current.go
@@ -7,7 +7,6 @@ import (
 	"github.com/giantswarm/errors/guest"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
-	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	"github.com/giantswarm/tenantcluster"
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -22,12 +21,12 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
-	// Guest cluster namespace is not deleted so cancel the reconcilation. The
-	// namespace will be deleted when the guest cluster resources are deleted.
+	// Tenant cluster resources are not deleted so cancel the reconcilation. They
+	// will be deleted when the tenant cluster is deleted.
 	if key.IsDeleted(objectMeta) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "redirecting namespace deletion to provider operators")
-		resourcecanceledcontext.SetCanceled(ctx)
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "redirecting deletion to provider operators")
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
 
 		return nil, nil
 	}

--- a/pkg/v7patch2/resource/namespace/current.go
+++ b/pkg/v7patch2/resource/namespace/current.go
@@ -7,7 +7,6 @@ import (
 	"github.com/giantswarm/errors/guest"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
-	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	"github.com/giantswarm/tenantcluster"
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -22,12 +21,12 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
-	// Guest cluster namespace is not deleted so cancel the reconcilation. The
-	// namespace will be deleted when the guest cluster resources are deleted.
+	// Tenant cluster resources are not deleted so cancel the reconcilation. They
+	// will be deleted when the tenant cluster is deleted.
 	if key.IsDeleted(objectMeta) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "redirecting namespace deletion to provider operators")
-		resourcecanceledcontext.SetCanceled(ctx)
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "redirecting deletion to provider operators")
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
 
 		return nil, nil
 	}

--- a/pkg/v8/resource/namespace/current.go
+++ b/pkg/v8/resource/namespace/current.go
@@ -7,7 +7,6 @@ import (
 	"github.com/giantswarm/errors/guest"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
-	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	"github.com/giantswarm/tenantcluster"
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -22,12 +21,12 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
-	// Guest cluster namespace is not deleted so cancel the reconcilation. The
-	// namespace will be deleted when the guest cluster resources are deleted.
+	// Tenant cluster resources are not deleted so cancel the reconcilation. They
+	// will be deleted when the tenant cluster is deleted.
 	if key.IsDeleted(objectMeta) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "redirecting namespace deletion to provider operators")
-		resourcecanceledcontext.SetCanceled(ctx)
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "redirecting deletion to provider operators")
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
 
 		return nil, nil
 	}

--- a/pkg/v9/resource/namespace/current.go
+++ b/pkg/v9/resource/namespace/current.go
@@ -7,7 +7,6 @@ import (
 	"github.com/giantswarm/errors/guest"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
-	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	"github.com/giantswarm/tenantcluster"
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -22,12 +21,12 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
-	// Guest cluster namespace is not deleted so cancel the reconcilation. The
-	// namespace will be deleted when the guest cluster resources are deleted.
+	// Tenant cluster resources are not deleted so cancel the reconcilation. They
+	// will be deleted when the tenant cluster is deleted.
 	if key.IsDeleted(objectMeta) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "redirecting namespace deletion to provider operators")
-		resourcecanceledcontext.SetCanceled(ctx)
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "redirecting deletion to provider operators")
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
 
 		return nil, nil
 	}


### PR DESCRIPTION
Fixes a bug with finalizers not being removed for *clusterconfig CRs. This is worst on gauss but the other control planes will be affected.

```
k get awsclusterconfig -n default | wc -l     
39
```

The bug is the `configmap` resource hits a timeout getting the `cluster-operator-api` secret because it has already been deleted when the `certconfig` was deleted.

```
E 02/21 08:49:08 /apis/core.giantswarm.io/v1alpha1/namespaces/default/awsclusterconfigs/uony9-aws-cluster-config configmapv10 stop reconciliation due to error | operatorkit/controller/controller.go:222 | controller=cluster-operator | event=delete | loop=0 | version=22001828
	/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:489: 
	/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/metricsresource/crud_resource_wrapper.go:73: 
	/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource/crud_resource_wrapper.go:92: 
	/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/controller/crud_resource.go:207: 
	/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/metricsresource/crud_resource_ops_wrapper.go:53: 
	/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource/crud_resource_ops_wrapper.go:76: 
	/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource/crud_resource_ops_wrapper.go:64: 
	/go/src/github.com/giantswarm/cluster-operator/service/controller/aws/v10/resource/configmap/current.go:42: 
	/go/src/github.com/giantswarm/cluster-operator/pkg/v10/configmap/current.go:19: 
	/go/src/github.com/giantswarm/cluster-operator/pkg/v10/configmap/configmap.go:56: 
	/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/tenantcluster/tenantcluster.go:118: 
	/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/tenantcluster/tenantcluster.go:142: waiting secrets, selector = "clusterComponent=cluster-operator-api, clusterID=uony9": timeout error
```

Fix is to cancel the entire reconciliation in the `namespace` resource. For v11 this was fixed the nicer but longer way by adding the logic to all resources. 
https://github.com/giantswarm/cluster-operator/pull/387

