### PR TITLE
add machine deployment controller

### DIFF
--- a/helm/cluster-operator-chart/templates/rbac.yaml
+++ b/helm/cluster-operator-chart/templates/rbac.yaml
@@ -32,6 +32,7 @@ rules:
       - cluster.k8s.io
     resources:
       - clusters
+      - machinedeployments
     verbs:
       - get
       - list

--- a/service/controller/clusterapi/v17/machine_deployment_resource_set.go
+++ b/service/controller/clusterapi/v17/machine_deployment_resource_set.go
@@ -1,0 +1,87 @@
+package v17
+
+import (
+	"context"
+
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/resource/metricsresource"
+	"github.com/giantswarm/operatorkit/controller/resource/retryresource"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
+
+	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v17/resources/machinedeploymentstatus"
+)
+
+type MachineDeploymentResourceSetConfig struct {
+	CMAClient clientset.Interface
+	G8sClient versioned.Interface
+	Logger    micrologger.Logger
+}
+
+func NewMachineDeploymentResourceSet(config MachineDeploymentResourceSetConfig) (*controller.ResourceSet, error) {
+	var err error
+
+	var machineDeploymentStatusResource controller.Resource
+	{
+		c := machinedeploymentstatus.Config{
+			CMAClient: config.CMAClient,
+			G8sClient: config.G8sClient,
+			Logger:    config.Logger,
+		}
+
+		machineDeploymentStatusResource, err = machinedeploymentstatus.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	resources := []controller.Resource{
+		machineDeploymentStatusResource,
+	}
+
+	{
+		c := retryresource.WrapConfig{
+			Logger: config.Logger,
+		}
+
+		resources, err = retryresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	{
+		c := metricsresource.WrapConfig{}
+		resources, err = metricsresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	initCtxFunc := func(ctx context.Context, obj interface{}) (context.Context, error) {
+		return ctx, nil
+	}
+
+	handlesFunc := func(obj interface{}) bool {
+		return true
+	}
+
+	var resourceSet *controller.ResourceSet
+	{
+		c := controller.ResourceSetConfig{
+			Handles:   handlesFunc,
+			InitCtx:   initCtxFunc,
+			Logger:    config.Logger,
+			Resources: resources,
+		}
+
+		resourceSet, err = controller.NewResourceSet(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return resourceSet, nil
+}

--- a/service/controller/clusterapi/v17/resources/machinedeploymentstatus/create.go
+++ b/service/controller/clusterapi/v17/resources/machinedeploymentstatus/create.go
@@ -1,0 +1,9 @@
+package machinedeploymentstatus
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/clusterapi/v17/resources/machinedeploymentstatus/delete.go
+++ b/service/controller/clusterapi/v17/resources/machinedeploymentstatus/delete.go
@@ -1,0 +1,9 @@
+package machinedeploymentstatus
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/clusterapi/v17/resources/machinedeploymentstatus/error.go
+++ b/service/controller/clusterapi/v17/resources/machinedeploymentstatus/error.go
@@ -1,0 +1,14 @@
+package machinedeploymentstatus
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/clusterapi/v17/resources/machinedeploymentstatus/resource.go
+++ b/service/controller/clusterapi/v17/resources/machinedeploymentstatus/resource.go
@@ -1,0 +1,48 @@
+package machinedeploymentstatus
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
+)
+
+const (
+	Name = "machinedeploymentstatusv17"
+)
+
+type Config struct {
+	CMAClient clientset.Interface
+	G8sClient versioned.Interface
+	Logger    micrologger.Logger
+}
+
+type Resource struct {
+	cmaClient clientset.Interface
+	g8sClient versioned.Interface
+	logger    micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.CMAClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CMAClient must not be empty", config)
+	}
+	if config.G8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		cmaClient: config.CMAClient,
+		g8sClient: config.G8sClient,
+		logger:    config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}


### PR DESCRIPTION
Towards Node Pools. `cluster-operator` will reconcile the status of machine deployments based on registered TC nodes. 