### PR TITLE
Use chartconfig 0.6.0 for upgrade force support

### DIFF
--- a/pkg/v16/chartconfig/desired.go
+++ b/pkg/v16/chartconfig/desired.go
@@ -17,7 +17,7 @@ import (
 const (
 	chartConfigAPIVersion           = "core.giantswarm.io"
 	chartConfigKind                 = "ChartConfig"
-	chartConfigVersionBundleVersion = "0.5.0"
+	chartConfigVersionBundleVersion = "0.6.0"
 )
 
 func (c *ChartConfig) GetDesiredState(ctx context.Context, clusterConfig ClusterConfig, providerChartSpecs []key.ChartSpec) ([]*v1alpha1.ChartConfig, error) {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5745

I missed an important step. We need to bump the version in chartconfig CRs to 0.6.0 to enable the force upgrade fix.

I also need to add new v7 WIP version. I'll do that next.