### PR TITLE
Bump chart-op release channel to 0-7-stable

### DIFF
--- a/pkg/v16/resource/chartoperator/resource.go
+++ b/pkg/v16/resource/chartoperator/resource.go
@@ -24,7 +24,7 @@ const (
 	Name = "chartoperatorv16"
 
 	chartOperatorChart         = "chart-operator-chart"
-	chartOperatorChannel       = "0-6-stable"
+	chartOperatorChannel       = "0-7-stable"
 	chartOperatorDeployment    = "chart-operator"
 	chartOperatorRelease       = "chart-operator"
 	chartOperatorNamespace     = "giantswarm"


### PR DESCRIPTION
Final piece of the puzzle that I missed.

We had a problem with rogue commits getting pushed to release channels. So we create a new release channel for each new WIP chart-operator version.