### PR TITLE
Update cluster autoscaler in patch release to fix rbac rules

### DIFF
--- a/service/controller/aws/v14patch1/key/key.go
+++ b/service/controller/aws/v14patch1/key/key.go
@@ -14,7 +14,7 @@ func ChartSpecs() []key.ChartSpec {
 	return []key.ChartSpec{
 		{
 			AppName:           "cluster-autoscaler",
-			ChannelName:       "0-2-stable",
+			ChannelName:       "0-3-stable",
 			ChartName:         "kubernetes-cluster-autoscaler-chart",
 			ConfigMapName:     "cluster-autoscaler-values",
 			Namespace:         metav1.NamespaceSystem,

--- a/service/controller/aws/v14patch1/version_bundle.go
+++ b/service/controller/aws/v14patch1/version_bundle.go
@@ -12,6 +12,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Updated to 0.24.1. More info here https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md",
 				Kind:        versionbundle.KindChanged,
 			},
+			{
+				Component:   "cluster-autoscaler",
+				Description: "Fix RBAC rules to include jobs and daemonsets.",
+				Kind:        versionbundle.KindChanged,
+			},
 		},
 		Components: []versionbundle.Component{
 			{

--- a/service/controller/aws/v14patch1/version_bundle.go
+++ b/service/controller/aws/v14patch1/version_bundle.go
@@ -14,7 +14,7 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Component:   "cluster-autoscaler",
-				Description: "Fix RBAC rules to include jobs and daemonsets.",
+				Description: "Fixed RBAC rules to include jobs and daemonsets.",
 				Kind:        versionbundle.KindChanged,
 			},
 		},


### PR DESCRIPTION
Need to test once real quick but this brings the fix for RBAC to k8s 1.13.