### PR TITLE
Add boilerplate for clusterstatus resource

### DIFF
--- a/service/controller/clusterapi/v17/resource_set.go
+++ b/service/controller/clusterapi/v17/resource_set.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/giantswarm/cluster-operator/pkg/cluster"
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v17/resources/awsclusterconfig"
+	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v17/resources/clusterstatus"
 )
 
 // ResourceSetConfig contains necessary dependencies and settings for
@@ -43,6 +44,20 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 
+	var clusterstatusResource controller.Resource
+	{
+		c := clusterstatus.Config{
+			CMAClient: config.CMAClient,
+			G8sClient: config.G8sClient,
+			Logger:    config.Logger,
+		}
+
+		clusterstatusResource, err = clusterstatus.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var awsclusterconfigResource controller.Resource
 	{
 		c := awsclusterconfig.Config{
@@ -60,6 +75,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	}
 
 	resources := []controller.Resource{
+		clusterstatusResource,
 		awsclusterconfigResource,
 	}
 

--- a/service/controller/clusterapi/v17/resources/clusterstatus/create.go
+++ b/service/controller/clusterapi/v17/resources/clusterstatus/create.go
@@ -1,0 +1,9 @@
+package clusterstatus
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/clusterapi/v17/resources/clusterstatus/delete.go
+++ b/service/controller/clusterapi/v17/resources/clusterstatus/delete.go
@@ -1,0 +1,9 @@
+package clusterstatus
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/clusterapi/v17/resources/clusterstatus/error.go
+++ b/service/controller/clusterapi/v17/resources/clusterstatus/error.go
@@ -1,0 +1,14 @@
+package clusterstatus
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/clusterapi/v17/resources/clusterstatus/resource.go
+++ b/service/controller/clusterapi/v17/resources/clusterstatus/resource.go
@@ -1,0 +1,48 @@
+package clusterstatus
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
+)
+
+const (
+	Name = "clusterstatusv17"
+)
+
+type Config struct {
+	CMAClient clientset.Interface
+	G8sClient versioned.Interface
+	Logger    micrologger.Logger
+}
+
+type Resource struct {
+	cmaClient clientset.Interface
+	g8sClient versioned.Interface
+	logger    micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.CMAClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CMAClient must not be empty", config)
+	}
+	if config.G8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		cmaClient: config.CMAClient,
+		g8sClient: config.G8sClient,
+		logger:    config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}


### PR DESCRIPTION
This introduces a clusterstatus resource that is used to populate provider
independent fields into Cluster CR provider status extension. In other words,
this will populate AWSClusterStatus.Cluster which is stored in Cluster CR under
Status.ProviderStatus.