### PR TITLE
Backport fix for failed chart-operator helm releases

### DIFF
--- a/pkg/v10/resource/chartoperator/resource.go
+++ b/pkg/v10/resource/chartoperator/resource.go
@@ -185,5 +185,10 @@ func shouldUpdate(currentState, desiredState ResourceState) bool {
 		return true
 	}
 
+	if currentState.ReleaseStatus == "FAILED" {
+		// Release status is failed so do force upgrade to attempt to fix it.
+		return true
+	}
+
 	return false
 }

--- a/pkg/v10/resource/chartoperator/update.go
+++ b/pkg/v10/resource/chartoperator/update.go
@@ -87,6 +87,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 				updateState.ReleaseName,
 				tarballPath,
 				helm.UpdateValueOverrides([]byte("{}")),
+				helm.UpgradeForce(true),
 			)
 			if err != nil {
 				return microerror.Mask(err)

--- a/pkg/v12/resource/chartoperator/resource.go
+++ b/pkg/v12/resource/chartoperator/resource.go
@@ -216,5 +216,10 @@ func shouldUpdate(currentState, desiredState ResourceState) bool {
 		return true
 	}
 
+	if currentState.ReleaseStatus == "FAILED" {
+		// Release status is failed so do force upgrade to attempt to fix it.
+		return true
+	}
+
 	return false
 }

--- a/pkg/v12/resource/chartoperator/update.go
+++ b/pkg/v12/resource/chartoperator/update.go
@@ -84,6 +84,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 				updateState.ReleaseName,
 				tarballPath,
 				helm.UpdateValueOverrides(b),
+				helm.UpgradeForce(true),
 			)
 			if err != nil {
 				return microerror.Mask(err)

--- a/pkg/v13/resource/chartoperator/resource.go
+++ b/pkg/v13/resource/chartoperator/resource.go
@@ -216,5 +216,10 @@ func shouldUpdate(currentState, desiredState ResourceState) bool {
 		return true
 	}
 
+	if currentState.ReleaseStatus == "FAILED" {
+		// Release status is failed so do force upgrade to attempt to fix it.
+		return true
+	}
+
 	return false
 }

--- a/pkg/v13/resource/chartoperator/update.go
+++ b/pkg/v13/resource/chartoperator/update.go
@@ -84,6 +84,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 				updateState.ReleaseName,
 				tarballPath,
 				helm.UpdateValueOverrides(b),
+				helm.UpgradeForce(true),
 			)
 			if err != nil {
 				return microerror.Mask(err)

--- a/pkg/v14patch1/resource/chartoperator/resource.go
+++ b/pkg/v14patch1/resource/chartoperator/resource.go
@@ -216,5 +216,10 @@ func shouldUpdate(currentState, desiredState ResourceState) bool {
 		return true
 	}
 
+	if currentState.ReleaseStatus == "FAILED" {
+		// Release status is failed so do force upgrade to attempt to fix it.
+		return true
+	}
+
 	return false
 }

--- a/pkg/v14patch1/resource/chartoperator/update.go
+++ b/pkg/v14patch1/resource/chartoperator/update.go
@@ -84,6 +84,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 				updateState.ReleaseName,
 				tarballPath,
 				helm.UpdateValueOverrides(b),
+				helm.UpgradeForce(true),
 			)
 			if err != nil {
 				return microerror.Mask(err)

--- a/pkg/v15/resource/chartoperator/resource.go
+++ b/pkg/v15/resource/chartoperator/resource.go
@@ -216,5 +216,10 @@ func shouldUpdate(currentState, desiredState ResourceState) bool {
 		return true
 	}
 
+	if currentState.ReleaseStatus == "FAILED" {
+		// Release status is failed so do force upgrade to attempt to fix it.
+		return true
+	}
+
 	return false
 }

--- a/pkg/v15/resource/chartoperator/update.go
+++ b/pkg/v15/resource/chartoperator/update.go
@@ -84,6 +84,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 				updateState.ReleaseName,
 				tarballPath,
 				helm.UpdateValueOverrides(b),
+				helm.UpgradeForce(true),
 			)
 			if err != nil {
 				return microerror.Mask(err)


### PR DESCRIPTION
Towards giantswarm/giantswarm#5749

Follow up to https://github.com/giantswarm/cluster-operator/pull/468 backports fix to `v15, v14patch1, v13, v12 and v10` which provides coverage for most tenant clusters.