### PR TITLE
Handle API server timeout in namespace resource

### DIFF
--- a/pkg/v11/resource/namespace/current.go
+++ b/pkg/v11/resource/namespace/current.go
@@ -54,8 +54,8 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		if apierrors.IsNotFound(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the namespace in the guest cluster")
 			// fall through
-		} else if guest.IsAPINotAvailable(err) {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster is not available")
+		} else if apierrors.IsTimeout(err) || guest.IsAPINotAvailable(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
 
 			// We can't continue without a successful K8s connection. Cluster
 			// may not be up yet. We will retry during the next execution.

--- a/pkg/v11/resource/namespace/current.go
+++ b/pkg/v11/resource/namespace/current.go
@@ -33,7 +33,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 
 	tenantK8sClient, err := r.gettenantK8sClient(ctx, obj)
 	if tenantcluster.IsTimeout(err) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "did not get a K8s client for the guest cluster")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "did not get a K8s client for the tenant cluster")
 
 		// We can't continue without a K8s client. We will retry during the
 		// next execution.
@@ -45,14 +45,14 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for the namespace in the guest cluster")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for the namespace in the tenant cluster")
 
 	// Lookup the current state of the namespace.
 	var namespace *apiv1.Namespace
 	{
 		manifest, err := tenantK8sClient.CoreV1().Namespaces().Get(namespaceName, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the namespace in the guest cluster")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the namespace in the tenant cluster")
 			// fall through
 		} else if apierrors.IsTimeout(err) || guest.IsAPINotAvailable(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
@@ -67,7 +67,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		} else if err != nil {
 			return nil, microerror.Mask(err)
 		} else {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "found the namespace in the guest cluster")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "found the namespace in the tenant cluster")
 			namespace = manifest
 		}
 	}

--- a/pkg/v11/resource/namespace/delete.go
+++ b/pkg/v11/resource/namespace/delete.go
@@ -6,14 +6,14 @@ import (
 	"github.com/giantswarm/operatorkit/controller"
 )
 
-// ApplyDeleteChange is a no-op because the namespace in the guest cluster is
-// deleted with the guest cluster resources.
+// ApplyDeleteChange is a no-op because the namespace in the tenant cluster is
+// deleted with the tenant cluster resources.
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
 	return nil
 }
 
-// NewDeletePatch is a no-op because the namespace in the guest cluster is
-// deleted with the guest cluster resources.
+// NewDeletePatch is a no-op because the namespace in the tenant cluster is
+// deleted with the tenant cluster resources.
 func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
 	return nil, nil
 }

--- a/pkg/v11/resource/namespace/update.go
+++ b/pkg/v11/resource/namespace/update.go
@@ -7,7 +7,7 @@ import (
 	"github.com/giantswarm/operatorkit/controller"
 )
 
-// ApplyUpdateChange is a no-op because the namespace in the guest cluster is
+// ApplyUpdateChange is a no-op because the namespace in the tenant cluster is
 // not updated.
 func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
 	return nil
@@ -31,7 +31,7 @@ func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desire
 	return patch, nil
 }
 
-// newUpdateChange is a no-op because the namespace in the guest cluster is not
+// newUpdateChange is a no-op because the namespace in the tenant cluster is not
 // updated.
 func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
 	return nil, nil


### PR DESCRIPTION
Previous deploys triggered alerts in viking due to this timeout error accessing the tenant API.

```
E 02/21 11:35:47 /apis/core.giantswarm.io/v1alpha1/namespaces/default/awsclusterconfigs/yq237-aws-cluster-config namespacev10 stop reconciliation due to error | operatorkit/controller/controller.go:358 | controller=cluster-operator | event=update | loop=0 | version=100866936
	/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:518: 
	/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/metricsresource/crud_resource_wrapper.go:62: 
	/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource/crud_resource_wrapper.go:81: 
	/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/controller/crud_resource.go:69: 
	/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/metricsresource/crud_resource_ops_wrapper.go:53: 
	/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource/crud_resource_ops_wrapper.go:76: 
	/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource/crud_resource_ops_wrapper.go:64: 
	/go/src/github.com/giantswarm/cluster-operator/pkg/v10/resource/namespace/current.go:67: 
	Get https://api.yq237.k8s.eu-central-1.aws.cps.vodafone.com/api/v1/namespaces/giantswarm?timeout=30s: context deadline exceeded
```

Fix is straightforward and I want to get it in as final change to v11.