### PR TITLE
Disable Ingress Controller migration logic for AWS

### DIFF
--- a/service/controller/aws/v14/resource/configmap/desired.go
+++ b/service/controller/aws/v14/resource/configmap/desired.go
@@ -35,9 +35,8 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 			ClusterIPRange:     r.clusterIPRange,
 		},
 		IngressController: configmap.IngressControllerValues{
-			// Migration is enabled so existing k8scloudconfig resources are
-			// replaced.
-			MigrationEnabled: true,
+			// Migration is disabled because AWS is already migrated.
+			MigrationEnabled: false,
 			// Proxy protocol is enabled for AWS clusters.
 			UseProxyProtocol: true,
 		},

--- a/service/controller/aws/v14/version_bundle.go
+++ b/service/controller/aws/v14/version_bundle.go
@@ -12,6 +12,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Added support for creating a kubeconfig for app-operator.",
 				Kind:        versionbundle.KindAdded,
 			},
+			{
+				Component:   "nginx-ingress-controller",
+				Description: "Disabled migration logic now migration to helm chart is complete.",
+				Kind:        versionbundle.KindRemoved,
+			},
 		},
 		Components: []versionbundle.Component{
 			{


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5750

Oldest AWS tenants are running `6.3.0` which has had the IC chart enabled for a while. On Azure we had it easy and didn't need to do a migration.

Once the last 2 KVM clusters are gone we can also disable KVM and simplify the IC chart and cluster-operator.