### PR TITLE
Backport fix to not delete chartconfig CRs and configmaps in tenant clusters

### DIFF
--- a/pkg/v10/chartconfig/delete.go
+++ b/pkg/v10/chartconfig/delete.go
@@ -38,16 +38,10 @@ func (c *ChartConfig) ApplyDeleteChange(ctx context.Context, clusterConfig Clust
 
 }
 
+// NewDeletePatch is a no-op because chartconfig CRs in the tenant cluster are
+// deleted with the tenant cluster resources.
 func (c *ChartConfig) NewDeletePatch(ctx context.Context, currentState, desiredState []*v1alpha1.ChartConfig) (*controller.Patch, error) {
-	delete, err := c.newDeleteChangeForDeletePatch(ctx, currentState, desiredState)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	patch := controller.NewPatch()
-	patch.SetDeleteChange(delete)
-
-	return patch, nil
+	return nil, nil
 }
 
 func (c *ChartConfig) newDeleteChangeForDeletePatch(ctx context.Context, currentChartConfigs, desiredChartConfigs []*v1alpha1.ChartConfig) ([]*v1alpha1.ChartConfig, error) {

--- a/pkg/v10/configmap/delete.go
+++ b/pkg/v10/configmap/delete.go
@@ -37,16 +37,10 @@ func (s *Service) ApplyDeleteChange(ctx context.Context, clusterConfig ClusterCo
 	return nil
 }
 
+// NewDeletePatch is a no-op because configmaps in the tenant cluster are
+// deleted with the tenant cluster resources.
 func (s *Service) NewDeletePatch(ctx context.Context, currentState, desiredState []*corev1.ConfigMap) (*controller.Patch, error) {
-	delete, err := s.newDeleteChangeForDeletePatch(ctx, currentState, desiredState)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	patch := controller.NewPatch()
-	patch.SetDeleteChange(delete)
-
-	return patch, nil
+	return nil, nil
 }
 
 func (s *Service) newDeleteChangeForDeletePatch(ctx context.Context, currentConfigMaps, desiredConfigMaps []*corev1.ConfigMap) ([]*corev1.ConfigMap, error) {

--- a/pkg/v11/chartconfig/delete.go
+++ b/pkg/v11/chartconfig/delete.go
@@ -38,16 +38,10 @@ func (c *ChartConfig) ApplyDeleteChange(ctx context.Context, clusterConfig Clust
 
 }
 
+// NewDeletePatch is a no-op because chartconfig CRs in the tenant cluster are
+// deleted with the tenant cluster resources.
 func (c *ChartConfig) NewDeletePatch(ctx context.Context, currentState, desiredState []*v1alpha1.ChartConfig) (*controller.Patch, error) {
-	delete, err := c.newDeleteChangeForDeletePatch(ctx, currentState, desiredState)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	patch := controller.NewPatch()
-	patch.SetDeleteChange(delete)
-
-	return patch, nil
+	return nil, nil
 }
 
 func (c *ChartConfig) newDeleteChangeForDeletePatch(ctx context.Context, currentChartConfigs, desiredChartConfigs []*v1alpha1.ChartConfig) ([]*v1alpha1.ChartConfig, error) {

--- a/pkg/v11/configmap/delete.go
+++ b/pkg/v11/configmap/delete.go
@@ -37,16 +37,10 @@ func (s *Service) ApplyDeleteChange(ctx context.Context, clusterConfig ClusterCo
 	return nil
 }
 
+// NewDeletePatch is a no-op because configmaps in the tenant cluster are
+// deleted with the tenant cluster resources.
 func (s *Service) NewDeletePatch(ctx context.Context, currentState, desiredState []*corev1.ConfigMap) (*controller.Patch, error) {
-	delete, err := s.newDeleteChangeForDeletePatch(ctx, currentState, desiredState)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	patch := controller.NewPatch()
-	patch.SetDeleteChange(delete)
-
-	return patch, nil
+	return nil, nil
 }
 
 func (s *Service) newDeleteChangeForDeletePatch(ctx context.Context, currentConfigMaps, desiredConfigMaps []*corev1.ConfigMap) ([]*corev1.ConfigMap, error) {

--- a/pkg/v12/chartconfig/delete.go
+++ b/pkg/v12/chartconfig/delete.go
@@ -38,16 +38,10 @@ func (c *ChartConfig) ApplyDeleteChange(ctx context.Context, clusterConfig Clust
 
 }
 
+// NewDeletePatch is a no-op because chartconfig CRs in the tenant cluster are
+// deleted with the tenant cluster resources.
 func (c *ChartConfig) NewDeletePatch(ctx context.Context, currentState, desiredState []*v1alpha1.ChartConfig) (*controller.Patch, error) {
-	delete, err := c.newDeleteChangeForDeletePatch(ctx, currentState, desiredState)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	patch := controller.NewPatch()
-	patch.SetDeleteChange(delete)
-
-	return patch, nil
+	return nil, nil
 }
 
 func (c *ChartConfig) newDeleteChangeForDeletePatch(ctx context.Context, currentChartConfigs, desiredChartConfigs []*v1alpha1.ChartConfig) ([]*v1alpha1.ChartConfig, error) {

--- a/pkg/v12/configmap/delete.go
+++ b/pkg/v12/configmap/delete.go
@@ -37,16 +37,10 @@ func (s *Service) ApplyDeleteChange(ctx context.Context, clusterConfig ClusterCo
 	return nil
 }
 
+// NewDeletePatch is a no-op because configmaps in the tenant cluster are
+// deleted with the tenant cluster resources.
 func (s *Service) NewDeletePatch(ctx context.Context, currentState, desiredState []*corev1.ConfigMap) (*controller.Patch, error) {
-	delete, err := s.newDeleteChangeForDeletePatch(ctx, currentState, desiredState)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	patch := controller.NewPatch()
-	patch.SetDeleteChange(delete)
-
-	return patch, nil
+	return nil, nil
 }
 
 func (s *Service) newDeleteChangeForDeletePatch(ctx context.Context, currentConfigMaps, desiredConfigMaps []*corev1.ConfigMap) ([]*corev1.ConfigMap, error) {

--- a/pkg/v13/chartconfig/delete.go
+++ b/pkg/v13/chartconfig/delete.go
@@ -38,16 +38,10 @@ func (c *ChartConfig) ApplyDeleteChange(ctx context.Context, clusterConfig Clust
 
 }
 
+// NewDeletePatch is a no-op because chartconfig CRs in the tenant cluster are
+// deleted with the tenant cluster resources.
 func (c *ChartConfig) NewDeletePatch(ctx context.Context, currentState, desiredState []*v1alpha1.ChartConfig) (*controller.Patch, error) {
-	delete, err := c.newDeleteChangeForDeletePatch(ctx, currentState, desiredState)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	patch := controller.NewPatch()
-	patch.SetDeleteChange(delete)
-
-	return patch, nil
+	return nil, nil
 }
 
 func (c *ChartConfig) newDeleteChangeForDeletePatch(ctx context.Context, currentChartConfigs, desiredChartConfigs []*v1alpha1.ChartConfig) ([]*v1alpha1.ChartConfig, error) {

--- a/pkg/v13/configmap/delete.go
+++ b/pkg/v13/configmap/delete.go
@@ -37,16 +37,10 @@ func (s *Service) ApplyDeleteChange(ctx context.Context, clusterConfig ClusterCo
 	return nil
 }
 
+// NewDeletePatch is a no-op because configmaps in the tenant cluster are
+// deleted with the tenant cluster resources.
 func (s *Service) NewDeletePatch(ctx context.Context, currentState, desiredState []*corev1.ConfigMap) (*controller.Patch, error) {
-	delete, err := s.newDeleteChangeForDeletePatch(ctx, currentState, desiredState)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	patch := controller.NewPatch()
-	patch.SetDeleteChange(delete)
-
-	return patch, nil
+	return nil, nil
 }
 
 func (s *Service) newDeleteChangeForDeletePatch(ctx context.Context, currentConfigMaps, desiredConfigMaps []*corev1.ConfigMap) ([]*corev1.ConfigMap, error) {

--- a/pkg/v6patch1/configmap/delete.go
+++ b/pkg/v6patch1/configmap/delete.go
@@ -37,16 +37,10 @@ func (s *Service) ApplyDeleteChange(ctx context.Context, configMapConfig ConfigM
 	return nil
 }
 
+// NewDeletePatch is a no-op because configmaps in the tenant cluster are
+// deleted with the tenant cluster resources.
 func (s *Service) NewDeletePatch(ctx context.Context, currentState, desiredState []*corev1.ConfigMap) (*controller.Patch, error) {
-	delete, err := s.newDeleteChangeForDeletePatch(ctx, currentState, desiredState)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	patch := controller.NewPatch()
-	patch.SetDeleteChange(delete)
-
-	return patch, nil
+	return nil, nil
 }
 
 func (s *Service) newDeleteChangeForDeletePatch(ctx context.Context, currentConfigMaps, desiredConfigMaps []*corev1.ConfigMap) ([]*corev1.ConfigMap, error) {

--- a/pkg/v7/chartconfig/delete.go
+++ b/pkg/v7/chartconfig/delete.go
@@ -38,16 +38,10 @@ func (c *ChartConfig) ApplyDeleteChange(ctx context.Context, clusterConfig Clust
 
 }
 
+// NewDeletePatch is a no-op because chartconfig CRs in the tenant cluster are
+// deleted with the tenant cluster resources.
 func (c *ChartConfig) NewDeletePatch(ctx context.Context, currentState, desiredState []*v1alpha1.ChartConfig) (*controller.Patch, error) {
-	delete, err := c.newDeleteChangeForDeletePatch(ctx, currentState, desiredState)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	patch := controller.NewPatch()
-	patch.SetDeleteChange(delete)
-
-	return patch, nil
+	return nil, nil
 }
 
 func (c *ChartConfig) newDeleteChangeForDeletePatch(ctx context.Context, currentChartConfigs, desiredChartConfigs []*v1alpha1.ChartConfig) ([]*v1alpha1.ChartConfig, error) {

--- a/pkg/v7/configmap/delete.go
+++ b/pkg/v7/configmap/delete.go
@@ -37,16 +37,10 @@ func (s *Service) ApplyDeleteChange(ctx context.Context, clusterConfig ClusterCo
 	return nil
 }
 
+// NewDeletePatch is a no-op because configmaps in the tenant cluster are
+// deleted with the tenant cluster resources.
 func (s *Service) NewDeletePatch(ctx context.Context, currentState, desiredState []*corev1.ConfigMap) (*controller.Patch, error) {
-	delete, err := s.newDeleteChangeForDeletePatch(ctx, currentState, desiredState)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	patch := controller.NewPatch()
-	patch.SetDeleteChange(delete)
-
-	return patch, nil
+	return nil, nil
 }
 
 func (s *Service) newDeleteChangeForDeletePatch(ctx context.Context, currentConfigMaps, desiredConfigMaps []*corev1.ConfigMap) ([]*corev1.ConfigMap, error) {

--- a/pkg/v7patch1/chartconfig/delete.go
+++ b/pkg/v7patch1/chartconfig/delete.go
@@ -38,16 +38,10 @@ func (c *ChartConfig) ApplyDeleteChange(ctx context.Context, clusterConfig Clust
 
 }
 
+// NewDeletePatch is a no-op because chartconfig CRs in the tenant cluster are
+// deleted with the tenant cluster resources.
 func (c *ChartConfig) NewDeletePatch(ctx context.Context, currentState, desiredState []*v1alpha1.ChartConfig) (*controller.Patch, error) {
-	delete, err := c.newDeleteChangeForDeletePatch(ctx, currentState, desiredState)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	patch := controller.NewPatch()
-	patch.SetDeleteChange(delete)
-
-	return patch, nil
+	return nil, nil
 }
 
 func (c *ChartConfig) newDeleteChangeForDeletePatch(ctx context.Context, currentChartConfigs, desiredChartConfigs []*v1alpha1.ChartConfig) ([]*v1alpha1.ChartConfig, error) {

--- a/pkg/v7patch1/configmap/delete.go
+++ b/pkg/v7patch1/configmap/delete.go
@@ -37,16 +37,10 @@ func (s *Service) ApplyDeleteChange(ctx context.Context, clusterConfig ClusterCo
 	return nil
 }
 
+// NewDeletePatch is a no-op because configmaps in the tenant cluster are
+// deleted with the tenant cluster resources.
 func (s *Service) NewDeletePatch(ctx context.Context, currentState, desiredState []*corev1.ConfigMap) (*controller.Patch, error) {
-	delete, err := s.newDeleteChangeForDeletePatch(ctx, currentState, desiredState)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	patch := controller.NewPatch()
-	patch.SetDeleteChange(delete)
-
-	return patch, nil
+	return nil, nil
 }
 
 func (s *Service) newDeleteChangeForDeletePatch(ctx context.Context, currentConfigMaps, desiredConfigMaps []*corev1.ConfigMap) ([]*corev1.ConfigMap, error) {

--- a/pkg/v7patch2/chartconfig/delete.go
+++ b/pkg/v7patch2/chartconfig/delete.go
@@ -38,16 +38,10 @@ func (c *ChartConfig) ApplyDeleteChange(ctx context.Context, clusterConfig Clust
 
 }
 
+// NewDeletePatch is a no-op because chartconfig CRs in the tenant cluster are
+// deleted with the tenant cluster resources.
 func (c *ChartConfig) NewDeletePatch(ctx context.Context, currentState, desiredState []*v1alpha1.ChartConfig) (*controller.Patch, error) {
-	delete, err := c.newDeleteChangeForDeletePatch(ctx, currentState, desiredState)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	patch := controller.NewPatch()
-	patch.SetDeleteChange(delete)
-
-	return patch, nil
+	return nil, nil
 }
 
 func (c *ChartConfig) newDeleteChangeForDeletePatch(ctx context.Context, currentChartConfigs, desiredChartConfigs []*v1alpha1.ChartConfig) ([]*v1alpha1.ChartConfig, error) {

--- a/pkg/v7patch2/configmap/delete.go
+++ b/pkg/v7patch2/configmap/delete.go
@@ -37,16 +37,10 @@ func (s *Service) ApplyDeleteChange(ctx context.Context, clusterConfig ClusterCo
 	return nil
 }
 
+// NewDeletePatch is a no-op because configmaps in the tenant cluster are
+// deleted with the tenant cluster resources.
 func (s *Service) NewDeletePatch(ctx context.Context, currentState, desiredState []*corev1.ConfigMap) (*controller.Patch, error) {
-	delete, err := s.newDeleteChangeForDeletePatch(ctx, currentState, desiredState)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	patch := controller.NewPatch()
-	patch.SetDeleteChange(delete)
-
-	return patch, nil
+	return nil, nil
 }
 
 func (s *Service) newDeleteChangeForDeletePatch(ctx context.Context, currentConfigMaps, desiredConfigMaps []*corev1.ConfigMap) ([]*corev1.ConfigMap, error) {

--- a/pkg/v8/chartconfig/delete.go
+++ b/pkg/v8/chartconfig/delete.go
@@ -38,16 +38,10 @@ func (c *ChartConfig) ApplyDeleteChange(ctx context.Context, clusterConfig Clust
 
 }
 
+// NewDeletePatch is a no-op because chartconfig CRs in the tenant cluster are
+// deleted with the tenant cluster resources.
 func (c *ChartConfig) NewDeletePatch(ctx context.Context, currentState, desiredState []*v1alpha1.ChartConfig) (*controller.Patch, error) {
-	delete, err := c.newDeleteChangeForDeletePatch(ctx, currentState, desiredState)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	patch := controller.NewPatch()
-	patch.SetDeleteChange(delete)
-
-	return patch, nil
+	return nil, nil
 }
 
 func (c *ChartConfig) newDeleteChangeForDeletePatch(ctx context.Context, currentChartConfigs, desiredChartConfigs []*v1alpha1.ChartConfig) ([]*v1alpha1.ChartConfig, error) {

--- a/pkg/v8/configmap/delete.go
+++ b/pkg/v8/configmap/delete.go
@@ -37,16 +37,10 @@ func (s *Service) ApplyDeleteChange(ctx context.Context, clusterConfig ClusterCo
 	return nil
 }
 
+// NewDeletePatch is a no-op because configmaps in the tenant cluster are
+// deleted with the tenant cluster resources.
 func (s *Service) NewDeletePatch(ctx context.Context, currentState, desiredState []*corev1.ConfigMap) (*controller.Patch, error) {
-	delete, err := s.newDeleteChangeForDeletePatch(ctx, currentState, desiredState)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	patch := controller.NewPatch()
-	patch.SetDeleteChange(delete)
-
-	return patch, nil
+	return nil, nil
 }
 
 func (s *Service) newDeleteChangeForDeletePatch(ctx context.Context, currentConfigMaps, desiredConfigMaps []*corev1.ConfigMap) ([]*corev1.ConfigMap, error) {

--- a/pkg/v9/chartconfig/delete.go
+++ b/pkg/v9/chartconfig/delete.go
@@ -38,16 +38,10 @@ func (c *ChartConfig) ApplyDeleteChange(ctx context.Context, clusterConfig Clust
 
 }
 
+// NewDeletePatch is a no-op because chartconfig CRs in the tenant cluster are
+// deleted with the tenant cluster resources.
 func (c *ChartConfig) NewDeletePatch(ctx context.Context, currentState, desiredState []*v1alpha1.ChartConfig) (*controller.Patch, error) {
-	delete, err := c.newDeleteChangeForDeletePatch(ctx, currentState, desiredState)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	patch := controller.NewPatch()
-	patch.SetDeleteChange(delete)
-
-	return patch, nil
+	return nil, nil
 }
 
 func (c *ChartConfig) newDeleteChangeForDeletePatch(ctx context.Context, currentChartConfigs, desiredChartConfigs []*v1alpha1.ChartConfig) ([]*v1alpha1.ChartConfig, error) {

--- a/pkg/v9/configmap/delete.go
+++ b/pkg/v9/configmap/delete.go
@@ -37,16 +37,10 @@ func (s *Service) ApplyDeleteChange(ctx context.Context, clusterConfig ClusterCo
 	return nil
 }
 
+// NewDeletePatch is a no-op because configmaps in the tenant cluster are
+// deleted with the tenant cluster resources.
 func (s *Service) NewDeletePatch(ctx context.Context, currentState, desiredState []*corev1.ConfigMap) (*controller.Patch, error) {
-	delete, err := s.newDeleteChangeForDeletePatch(ctx, currentState, desiredState)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	patch := controller.NewPatch()
-	patch.SetDeleteChange(delete)
-
-	return patch, nil
+	return nil, nil
 }
 
 func (s *Service) newDeleteChangeForDeletePatch(ctx context.Context, currentConfigMaps, desiredConfigMaps []*corev1.ConfigMap) ([]*corev1.ConfigMap, error) {


### PR DESCRIPTION
Fixes giantswarm/giantswarm#5225

Now v14 is straight this backports the fixes so we don't delete these resources in tenant clusters.

Sadly we are still carrying a lot of code. The situation will improve a lot after the KVM upgrades.