### PR TITLE
Fix https problem

### DIFF
--- a/pkg/v14/resource/kubeconfig/desired.go
+++ b/pkg/v14/resource/kubeconfig/desired.go
@@ -2,7 +2,6 @@ package kubeconfig
 
 import (
 	"context"
-	"log"
 	"net/url"
 
 	"github.com/giantswarm/certs"
@@ -40,7 +39,7 @@ func (r *StateGetter) GetDesiredState(ctx context.Context, obj interface{}) ([]*
 
 	u, err := url.Parse(apiDomain)
 	if err != nil {
-		log.Fatal(err)
+		return nil, microerror.Mask(err)
 	}
 	u.Scheme = "https"
 	apiDomain = u.String()

--- a/pkg/v14/resource/kubeconfig/desired.go
+++ b/pkg/v14/resource/kubeconfig/desired.go
@@ -2,6 +2,8 @@ package kubeconfig
 
 import (
 	"context"
+	"log"
+	"net/url"
 
 	"github.com/giantswarm/certs"
 	"github.com/giantswarm/kubeconfig"
@@ -35,6 +37,13 @@ func (r *StateGetter) GetDesiredState(ctx context.Context, obj interface{}) ([]*
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
+
+	u, err := url.Parse(apiDomain)
+	if err != nil {
+		log.Fatal(err)
+	}
+	u.Scheme = "https"
+	apiDomain = u.String()
 
 	appOperator, err := r.certsSearcher.SearchAppOperator(clusterGuestConfig.ID)
 	if certs.IsTimeout(err) {

--- a/pkg/v14/resource/kubeconfig/desired_test.go
+++ b/pkg/v14/resource/kubeconfig/desired_test.go
@@ -22,7 +22,7 @@ kind: Config
 clusters:
 - name: giantswarm-w7utg
   cluster:
-    server: api.giantswarm.io
+    server: https://api.giantswarm.io
     certificate-authority-data: Y2E=
 users:
 - name: giantswarm-w7utg-user


### PR DESCRIPTION
Currently we are getting a problem in `ginger` as below, since we do not set the scheme as `https`
```
E 04/02 09:58:01 /apis/application.giantswarm.io/v1alpha1/namespaces/giantswarm/apps/test-app configmapv1 stop reconciliation due to error | operatorkit/controller/controller.go:370 | controller=app-operator | event=update | loop=65 | version=111672863
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:530:
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/metricsresource/crud_resource_wrapper.go:62:
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource/crud_resource_wrapper.go:81:
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/crud_resource.go:69:
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/metricsresource/crud_resource_ops_wrapper.go:53:
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource/crud_resource_ops_wrapper.go:76:
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource/crud_resource_ops_wrapper.go:64:
	/go/src/github.com/giantswarm/app-operator/service/controller/app/v1/resource/configmap/current.go:37:
	Get http://api.qn8p8.k8s.ginger.eu-central-1.aws.gigantic.io/api/v1/namespaces/giantswarm/configmaps/test-app-chart-values: dial tcp 52.29.183.53:80: i/o timeout
```