### PR TITLE
 Get chart values in current state for chartoperator resource

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -233,7 +233,7 @@
     ".",
     "helmclienttest"
   ]
-  revision = "8b2aa2e7ebec773dcf8e02e9e34c8085ef08697f"
+  revision = "72611db89eeb829055cdee2640b06ea725d5600d"
 
 [[projects]]
   branch = "master"

--- a/pkg/v12/resource/chartoperator/current.go
+++ b/pkg/v12/resource/chartoperator/current.go
@@ -2,6 +2,7 @@ package chartoperator
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/giantswarm/errors/guest"
 	"github.com/giantswarm/helmclient"
@@ -87,8 +88,20 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 			return nil, microerror.Mask(err)
 		}
 
+		bytes, err := json.Marshal(releaseContent.Values)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		chartValues := &Values{}
+		err = json.Unmarshal(bytes, chartValues)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
 		chartState = &ResourceState{
 			ChartName:      chartOperatorChart,
+			ChartValues:    *chartValues,
 			ReleaseName:    chartOperatorRelease,
 			ReleaseStatus:  releaseContent.Status,
 			ReleaseVersion: releaseHistory.Version,

--- a/pkg/v12/resource/chartoperator/current_test.go
+++ b/pkg/v12/resource/chartoperator/current_test.go
@@ -2,6 +2,7 @@ package chartoperator
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"testing"
@@ -20,6 +21,26 @@ import (
 )
 
 func Test_Chart_GetCurrentState(t *testing.T) {
+	chartValues := Values{
+		Image: Image{
+			Registry: "quay.io",
+		},
+		Tiller: Tiller{
+			Namespace: "giantswarm",
+		},
+	}
+
+	bytes, err := json.Marshal(chartValues)
+	if err != nil {
+		t.Fatalf("expected nil got %#v", err)
+	}
+
+	values := map[string]interface{}{}
+	err = json.Unmarshal(bytes, &values)
+	if err != nil {
+		t.Fatalf("expected nil got %#v", err)
+	}
+
 	testCases := []struct {
 		name           string
 		obj            interface{}
@@ -39,16 +60,22 @@ func Test_Chart_GetCurrentState(t *testing.T) {
 			releaseContent: &helmclient.ReleaseContent{
 				Name:   "chart-operator",
 				Status: "DEPLOYED",
-				Values: map[string]interface{}{
-					"key": "value",
-				},
+				Values: values,
 			},
 			releaseHistory: &helmclient.ReleaseHistory{
 				Name:    "chart-operator",
 				Version: "0.1.2",
 			},
 			expectedState: ResourceState{
-				ChartName:      "chart-operator-chart",
+				ChartName: "chart-operator-chart",
+				ChartValues: Values{
+					Image: Image{
+						Registry: "quay.io",
+					},
+					Tiller: Tiller{
+						Namespace: "giantswarm",
+					},
+				},
 				ReleaseName:    "chart-operator",
 				ReleaseStatus:  "DEPLOYED",
 				ReleaseVersion: "0.1.2",

--- a/pkg/v13/resource/chartoperator/current.go
+++ b/pkg/v13/resource/chartoperator/current.go
@@ -2,6 +2,7 @@ package chartoperator
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/giantswarm/errors/guest"
 	"github.com/giantswarm/helmclient"
@@ -87,8 +88,20 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 			return nil, microerror.Mask(err)
 		}
 
+		bytes, err := json.Marshal(releaseContent.Values)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		chartValues := &Values{}
+		err = json.Unmarshal(bytes, chartValues)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
 		chartState = &ResourceState{
 			ChartName:      chartOperatorChart,
+			ChartValues:    *chartValues,
 			ReleaseName:    chartOperatorRelease,
 			ReleaseStatus:  releaseContent.Status,
 			ReleaseVersion: releaseHistory.Version,

--- a/pkg/v13/resource/chartoperator/current_test.go
+++ b/pkg/v13/resource/chartoperator/current_test.go
@@ -2,6 +2,7 @@ package chartoperator
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"testing"
@@ -20,6 +21,26 @@ import (
 )
 
 func Test_Chart_GetCurrentState(t *testing.T) {
+	chartValues := Values{
+		Image: Image{
+			Registry: "quay.io",
+		},
+		Tiller: Tiller{
+			Namespace: "giantswarm",
+		},
+	}
+
+	bytes, err := json.Marshal(chartValues)
+	if err != nil {
+		t.Fatalf("expected nil got %#v", err)
+	}
+
+	values := map[string]interface{}{}
+	err = json.Unmarshal(bytes, &values)
+	if err != nil {
+		t.Fatalf("expected nil got %#v", err)
+	}
+
 	testCases := []struct {
 		name           string
 		obj            interface{}
@@ -39,16 +60,22 @@ func Test_Chart_GetCurrentState(t *testing.T) {
 			releaseContent: &helmclient.ReleaseContent{
 				Name:   "chart-operator",
 				Status: "DEPLOYED",
-				Values: map[string]interface{}{
-					"key": "value",
-				},
+				Values: values,
 			},
 			releaseHistory: &helmclient.ReleaseHistory{
 				Name:    "chart-operator",
 				Version: "0.1.2",
 			},
 			expectedState: ResourceState{
-				ChartName:      "chart-operator-chart",
+				ChartName: "chart-operator-chart",
+				ChartValues: Values{
+					Image: Image{
+						Registry: "quay.io",
+					},
+					Tiller: Tiller{
+						Namespace: "giantswarm",
+					},
+				},
 				ReleaseName:    "chart-operator",
 				ReleaseStatus:  "DEPLOYED",
 				ReleaseVersion: "0.1.2",

--- a/vendor/github.com/giantswarm/helmclient/helmclient.go
+++ b/vendor/github.com/giantswarm/helmclient/helmclient.go
@@ -299,7 +299,7 @@ func (c *Client) EnsureTillerInstalled(ctx context.Context) error {
 		if err != nil {
 			return microerror.Mask(err)
 		}
-	} else {
+	} else if installTiller && upgradeTiller {
 		return microerror.Maskf(executionFailedError, "invalid state cannot both install and upgrade tiller")
 	}
 


### PR DESCRIPTION
Fixes a bug getting the current state for the chartoperator resource. It needs to get the current values for the state comparison.

Also vendors a helmclient fix for EnsureTillerInstalled.
https://github.com/giantswarm/helmclient/pull/90
