### PR TITLE
add tenantclients resource to have them available in the controllercontext

### DIFF
--- a/service/controller/clusterapi/v17/machine_deployment_resource_set.go
+++ b/service/controller/clusterapi/v17/machine_deployment_resource_set.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v17/key"
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v17/resources/machinedeploymentstatus"
+	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v17/resources/tenantclients"
 )
 
 type MachineDeploymentResourceSetConfig struct {
@@ -38,7 +39,22 @@ func NewMachineDeploymentResourceSet(config MachineDeploymentResourceSetConfig) 
 		}
 	}
 
+	var tenantClientsResource controller.Resource
+	{
+		c := tenantclients.Config{
+			CMAClient: config.CMAClient,
+			G8sClient: config.G8sClient,
+			Logger:    config.Logger,
+		}
+
+		tenantClientsResource, err = tenantclients.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	resources := []controller.Resource{
+		tenantClientsResource,
 		machineDeploymentStatusResource,
 	}
 

--- a/service/controller/clusterapi/v17/resources/tenantclients/create.go
+++ b/service/controller/clusterapi/v17/resources/tenantclients/create.go
@@ -1,0 +1,9 @@
+package tenantclients
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/clusterapi/v17/resources/tenantclients/delete.go
+++ b/service/controller/clusterapi/v17/resources/tenantclients/delete.go
@@ -1,0 +1,9 @@
+package tenantclients
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/clusterapi/v17/resources/tenantclients/error.go
+++ b/service/controller/clusterapi/v17/resources/tenantclients/error.go
@@ -1,0 +1,14 @@
+package tenantclients
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/clusterapi/v17/resources/tenantclients/resource.go
+++ b/service/controller/clusterapi/v17/resources/tenantclients/resource.go
@@ -1,0 +1,48 @@
+package tenantclients
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
+)
+
+const (
+	Name = "tenantclientsv17"
+)
+
+type Config struct {
+	CMAClient clientset.Interface
+	G8sClient versioned.Interface
+	Logger    micrologger.Logger
+}
+
+type Resource struct {
+	cmaClient clientset.Interface
+	g8sClient versioned.Interface
+	logger    micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.CMAClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CMAClient must not be empty", config)
+	}
+	if config.G8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		cmaClient: config.CMAClient,
+		g8sClient: config.G8sClient,
+		logger:    config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}


### PR DESCRIPTION
Towards Node Pools. For status management we need information of the tenant cluster nodes. Idea here is to have tenant clients in the controller context. A dedicated resource can put it there and make it available for all other resources that way so that other resources do not need to deal with it. The PR here only provides the structure of the proposed resource. 