### PR TITLE
Use upgrade force in chartoperator resource

### DIFF
--- a/pkg/v16/resource/chartoperator/create.go
+++ b/pkg/v16/resource/chartoperator/create.go
@@ -84,9 +84,9 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 			}
 
 			err = tenantHelmClient.InstallReleaseFromTarball(ctx, p, chartOperatorNamespace,
+				helm.InstallWait(true),
 				helm.ReleaseName(createState.ReleaseName),
 				helm.ValueOverrides(b),
-				helm.InstallWait(true),
 			)
 			if err != nil {
 				return microerror.Mask(err)

--- a/pkg/v16/resource/chartoperator/resource.go
+++ b/pkg/v16/resource/chartoperator/resource.go
@@ -104,16 +104,16 @@ func New(config Config) (*Resource, error) {
 	}
 
 	newResource := &Resource{
-		apprClient:        config.ApprClient,
-		baseClusterConfig: config.BaseClusterConfig,
-		clusterIPRange:    config.ClusterIPRange,
-		fs:                config.Fs,
-		g8sClient:         config.G8sClient,
-		k8sClient:         config.K8sClient,
-		logger:            config.Logger,
-		projectName:       config.ProjectName,
-		registryDomain:    config.RegistryDomain,
-		tenant:            config.Tenant,
+		apprClient:               config.ApprClient,
+		baseClusterConfig:        config.BaseClusterConfig,
+		clusterIPRange:           config.ClusterIPRange,
+		fs:                       config.Fs,
+		g8sClient:                config.G8sClient,
+		k8sClient:                config.K8sClient,
+		logger:                   config.Logger,
+		projectName:              config.ProjectName,
+		registryDomain:           config.RegistryDomain,
+		tenant:                   config.Tenant,
 		toClusterGuestConfigFunc: config.ToClusterGuestConfigFunc,
 		toClusterObjectMetaFunc:  config.ToClusterObjectMetaFunc,
 	}

--- a/pkg/v16/resource/chartoperator/resource.go
+++ b/pkg/v16/resource/chartoperator/resource.go
@@ -29,6 +29,7 @@ const (
 	chartOperatorRelease       = "chart-operator"
 	chartOperatorNamespace     = "giantswarm"
 	chartOperatorDesiredStatus = "DEPLOYED"
+	chartOperatorFailedStatus  = "FAILED"
 )
 
 // Config represents the configuration used to create a new chartoperator resource.
@@ -103,16 +104,16 @@ func New(config Config) (*Resource, error) {
 	}
 
 	newResource := &Resource{
-		apprClient:               config.ApprClient,
-		baseClusterConfig:        config.BaseClusterConfig,
-		clusterIPRange:           config.ClusterIPRange,
-		fs:                       config.Fs,
-		g8sClient:                config.G8sClient,
-		k8sClient:                config.K8sClient,
-		logger:                   config.Logger,
-		projectName:              config.ProjectName,
-		registryDomain:           config.RegistryDomain,
-		tenant:                   config.Tenant,
+		apprClient:        config.ApprClient,
+		baseClusterConfig: config.BaseClusterConfig,
+		clusterIPRange:    config.ClusterIPRange,
+		fs:                config.Fs,
+		g8sClient:         config.G8sClient,
+		k8sClient:         config.K8sClient,
+		logger:            config.Logger,
+		projectName:       config.ProjectName,
+		registryDomain:    config.RegistryDomain,
+		tenant:            config.Tenant,
 		toClusterGuestConfigFunc: config.ToClusterGuestConfigFunc,
 		toClusterObjectMetaFunc:  config.ToClusterObjectMetaFunc,
 	}
@@ -213,6 +214,11 @@ func shouldUpdate(currentState, desiredState ResourceState) bool {
 	}
 
 	if !reflect.DeepEqual(currentState.ChartValues, desiredState.ChartValues) {
+		return true
+	}
+
+	if currentState.ReleaseStatus == chartOperatorFailedStatus {
+		// Release status is failed so do force upgrade to attempt to fix it.
 		return true
 	}
 

--- a/pkg/v16/resource/chartoperator/update.go
+++ b/pkg/v16/resource/chartoperator/update.go
@@ -84,6 +84,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 				updateState.ReleaseName,
 				tarballPath,
 				helm.UpdateValueOverrides(b),
+				helm.UpgradeForce(true),
 			)
 			if err != nil {
 				return microerror.Mask(err)

--- a/pkg/v16/resource/chartoperator/update_test.go
+++ b/pkg/v16/resource/chartoperator/update_test.go
@@ -108,6 +108,37 @@ func Test_Resource_Chart_newUpdate(t *testing.T) {
 				ReleaseVersion: "0.1.2",
 			},
 		},
+		{
+			name: "case 6: current release is failed, expected desired",
+			currentState: &ResourceState{
+				ChartName: "current",
+				ChartValues: Values{
+					Tiller: Tiller{
+						Namespace: "default",
+					},
+				},
+				ReleaseStatus:  "FAILED",
+				ReleaseVersion: "0.1.2",
+			},
+			desiredState: &ResourceState{
+				ChartName: "desired",
+				ChartValues: Values{
+					Tiller: Tiller{
+						Namespace: "giantswarm",
+					},
+				},
+				ReleaseVersion: "0.1.2",
+			},
+			expectedState: &ResourceState{
+				ChartName: "desired",
+				ChartValues: Values{
+					Tiller: Tiller{
+						Namespace: "giantswarm",
+					},
+				},
+				ReleaseVersion: "0.1.2",
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5749

An automated fix for failed chart-operator helm releases in tenant clusters. We now do `helm.UpgradeForce` and an update is triggered if the release if failed.