### PR TITLE
Backport fix for API server timeouts in namespace resource

### DIFF
--- a/pkg/v10/resource/namespace/create.go
+++ b/pkg/v10/resource/namespace/create.go
@@ -27,7 +27,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		_, err = tenantK8sClient.CoreV1().Namespaces().Create(namespaceToCreate)
 		if apierrors.IsAlreadyExists(err) {
 			// fall through
-		} else if guest.IsAPINotAvailable(err) {
+		} else if apierrors.IsTimeout(err) || guest.IsAPINotAvailable(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster is not available.")
 
 			// We should not hammer guest API if it is not available, the guest cluster

--- a/pkg/v10/resource/namespace/current.go
+++ b/pkg/v10/resource/namespace/current.go
@@ -53,7 +53,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		if apierrors.IsNotFound(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the namespace in the guest cluster")
 			// fall through
-		} else if guest.IsAPINotAvailable(err) {
+		} else if apierrors.IsTimeout(err) || guest.IsAPINotAvailable(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster is not available")
 
 			// We can't continue without a successful K8s connection. Cluster


### PR DESCRIPTION
This was fixed in https://github.com/giantswarm/cluster-operator/pull/391 for `0.11.0` onwards of cluster operator.

@corest The alerts in viking are because the tenants are running `0.10.0`. Backporting the fix since its small.