### PR TITLE
Disable kubeconfig resource from v14

### DIFF
--- a/service/controller/aws/v14/resource_set.go
+++ b/service/controller/aws/v14/resource_set.go
@@ -132,10 +132,10 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var namespaceResource controller.Resource
 	{
 		c := namespace.Config{
-			BaseClusterConfig: *config.BaseClusterConfig,
-			Logger:            config.Logger,
-			ProjectName:       config.ProjectName,
-			Tenant:            tenantClusterService,
+			BaseClusterConfig:        *config.BaseClusterConfig,
+			Logger:                   config.Logger,
+			ProjectName:              config.ProjectName,
+			Tenant:                   tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -154,16 +154,16 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var chartOperatorResource controller.Resource
 	{
 		c := chartoperator.Config{
-			ApprClient:        config.ApprClient,
-			BaseClusterConfig: *config.BaseClusterConfig,
-			ClusterIPRange:    config.ClusterIPRange,
-			Fs:                config.Fs,
-			G8sClient:         config.G8sClient,
-			K8sClient:         config.K8sClient,
-			Logger:            config.Logger,
-			ProjectName:       config.ProjectName,
-			RegistryDomain:    config.RegistryDomain,
-			Tenant:            tenantClusterService,
+			ApprClient:               config.ApprClient,
+			BaseClusterConfig:        *config.BaseClusterConfig,
+			ClusterIPRange:           config.ClusterIPRange,
+			Fs:                       config.Fs,
+			G8sClient:                config.G8sClient,
+			K8sClient:                config.K8sClient,
+			Logger:                   config.Logger,
+			ProjectName:              config.ProjectName,
+			RegistryDomain:           config.RegistryDomain,
+			Tenant:                   tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -256,9 +256,9 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var tillerResource controller.Resource
 	{
 		c := tiller.Config{
-			BaseClusterConfig: *config.BaseClusterConfig,
-			Logger:            config.Logger,
-			Tenant:            tenantClusterService,
+			BaseClusterConfig:        *config.BaseClusterConfig,
+			Logger:                   config.Logger,
+			Tenant:                   tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}

--- a/service/controller/aws/v14/resource_set.go
+++ b/service/controller/aws/v14/resource_set.go
@@ -12,7 +12,6 @@ import (
 	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/controller/resource/metricsresource"
 	"github.com/giantswarm/operatorkit/controller/resource/retryresource"
-	"github.com/giantswarm/operatorkit/resource/secret"
 	"github.com/giantswarm/tenantcluster"
 	"github.com/spf13/afero"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,7 +24,6 @@ import (
 	"github.com/giantswarm/cluster-operator/pkg/v14/resource/certconfig"
 	"github.com/giantswarm/cluster-operator/pkg/v14/resource/chartoperator"
 	"github.com/giantswarm/cluster-operator/pkg/v14/resource/encryptionkey"
-	"github.com/giantswarm/cluster-operator/pkg/v14/resource/kubeconfig"
 	"github.com/giantswarm/cluster-operator/pkg/v14/resource/namespace"
 	"github.com/giantswarm/cluster-operator/pkg/v14/resource/tiller"
 	"github.com/giantswarm/cluster-operator/service/controller/aws/v14/key"
@@ -134,10 +132,10 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var namespaceResource controller.Resource
 	{
 		c := namespace.Config{
-			BaseClusterConfig:        *config.BaseClusterConfig,
-			Logger:                   config.Logger,
-			ProjectName:              config.ProjectName,
-			Tenant:                   tenantClusterService,
+			BaseClusterConfig: *config.BaseClusterConfig,
+			Logger:            config.Logger,
+			ProjectName:       config.ProjectName,
+			Tenant:            tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -156,16 +154,16 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var chartOperatorResource controller.Resource
 	{
 		c := chartoperator.Config{
-			ApprClient:               config.ApprClient,
-			BaseClusterConfig:        *config.BaseClusterConfig,
-			ClusterIPRange:           config.ClusterIPRange,
-			Fs:                       config.Fs,
-			G8sClient:                config.G8sClient,
-			K8sClient:                config.K8sClient,
-			Logger:                   config.Logger,
-			ProjectName:              config.ProjectName,
-			RegistryDomain:           config.RegistryDomain,
-			Tenant:                   tenantClusterService,
+			ApprClient:        config.ApprClient,
+			BaseClusterConfig: *config.BaseClusterConfig,
+			ClusterIPRange:    config.ClusterIPRange,
+			Fs:                config.Fs,
+			G8sClient:         config.G8sClient,
+			K8sClient:         config.K8sClient,
+			Logger:            config.Logger,
+			ProjectName:       config.ProjectName,
+			RegistryDomain:    config.RegistryDomain,
+			Tenant:            tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -255,48 +253,12 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		}
 	}
 
-	var kubeConfigResource controller.Resource
-	{
-		c := kubeconfig.Config{
-			CertSearcher:         config.CertSearcher,
-			GetClusterConfigFunc: getClusterConfig,
-			K8sClient:            config.K8sClient,
-			Logger:               config.Logger,
-
-			ProjectName:       config.ProjectName,
-			ResourceNamespace: config.ResourceNamespace,
-		}
-
-		stateGetter, err := kubeconfig.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-
-		configOps := secret.Config{
-			K8sClient: config.K8sClient,
-			Logger:    config.Logger,
-
-			Name:        kubeconfig.Name,
-			StateGetter: stateGetter,
-		}
-
-		ops, err := secret.New(configOps)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-
-		kubeConfigResource, err = toCRUDResource(config.Logger, ops)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
 	var tillerResource controller.Resource
 	{
 		c := tiller.Config{
-			BaseClusterConfig:        *config.BaseClusterConfig,
-			Logger:                   config.Logger,
-			Tenant:                   tenantClusterService,
+			BaseClusterConfig: *config.BaseClusterConfig,
+			Logger:            config.Logger,
+			Tenant:            tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -313,7 +275,6 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		// creation.
 		encryptionKeyResource,
 		certConfigResource,
-		kubeConfigResource,
 		// Following resources manage resources in tenant clusters so they
 		// should be executed last.
 		namespaceResource,

--- a/service/controller/aws/v14/version_bundle.go
+++ b/service/controller/aws/v14/version_bundle.go
@@ -8,8 +8,8 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "cluster-operator",
-				Description: "Added support for creating a kubeconfig for app-operator.",
+				Component:   "TODO",
+				Description: "TODO",
 				Kind:        versionbundle.KindAdded,
 			},
 		},

--- a/service/controller/azure/v14/resource_set.go
+++ b/service/controller/azure/v14/resource_set.go
@@ -12,7 +12,6 @@ import (
 	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/controller/resource/metricsresource"
 	"github.com/giantswarm/operatorkit/controller/resource/retryresource"
-	"github.com/giantswarm/operatorkit/resource/secret"
 	"github.com/giantswarm/tenantcluster"
 	"github.com/spf13/afero"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,7 +24,6 @@ import (
 	"github.com/giantswarm/cluster-operator/pkg/v14/resource/certconfig"
 	"github.com/giantswarm/cluster-operator/pkg/v14/resource/chartoperator"
 	"github.com/giantswarm/cluster-operator/pkg/v14/resource/encryptionkey"
-	"github.com/giantswarm/cluster-operator/pkg/v14/resource/kubeconfig"
 	"github.com/giantswarm/cluster-operator/pkg/v14/resource/namespace"
 	"github.com/giantswarm/cluster-operator/pkg/v14/resource/tiller"
 	"github.com/giantswarm/cluster-operator/service/controller/azure/v14/key"
@@ -131,10 +129,10 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var namespaceResource controller.Resource
 	{
 		c := namespace.Config{
-			BaseClusterConfig:        *config.BaseClusterConfig,
-			Logger:                   config.Logger,
-			ProjectName:              config.ProjectName,
-			Tenant:                   tenantClusterService,
+			BaseClusterConfig: *config.BaseClusterConfig,
+			Logger:            config.Logger,
+			ProjectName:       config.ProjectName,
+			Tenant:            tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -153,16 +151,16 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var chartOperatorResource controller.Resource
 	{
 		c := chartoperator.Config{
-			ApprClient:               config.ApprClient,
-			BaseClusterConfig:        *config.BaseClusterConfig,
-			ClusterIPRange:           config.ClusterIPRange,
-			Fs:                       config.Fs,
-			G8sClient:                config.G8sClient,
-			K8sClient:                config.K8sClient,
-			Logger:                   config.Logger,
-			ProjectName:              config.ProjectName,
-			RegistryDomain:           config.RegistryDomain,
-			Tenant:                   tenantClusterService,
+			ApprClient:        config.ApprClient,
+			BaseClusterConfig: *config.BaseClusterConfig,
+			ClusterIPRange:    config.ClusterIPRange,
+			Fs:                config.Fs,
+			G8sClient:         config.G8sClient,
+			K8sClient:         config.K8sClient,
+			Logger:            config.Logger,
+			ProjectName:       config.ProjectName,
+			RegistryDomain:    config.RegistryDomain,
+			Tenant:            tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -252,48 +250,12 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		}
 	}
 
-	var kubeConfigResource controller.Resource
-	{
-		c := kubeconfig.Config{
-			CertSearcher:         config.CertSearcher,
-			GetClusterConfigFunc: getClusterConfig,
-			K8sClient:            config.K8sClient,
-			Logger:               config.Logger,
-
-			ProjectName:       config.ProjectName,
-			ResourceNamespace: config.ResourceNamespace,
-		}
-
-		stateGetter, err := kubeconfig.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-
-		configOps := secret.Config{
-			K8sClient: config.K8sClient,
-			Logger:    config.Logger,
-
-			Name:        kubeconfig.Name,
-			StateGetter: stateGetter,
-		}
-
-		ops, err := secret.New(configOps)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-
-		kubeConfigResource, err = toCRUDResource(config.Logger, ops)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
 	var tillerResource controller.Resource
 	{
 		c := tiller.Config{
-			BaseClusterConfig:        *config.BaseClusterConfig,
-			Logger:                   config.Logger,
-			Tenant:                   tenantClusterService,
+			BaseClusterConfig: *config.BaseClusterConfig,
+			Logger:            config.Logger,
+			Tenant:            tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -310,7 +272,6 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		// creation.
 		encryptionKeyResource,
 		certConfigResource,
-		kubeConfigResource,
 		// Following resources manage resources in tenant clusters so they
 		// should be executed last
 		namespaceResource,

--- a/service/controller/azure/v14/resource_set.go
+++ b/service/controller/azure/v14/resource_set.go
@@ -129,10 +129,10 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var namespaceResource controller.Resource
 	{
 		c := namespace.Config{
-			BaseClusterConfig: *config.BaseClusterConfig,
-			Logger:            config.Logger,
-			ProjectName:       config.ProjectName,
-			Tenant:            tenantClusterService,
+			BaseClusterConfig:        *config.BaseClusterConfig,
+			Logger:                   config.Logger,
+			ProjectName:              config.ProjectName,
+			Tenant:                   tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -151,16 +151,16 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var chartOperatorResource controller.Resource
 	{
 		c := chartoperator.Config{
-			ApprClient:        config.ApprClient,
-			BaseClusterConfig: *config.BaseClusterConfig,
-			ClusterIPRange:    config.ClusterIPRange,
-			Fs:                config.Fs,
-			G8sClient:         config.G8sClient,
-			K8sClient:         config.K8sClient,
-			Logger:            config.Logger,
-			ProjectName:       config.ProjectName,
-			RegistryDomain:    config.RegistryDomain,
-			Tenant:            tenantClusterService,
+			ApprClient:               config.ApprClient,
+			BaseClusterConfig:        *config.BaseClusterConfig,
+			ClusterIPRange:           config.ClusterIPRange,
+			Fs:                       config.Fs,
+			G8sClient:                config.G8sClient,
+			K8sClient:                config.K8sClient,
+			Logger:                   config.Logger,
+			ProjectName:              config.ProjectName,
+			RegistryDomain:           config.RegistryDomain,
+			Tenant:                   tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -253,9 +253,9 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var tillerResource controller.Resource
 	{
 		c := tiller.Config{
-			BaseClusterConfig: *config.BaseClusterConfig,
-			Logger:            config.Logger,
-			Tenant:            tenantClusterService,
+			BaseClusterConfig:        *config.BaseClusterConfig,
+			Logger:                   config.Logger,
+			Tenant:                   tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}

--- a/service/controller/azure/v14/version_bundle.go
+++ b/service/controller/azure/v14/version_bundle.go
@@ -8,8 +8,8 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "cluster-operator",
-				Description: "Added support for creating a kubeconfig for app-operator.",
+				Component:   "TODO",
+				Description: "TODO",
 				Kind:        versionbundle.KindAdded,
 			},
 		},

--- a/service/controller/kvm/v14/resource_set.go
+++ b/service/controller/kvm/v14/resource_set.go
@@ -12,7 +12,6 @@ import (
 	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/controller/resource/metricsresource"
 	"github.com/giantswarm/operatorkit/controller/resource/retryresource"
-	"github.com/giantswarm/operatorkit/resource/secret"
 	"github.com/giantswarm/tenantcluster"
 	"github.com/spf13/afero"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,7 +24,6 @@ import (
 	"github.com/giantswarm/cluster-operator/pkg/v14/resource/certconfig"
 	"github.com/giantswarm/cluster-operator/pkg/v14/resource/chartoperator"
 	"github.com/giantswarm/cluster-operator/pkg/v14/resource/encryptionkey"
-	"github.com/giantswarm/cluster-operator/pkg/v14/resource/kubeconfig"
 	"github.com/giantswarm/cluster-operator/pkg/v14/resource/namespace"
 	"github.com/giantswarm/cluster-operator/pkg/v14/resource/tiller"
 	"github.com/giantswarm/cluster-operator/service/controller/kvm/v14/key"
@@ -130,10 +128,10 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var namespaceResource controller.Resource
 	{
 		c := namespace.Config{
-			BaseClusterConfig:        *config.BaseClusterConfig,
-			Logger:                   config.Logger,
-			ProjectName:              config.ProjectName,
-			Tenant:                   tenantClusterService,
+			BaseClusterConfig: *config.BaseClusterConfig,
+			Logger:            config.Logger,
+			ProjectName:       config.ProjectName,
+			Tenant:            tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -152,16 +150,16 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var chartOperatorResource controller.Resource
 	{
 		c := chartoperator.Config{
-			ApprClient:               config.ApprClient,
-			BaseClusterConfig:        *config.BaseClusterConfig,
-			ClusterIPRange:           config.ClusterIPRange,
-			Fs:                       config.Fs,
-			G8sClient:                config.G8sClient,
-			K8sClient:                config.K8sClient,
-			Logger:                   config.Logger,
-			ProjectName:              config.ProjectName,
-			RegistryDomain:           config.RegistryDomain,
-			Tenant:                   tenantClusterService,
+			ApprClient:        config.ApprClient,
+			BaseClusterConfig: *config.BaseClusterConfig,
+			ClusterIPRange:    config.ClusterIPRange,
+			Fs:                config.Fs,
+			G8sClient:         config.G8sClient,
+			K8sClient:         config.K8sClient,
+			Logger:            config.Logger,
+			ProjectName:       config.ProjectName,
+			RegistryDomain:    config.RegistryDomain,
+			Tenant:            tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -251,48 +249,12 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		}
 	}
 
-	var kubeConfigResource controller.Resource
-	{
-		c := kubeconfig.Config{
-			CertSearcher:         config.CertSearcher,
-			GetClusterConfigFunc: getClusterConfig,
-			K8sClient:            config.K8sClient,
-			Logger:               config.Logger,
-
-			ProjectName:       config.ProjectName,
-			ResourceNamespace: config.ResourceNamespace,
-		}
-
-		stateGetter, err := kubeconfig.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-
-		configOps := secret.Config{
-			K8sClient: config.K8sClient,
-			Logger:    config.Logger,
-
-			Name:        kubeconfig.Name,
-			StateGetter: stateGetter,
-		}
-
-		ops, err := secret.New(configOps)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-
-		kubeConfigResource, err = toCRUDResource(config.Logger, ops)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
 	var tillerResource controller.Resource
 	{
 		c := tiller.Config{
-			BaseClusterConfig:        *config.BaseClusterConfig,
-			Logger:                   config.Logger,
-			Tenant:                   tenantClusterService,
+			BaseClusterConfig: *config.BaseClusterConfig,
+			Logger:            config.Logger,
+			Tenant:            tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -309,7 +271,6 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		// creation.
 		encryptionKeyResource,
 		certConfigResource,
-		kubeConfigResource,
 		// Following resources manage resources in tenant clusters so they
 		// should be executed last
 		namespaceResource,

--- a/service/controller/kvm/v14/resource_set.go
+++ b/service/controller/kvm/v14/resource_set.go
@@ -128,10 +128,10 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var namespaceResource controller.Resource
 	{
 		c := namespace.Config{
-			BaseClusterConfig: *config.BaseClusterConfig,
-			Logger:            config.Logger,
-			ProjectName:       config.ProjectName,
-			Tenant:            tenantClusterService,
+			BaseClusterConfig:        *config.BaseClusterConfig,
+			Logger:                   config.Logger,
+			ProjectName:              config.ProjectName,
+			Tenant:                   tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -150,16 +150,16 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var chartOperatorResource controller.Resource
 	{
 		c := chartoperator.Config{
-			ApprClient:        config.ApprClient,
-			BaseClusterConfig: *config.BaseClusterConfig,
-			ClusterIPRange:    config.ClusterIPRange,
-			Fs:                config.Fs,
-			G8sClient:         config.G8sClient,
-			K8sClient:         config.K8sClient,
-			Logger:            config.Logger,
-			ProjectName:       config.ProjectName,
-			RegistryDomain:    config.RegistryDomain,
-			Tenant:            tenantClusterService,
+			ApprClient:               config.ApprClient,
+			BaseClusterConfig:        *config.BaseClusterConfig,
+			ClusterIPRange:           config.ClusterIPRange,
+			Fs:                       config.Fs,
+			G8sClient:                config.G8sClient,
+			K8sClient:                config.K8sClient,
+			Logger:                   config.Logger,
+			ProjectName:              config.ProjectName,
+			RegistryDomain:           config.RegistryDomain,
+			Tenant:                   tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -252,9 +252,9 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var tillerResource controller.Resource
 	{
 		c := tiller.Config{
-			BaseClusterConfig: *config.BaseClusterConfig,
-			Logger:            config.Logger,
-			Tenant:            tenantClusterService,
+			BaseClusterConfig:        *config.BaseClusterConfig,
+			Logger:                   config.Logger,
+			Tenant:                   tenantClusterService,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}

--- a/service/controller/kvm/v14/version_bundle.go
+++ b/service/controller/kvm/v14/version_bundle.go
@@ -8,8 +8,8 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "cluster-operator",
-				Description: "Added support for creating a kubeconfig for app-operator.",
+				Component:   "TODO",
+				Description: "TODO.",
 				Kind:        versionbundle.KindAdded,
 			},
 		},


### PR DESCRIPTION
Currently the kubeconfig secrets are created in the giantswarm namespace in the CP cluster.

We are discussing how to improve the design in https://github.com/giantswarm/giantswarm/issues/5753. 

This removes the resource for now. When we create the new WIP release we will re-enable it.

