### PR TITLE
Fix update secret permission

### DIFF
--- a/helm/cluster-operator-chart/templates/rbac.yaml
+++ b/helm/cluster-operator-chart/templates/rbac.yaml
@@ -9,6 +9,7 @@ rules:
       - secrets
     verbs:
       - create
+      - update
       - delete
       - get
       - watch


### PR DESCRIPTION
Fix RBAC problem in cluster-operator, We need to assign `update` permission into kubeconfig after we apply generic secret resource. 
```
E 04/02 10:49:52 /apis/core.giantswarm.io/v1alpha1/namespaces/default/awsclusterconfigs/3cqha-aws-cluster-config kubeconfigv14 stop reconciliation due to error | operatorkit/controller/controller.go:370 | controller=cluster-operator | event=update | loop=1 | version=111664611
	/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:530:
	/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/metricsresource/crud_resource_wrapper.go:62:
	/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource/crud_resource_wrapper.go:81:
	/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/controller/crud_resource.go:179:
	/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/metricsresource/crud_resource_ops_wrapper.go:159:
	/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource/crud_resource_ops_wrapper.go:218:
	/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource/crud_resource_ops_wrapper.go:206:
	/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/resource/secret/update.go:22:
	secrets "3cqha-kubeconfig" is forbidden: User "system:serviceaccount:giantswarm:cluster-operator" cannot update resource "secrets" in API group "" in the namespace "giantswarm"
```