### PR TITLE
Change kubeconfig secret namespace as cluster id

### DIFF
--- a/pkg/v15/resource/kubeconfig/current.go
+++ b/pkg/v15/resource/kubeconfig/current.go
@@ -13,16 +13,16 @@ import (
 )
 
 func (r *StateGetter) GetCurrentState(ctx context.Context, obj interface{}) ([]*corev1.Secret, error) {
-	clusterGuestConfig, err := r.getClusterConfigFunc(obj)
+	clusterConfig, err := r.getClusterConfigFunc(obj)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	secretName := key.KubeConfigSecretName(clusterGuestConfig)
+	secretName := key.KubeConfigSecretName(clusterConfig)
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding kubeconfig secret %#q", secretName))
 
-	secret, err := r.k8sClient.CoreV1().Secrets(clusterGuestConfig.ID).Get(secretName, metav1.GetOptions{})
+	secret, err := r.k8sClient.CoreV1().Secrets(clusterConfig.ID).Get(secretName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find kubeconfig secret %#q", secretName))
 		return nil, nil

--- a/pkg/v15/resource/kubeconfig/current.go
+++ b/pkg/v15/resource/kubeconfig/current.go
@@ -22,7 +22,7 @@ func (r *StateGetter) GetCurrentState(ctx context.Context, obj interface{}) ([]*
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding kubeconfig secret %#q", secretName))
 
-	secret, err := r.k8sClient.CoreV1().Secrets(r.resourceNamespace).Get(secretName, metav1.GetOptions{})
+	secret, err := r.k8sClient.CoreV1().Secrets(clusterGuestConfig.ID).Get(secretName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find kubeconfig secret %#q", secretName))
 		return nil, nil

--- a/pkg/v15/resource/kubeconfig/desired.go
+++ b/pkg/v15/resource/kubeconfig/desired.go
@@ -84,7 +84,7 @@ func (r *StateGetter) GetDesiredState(ctx context.Context, obj interface{}) ([]*
 	secret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
-			Namespace: r.resourceNamespace,
+			Namespace: clusterGuestConfig.ID,
 			Labels: map[string]string{
 				label.Cluster:      clusterGuestConfig.ID,
 				label.ManagedBy:    r.projectName,

--- a/pkg/v15/resource/kubeconfig/desired_test.go
+++ b/pkg/v15/resource/kubeconfig/desired_test.go
@@ -73,7 +73,7 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "w7utg-kubeconfig",
-						Namespace: "giantswarm",
+						Namespace: "w7utg",
 						Labels: map[string]string{
 							"giantswarm.io/cluster":      "w7utg",
 							"giantswarm.io/organization": "giantswarm",
@@ -124,7 +124,6 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 				K8sClient:            clientgofake.NewSimpleClientset(),
 				Logger:               microloggertest.New(),
 				ProjectName:          "cluster-operator",
-				ResourceNamespace:    "giantswarm",
 			}
 
 			r, err := New(c)

--- a/pkg/v15/resource/kubeconfig/resource.go
+++ b/pkg/v15/resource/kubeconfig/resource.go
@@ -27,7 +27,6 @@ type Config struct {
 	// Settings.
 	CertsWatchTimeout time.Duration
 	ProjectName       string
-	ResourceNamespace string
 }
 
 // StateGetter implements the kubeconfig resource.
@@ -40,7 +39,6 @@ type StateGetter struct {
 
 	// Settings.
 	projectName       string
-	resourceNamespace string
 }
 
 // New creates a new configured index resource.
@@ -63,9 +61,6 @@ func New(config Config) (*StateGetter, error) {
 	if config.ProjectName == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ProjectName not be empty", config)
 	}
-	if config.ResourceNamespace == "" {
-		return nil, microerror.Maskf(invalidConfigError, "%T.ResourceNamespace not be empty", config)
-	}
 
 	r := &StateGetter{
 		// Dependencies.
@@ -76,7 +71,6 @@ func New(config Config) (*StateGetter, error) {
 
 		// Settings
 		projectName:       config.ProjectName,
-		resourceNamespace: config.ResourceNamespace,
 	}
 
 	return r, nil

--- a/pkg/v15/resource/kubeconfig/resource.go
+++ b/pkg/v15/resource/kubeconfig/resource.go
@@ -38,7 +38,7 @@ type StateGetter struct {
 	getClusterConfigFunc func(interface{}) (v1alpha1.ClusterGuestConfig, error)
 
 	// Settings.
-	projectName       string
+	projectName string
 }
 
 // New creates a new configured index resource.
@@ -70,7 +70,7 @@ func New(config Config) (*StateGetter, error) {
 		getClusterConfigFunc: config.GetClusterConfigFunc,
 
 		// Settings
-		projectName:       config.ProjectName,
+		projectName: config.ProjectName,
 	}
 
 	return r, nil

--- a/service/controller/aws/v15/resource_set.go
+++ b/service/controller/aws/v15/resource_set.go
@@ -263,7 +263,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			K8sClient:            config.K8sClient,
 			Logger:               config.Logger,
 
-			ProjectName:       config.ProjectName,
+			ProjectName: config.ProjectName,
 		}
 
 		stateGetter, err := kubeconfig.New(c)

--- a/service/controller/aws/v15/resource_set.go
+++ b/service/controller/aws/v15/resource_set.go
@@ -264,7 +264,6 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			Logger:               config.Logger,
 
 			ProjectName:       config.ProjectName,
-			ResourceNamespace: config.ResourceNamespace,
 		}
 
 		stateGetter, err := kubeconfig.New(c)

--- a/service/controller/azure/v15/resource_set.go
+++ b/service/controller/azure/v15/resource_set.go
@@ -261,7 +261,6 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			Logger:               config.Logger,
 
 			ProjectName:       config.ProjectName,
-			ResourceNamespace: config.ResourceNamespace,
 		}
 
 		stateGetter, err := kubeconfig.New(c)

--- a/service/controller/azure/v15/resource_set.go
+++ b/service/controller/azure/v15/resource_set.go
@@ -260,7 +260,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			K8sClient:            config.K8sClient,
 			Logger:               config.Logger,
 
-			ProjectName:       config.ProjectName,
+			ProjectName: config.ProjectName,
 		}
 
 		stateGetter, err := kubeconfig.New(c)

--- a/service/controller/kvm/v15/resource_set.go
+++ b/service/controller/kvm/v15/resource_set.go
@@ -259,7 +259,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			K8sClient:            config.K8sClient,
 			Logger:               config.Logger,
 
-			ProjectName:       config.ProjectName,
+			ProjectName: config.ProjectName,
 		}
 
 		stateGetter, err := kubeconfig.New(c)

--- a/service/controller/kvm/v15/resource_set.go
+++ b/service/controller/kvm/v15/resource_set.go
@@ -260,7 +260,6 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			Logger:               config.Logger,
 
 			ProjectName:       config.ProjectName,
-			ResourceNamespace: config.ResourceNamespace,
 		}
 
 		stateGetter, err := kubeconfig.New(c)


### PR DESCRIPTION
- We are not going to use `giantswarm` namespace anymore for tenant clusters' secret resource. 
- We would store it in tenant cluster ID namespace.