### PR TITLE
K8s 1.14 in cluster-autoscaler got bumped to 0.4.0

### DIFF
--- a/service/controller/aws/v15/key/key.go
+++ b/service/controller/aws/v15/key/key.go
@@ -14,7 +14,7 @@ func ChartSpecs() []key.ChartSpec {
 	return []key.ChartSpec{
 		{
 			AppName:           "cluster-autoscaler",
-			ChannelName:       "0-3-stable",
+			ChannelName:       "0-4-stable",
 			ChartName:         "kubernetes-cluster-autoscaler-chart",
 			ConfigMapName:     "cluster-autoscaler-values",
 			Namespace:         metav1.NamespaceSystem,


### PR DESCRIPTION
`0.3.0` got changed to k8s 1.13 for the patch releases, `0.4.0` now has the changes for k8s 1.14