### PR TITLE
Handle deleted CRs in tiller resource

### DIFF
--- a/pkg/v14/resource/tiller/create.go
+++ b/pkg/v14/resource/tiller/create.go
@@ -7,12 +7,7 @@ import (
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
-	clusterGuestConfig, err := r.toClusterGuestConfigFunc(obj)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	err = r.ensureTillerInstalled(ctx, clusterGuestConfig)
+	err := r.ensureTillerInstalled(ctx, obj)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/v14/resource/tiller/resource.go
+++ b/pkg/v14/resource/tiller/resource.go
@@ -10,7 +10,9 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	"github.com/giantswarm/tenantcluster"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/cluster-operator/pkg/cluster"
 	"github.com/giantswarm/cluster-operator/pkg/v10/key"
@@ -26,6 +28,7 @@ type Config struct {
 	Logger                   micrologger.Logger
 	Tenant                   tenantcluster.Interface
 	ToClusterGuestConfigFunc func(obj interface{}) (v1alpha1.ClusterGuestConfig, error)
+	ToClusterObjectMetaFunc  func(obj interface{}) (metav1.ObjectMeta, error)
 }
 
 // Resource implements the tiller resource.
@@ -34,6 +37,7 @@ type Resource struct {
 	logger                   micrologger.Logger
 	tenant                   tenantcluster.Interface
 	toClusterGuestConfigFunc func(obj interface{}) (v1alpha1.ClusterGuestConfig, error)
+	toClusterObjectMetaFunc  func(obj interface{}) (metav1.ObjectMeta, error)
 }
 
 // New creates a new configured tiller resource.
@@ -50,12 +54,16 @@ func New(config Config) (*Resource, error) {
 	if config.ToClusterGuestConfigFunc == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ToClusterGuestConfigFunc must not be empty", config)
 	}
+	if config.ToClusterObjectMetaFunc == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ToClusterObjectMetaFunc must not be empty", config)
+	}
 
 	r := &Resource{
 		baseClusterConfig:        config.BaseClusterConfig,
 		logger:                   config.Logger,
 		tenant:                   config.Tenant,
 		toClusterGuestConfigFunc: config.ToClusterGuestConfigFunc,
+		toClusterObjectMetaFunc:  config.ToClusterObjectMetaFunc,
 	}
 
 	return r, nil

--- a/pkg/v14/resource/tiller/resource.go
+++ b/pkg/v14/resource/tiller/resource.go
@@ -83,7 +83,8 @@ func (r *Resource) ensureTillerInstalled(ctx context.Context, obj interface{}) e
 	// cluster resources is handled by the provider operator
 	// e.g. aws-operator.
 	if key.IsDeleted(objectMeta) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "Tiller is not deleted in tenant cluster")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "not deleting tiller in tenant cluster")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "tiller in tenant cluster will be deleted with cluster deletion")
 
 		resourcecanceledcontext.SetCanceled(ctx)
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")

--- a/pkg/v14/resource/tiller/resource.go
+++ b/pkg/v14/resource/tiller/resource.go
@@ -79,10 +79,11 @@ func (r *Resource) ensureTillerInstalled(ctx context.Context, obj interface{}) e
 		return microerror.Mask(err)
 	}
 
-	// Tenant Tiller is not deleted so cancel the resource. Tiller deployment
-	// will be deleted when the tenant cluster resources are deleted.
+	// Tenant Tiller is not deleted by cluster-operator. Deleting tenant
+	// cluster resources is handled by the provider operator
+	// e.g. aws-operator.
 	if key.IsDeleted(objectMeta) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "redirecting Tiller deletion to provider operators")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "Tiller is not deleted in tenant cluster")
 
 		resourcecanceledcontext.SetCanceled(ctx)
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")

--- a/service/controller/aws/v14/resource_set.go
+++ b/service/controller/aws/v14/resource_set.go
@@ -256,6 +256,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			Logger:                   config.Logger,
 			Tenant:                   tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
+			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
 
 		tillerResource, err = tiller.New(c)

--- a/service/controller/azure/v14/resource_set.go
+++ b/service/controller/azure/v14/resource_set.go
@@ -256,6 +256,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			Logger:                   config.Logger,
 			Tenant:                   tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
+			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
 
 		tillerResource, err = tiller.New(c)

--- a/service/controller/kvm/v14/resource_set.go
+++ b/service/controller/kvm/v14/resource_set.go
@@ -255,6 +255,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			Logger:                   config.Logger,
 			Tenant:                   tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
+			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
 
 		tillerResource, err = tiller.New(c)


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5652

This is to prevent the operator hanging when trying to install tiller in deleted clusters. If the deletion timestamp is set we cancel the `tiller` resource.