### PR TITLE
Set ControllerServiceEnabled in configmap resources

### DIFF
--- a/pkg/v14/configmap/desired.go
+++ b/pkg/v14/configmap/desired.go
@@ -178,10 +178,6 @@ func exporterValues(configMapValues ConfigMapValues) ([]byte, error) {
 }
 
 func ingressControllerValues(configMapValues ConfigMapValues, hasLegacyIngressController bool) ([]byte, error) {
-	// controllerServiceEnabled needs to be set separately for the chart
-	// migration logic but is the reverse of migration enabled.
-	controllerServiceEnabled := !configMapValues.IngressController.MigrationEnabled
-
 	migrationEnabled := configMapValues.IngressController.MigrationEnabled
 	if migrationEnabled {
 		// No legacy ingress controller. So no need for the migration process.
@@ -201,7 +197,7 @@ func ingressControllerValues(configMapValues ConfigMapValues, hasLegacyIngressCo
 		Controller: IngressControllerController{
 			Replicas: configMapValues.WorkerCount,
 			Service: IngressControllerControllerService{
-				Enabled: controllerServiceEnabled,
+				Enabled: configMapValues.IngressController.ControllerServiceEnabled,
 			},
 		},
 		Global: IngressControllerGlobal{

--- a/pkg/v14/configmap/desired_test.go
+++ b/pkg/v14/configmap/desired_test.go
@@ -594,8 +594,9 @@ func Test_ConfigMap_ingressControllerValues(t *testing.T) {
 			name: "case 0: basic match",
 			configMapValues: ConfigMapValues{
 				IngressController: IngressControllerValues{
-					MigrationEnabled: true,
-					UseProxyProtocol: true,
+					ControllerServiceEnabled: false,
+					MigrationEnabled:         true,
+					UseProxyProtocol:         true,
 				},
 				RegistryDomain: "quay.io",
 				WorkerCount:    3,
@@ -607,8 +608,9 @@ func Test_ConfigMap_ingressControllerValues(t *testing.T) {
 			name: "case 1: different worker count",
 			configMapValues: ConfigMapValues{
 				IngressController: IngressControllerValues{
-					MigrationEnabled: true,
-					UseProxyProtocol: true,
+					ControllerServiceEnabled: false,
+					MigrationEnabled:         true,
+					UseProxyProtocol:         true,
 				},
 				RegistryDomain: "quay.io",
 				WorkerCount:    7,
@@ -620,8 +622,9 @@ func Test_ConfigMap_ingressControllerValues(t *testing.T) {
 			name: "case 2: different settings",
 			configMapValues: ConfigMapValues{
 				IngressController: IngressControllerValues{
-					MigrationEnabled: false,
-					UseProxyProtocol: false,
+					ControllerServiceEnabled: true,
+					MigrationEnabled:         false,
+					UseProxyProtocol:         false,
 				},
 				RegistryDomain: "quay.io",
 				WorkerCount:    1,
@@ -633,8 +636,9 @@ func Test_ConfigMap_ingressControllerValues(t *testing.T) {
 			name: "case 3: already migrated",
 			configMapValues: ConfigMapValues{
 				IngressController: IngressControllerValues{
-					MigrationEnabled: true,
-					UseProxyProtocol: false,
+					ControllerServiceEnabled: false,
+					MigrationEnabled:         true,
+					UseProxyProtocol:         false,
 				},
 				RegistryDomain: "quay.io",
 				WorkerCount:    3,

--- a/pkg/v14/configmap/spec.go
+++ b/pkg/v14/configmap/spec.go
@@ -59,8 +59,9 @@ type CoreDNSValues struct {
 // IngressControllerValues provides values for generating the Ingress
 // Controller configmap.
 type IngressControllerValues struct {
-	MigrationEnabled bool
-	UseProxyProtocol bool
+	ControllerServiceEnabled bool
+	MigrationEnabled         bool
+	UseProxyProtocol         bool
 }
 
 // Types below are used for generating values JSON for app configmaps.

--- a/pkg/v15/configmap/desired.go
+++ b/pkg/v15/configmap/desired.go
@@ -178,10 +178,6 @@ func exporterValues(configMapValues ConfigMapValues) ([]byte, error) {
 }
 
 func ingressControllerValues(configMapValues ConfigMapValues, hasLegacyIngressController bool) ([]byte, error) {
-	// controllerServiceEnabled needs to be set separately for the chart
-	// migration logic but is the reverse of migration enabled.
-	controllerServiceEnabled := !configMapValues.IngressController.MigrationEnabled
-
 	migrationEnabled := configMapValues.IngressController.MigrationEnabled
 	if migrationEnabled {
 		// No legacy ingress controller. So no need for the migration process.
@@ -201,7 +197,7 @@ func ingressControllerValues(configMapValues ConfigMapValues, hasLegacyIngressCo
 		Controller: IngressControllerController{
 			Replicas: configMapValues.WorkerCount,
 			Service: IngressControllerControllerService{
-				Enabled: controllerServiceEnabled,
+				Enabled: configMapValues.IngressController.ControllerServiceEnabled,
 			},
 		},
 		Global: IngressControllerGlobal{

--- a/pkg/v15/configmap/desired_test.go
+++ b/pkg/v15/configmap/desired_test.go
@@ -594,8 +594,9 @@ func Test_ConfigMap_ingressControllerValues(t *testing.T) {
 			name: "case 0: basic match",
 			configMapValues: ConfigMapValues{
 				IngressController: IngressControllerValues{
-					MigrationEnabled: true,
-					UseProxyProtocol: true,
+					ControllerServiceEnabled: false,
+					MigrationEnabled:         true,
+					UseProxyProtocol:         true,
 				},
 				RegistryDomain: "quay.io",
 				WorkerCount:    3,
@@ -607,8 +608,9 @@ func Test_ConfigMap_ingressControllerValues(t *testing.T) {
 			name: "case 1: different worker count",
 			configMapValues: ConfigMapValues{
 				IngressController: IngressControllerValues{
-					MigrationEnabled: true,
-					UseProxyProtocol: true,
+					ControllerServiceEnabled: false,
+					MigrationEnabled:         true,
+					UseProxyProtocol:         true,
 				},
 				RegistryDomain: "quay.io",
 				WorkerCount:    7,
@@ -620,8 +622,9 @@ func Test_ConfigMap_ingressControllerValues(t *testing.T) {
 			name: "case 2: different settings",
 			configMapValues: ConfigMapValues{
 				IngressController: IngressControllerValues{
-					MigrationEnabled: false,
-					UseProxyProtocol: false,
+					ControllerServiceEnabled: true,
+					MigrationEnabled:         false,
+					UseProxyProtocol:         false,
 				},
 				RegistryDomain: "quay.io",
 				WorkerCount:    1,
@@ -633,8 +636,9 @@ func Test_ConfigMap_ingressControllerValues(t *testing.T) {
 			name: "case 3: already migrated",
 			configMapValues: ConfigMapValues{
 				IngressController: IngressControllerValues{
-					MigrationEnabled: true,
-					UseProxyProtocol: false,
+					ControllerServiceEnabled: false,
+					MigrationEnabled:         true,
+					UseProxyProtocol:         false,
 				},
 				RegistryDomain: "quay.io",
 				WorkerCount:    3,

--- a/pkg/v15/configmap/spec.go
+++ b/pkg/v15/configmap/spec.go
@@ -59,8 +59,9 @@ type CoreDNSValues struct {
 // IngressControllerValues provides values for generating the Ingress
 // Controller configmap.
 type IngressControllerValues struct {
-	MigrationEnabled bool
-	UseProxyProtocol bool
+	ControllerServiceEnabled bool
+	MigrationEnabled         bool
+	UseProxyProtocol         bool
 }
 
 // Types below are used for generating values JSON for app configmaps.

--- a/service/controller/aws/v14/resource/configmap/desired.go
+++ b/service/controller/aws/v14/resource/configmap/desired.go
@@ -37,7 +37,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		IngressController: configmap.IngressControllerValues{
 			// Controller service is disabled because manifest is created by
 			// Ignition.
-			ControllerServiceEnabled: true,
+			ControllerServiceEnabled: false,
 			// Migration is disabled because AWS is already migrated.
 			MigrationEnabled: false,
 			// Proxy protocol is enabled for AWS clusters.

--- a/service/controller/aws/v14/resource/configmap/desired.go
+++ b/service/controller/aws/v14/resource/configmap/desired.go
@@ -35,6 +35,9 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 			ClusterIPRange:     r.clusterIPRange,
 		},
 		IngressController: configmap.IngressControllerValues{
+			// Controller service is disabled because manifest is created by
+			// Ignition.
+			ControllerServiceEnabled: true,
 			// Migration is disabled because AWS is already migrated.
 			MigrationEnabled: false,
 			// Proxy protocol is enabled for AWS clusters.

--- a/service/controller/aws/v15/resource/configmap/desired.go
+++ b/service/controller/aws/v15/resource/configmap/desired.go
@@ -35,6 +35,9 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 			ClusterIPRange:     r.clusterIPRange,
 		},
 		IngressController: configmap.IngressControllerValues{
+			// Controller service is disabled because manifest is created by
+			// Ignition.
+			ControllerServiceEnabled: false,
 			// Migration is disabled because AWS is already migrated.
 			MigrationEnabled: false,
 			// Proxy protocol is enabled for AWS clusters.

--- a/service/controller/azure/v14/resource/configmap/desired.go
+++ b/service/controller/azure/v14/resource/configmap/desired.go
@@ -35,6 +35,9 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 			ClusterIPRange:     r.clusterIPRange,
 		},
 		IngressController: configmap.IngressControllerValues{
+			// Controller service is enabled because manifest is not created by
+			// Ignition.
+			ControllerServiceEnabled: true,
 			// Migration is disabled because Azure is already migrated.
 			MigrationEnabled: false,
 			// Proxy protocol is disabled for Azure clusters.

--- a/service/controller/azure/v15/resource/configmap/desired.go
+++ b/service/controller/azure/v15/resource/configmap/desired.go
@@ -35,6 +35,9 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 			ClusterIPRange:     r.clusterIPRange,
 		},
 		IngressController: configmap.IngressControllerValues{
+			// Controller service is enabled because manifest is not created by
+			// Ignition.
+			ControllerServiceEnabled: true,
 			// Migration is disabled because Azure is already migrated.
 			MigrationEnabled: false,
 			// Proxy protocol is disabled for Azure clusters.

--- a/service/controller/kvm/v14/resource/configmap/desired.go
+++ b/service/controller/kvm/v14/resource/configmap/desired.go
@@ -35,6 +35,9 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 			ClusterIPRange:     r.clusterIPRange,
 		},
 		IngressController: configmap.IngressControllerValues{
+			// Controller service is disabled because manifest is created by
+			// Ignition.
+			ControllerServiceEnabled: false,
 			// Migration is enabled so existing k8scloudconfig resources are
 			// replaced.
 			MigrationEnabled: true,

--- a/service/controller/kvm/v15/resource/configmap/desired.go
+++ b/service/controller/kvm/v15/resource/configmap/desired.go
@@ -35,6 +35,9 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 			ClusterIPRange:     r.clusterIPRange,
 		},
 		IngressController: configmap.IngressControllerValues{
+			// Controller service is disabled because manifest is created by
+			// Ignition.
+			ControllerServiceEnabled: false,
 			// Migration is enabled so existing k8scloudconfig resources are
 			// replaced.
 			MigrationEnabled: true,


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5750

Since we're disabling the IC migration on AWS but keeping it for KVM it needs updated logic for the IC controller service.