### PR TITLE
Bump up version to v5

### DIFF
--- a/pkg/v15/chartconfig/desired.go
+++ b/pkg/v15/chartconfig/desired.go
@@ -16,7 +16,7 @@ import (
 const (
 	chartConfigAPIVersion           = "core.giantswarm.io"
 	chartConfigKind                 = "ChartConfig"
-	chartConfigVersionBundleVersion = "0.4.0"
+	chartConfigVersionBundleVersion = "0.5.0"
 )
 
 func (c *ChartConfig) GetDesiredState(ctx context.Context, clusterConfig ClusterConfig, providerChartSpecs []key.ChartSpec) ([]*v1alpha1.ChartConfig, error) {


### PR DESCRIPTION
- To enable status description feature for chartconfig, we bump up to `0-5-0` in case of `v15`