### PR TITLE
Update the changelogs for v14

### DIFF
--- a/service/controller/aws/v14/version_bundle.go
+++ b/service/controller/aws/v14/version_bundle.go
@@ -8,8 +8,8 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "TODO",
-				Description: "TODO",
+				Component:   "cluster-operator",
+				Description: "Added support for setting the kubeconfig with the app-operator-api certs.",
 				Kind:        versionbundle.KindChanged,
 			},
 		},

--- a/service/controller/aws/v14/version_bundle.go
+++ b/service/controller/aws/v14/version_bundle.go
@@ -10,7 +10,7 @@ func VersionBundle() versionbundle.Bundle {
 			{
 				Component:   "cluster-operator",
 				Description: "Added support for creating a kubeconfig for app-operator.",
-				Kind:        versionbundle.KindChanged,
+				Kind:        versionbundle.KindAdded,
 			},
 		},
 		Components: []versionbundle.Component{

--- a/service/controller/aws/v14/version_bundle.go
+++ b/service/controller/aws/v14/version_bundle.go
@@ -9,7 +9,7 @@ func VersionBundle() versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "cluster-operator",
-				Description: "Added support for setting the kubeconfig with the app-operator-api certs.",
+				Description: "Added support for creating a kubeconfig for app-operator.",
 				Kind:        versionbundle.KindChanged,
 			},
 		},

--- a/service/controller/azure/v14/version_bundle.go
+++ b/service/controller/azure/v14/version_bundle.go
@@ -8,8 +8,8 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "TODO",
-				Description: "TODO",
+				Component:   "cluster-operator",
+				Description: "Added support for setting the kubeconfig with the app-operator-api certs.",
 				Kind:        versionbundle.KindChanged,
 			},
 		},

--- a/service/controller/azure/v14/version_bundle.go
+++ b/service/controller/azure/v14/version_bundle.go
@@ -10,7 +10,7 @@ func VersionBundle() versionbundle.Bundle {
 			{
 				Component:   "cluster-operator",
 				Description: "Added support for setting the kubeconfig with the app-operator-api certs.",
-				Kind:        versionbundle.KindChanged,
+				Kind:        versionbundle.KindAdded,
 			},
 		},
 		Components: []versionbundle.Component{

--- a/service/controller/kvm/v14/version_bundle.go
+++ b/service/controller/kvm/v14/version_bundle.go
@@ -8,8 +8,8 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "TODO",
-				Description: "TODO",
+				Component:   "cluster-operator",
+				Description: "Added support for setting the kubeconfig with the app-operator-api certs.",
 				Kind:        versionbundle.KindChanged,
 			},
 		},

--- a/service/controller/kvm/v14/version_bundle.go
+++ b/service/controller/kvm/v14/version_bundle.go
@@ -10,7 +10,7 @@ func VersionBundle() versionbundle.Bundle {
 			{
 				Component:   "cluster-operator",
 				Description: "Added support for setting the kubeconfig with the app-operator-api certs.",
-				Kind:        versionbundle.KindChanged,
+				Kind:        versionbundle.KindAdded,
 			},
 		},
 		Components: []versionbundle.Component{


### PR DESCRIPTION
- Adding changeslogs for v14, indicates that we add kubeconfig support for app-operator.