### PR TITLE
Add tenantclients resource to Cluster controller

### DIFF
--- a/service/controller/clusterapi/cluster.go
+++ b/service/controller/clusterapi/cluster.go
@@ -9,12 +9,13 @@ import (
 	"github.com/giantswarm/operatorkit/client/k8scrdclient"
 	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/informer"
+	"github.com/giantswarm/tenantcluster"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 
 	"github.com/giantswarm/cluster-operator/pkg/cluster"
-	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v17"
+	v17 "github.com/giantswarm/cluster-operator/service/controller/clusterapi/v17"
 )
 
 // ClusterConfig contains necessary dependencies and settings for
@@ -26,6 +27,7 @@ type ClusterConfig struct {
 	G8sClient         versioned.Interface
 	K8sExtClient      apiextensionsclient.Interface
 	Logger            micrologger.Logger
+	Tenant            tenantcluster.Interface
 
 	ProjectName string
 }
@@ -75,6 +77,7 @@ func NewCluster(config ClusterConfig) (*Cluster, error) {
 			CMAClient:         config.CMAClient,
 			G8sClient:         config.G8sClient,
 			Logger:            config.Logger,
+			Tenant:            config.Tenant,
 		}
 
 		resourceSetV17, err = v17.NewClusterResourceSet(c)

--- a/service/controller/clusterapi/v17/resources/tenantclients/create.go
+++ b/service/controller/clusterapi/v17/resources/tenantclients/create.go
@@ -15,23 +15,35 @@ import (
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
-	cr, err := key.ToMachineDeployment(obj)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-	cc, err := controllercontext.FromContext(ctx)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
 	var cluster v1alpha1.Cluster
-	{
+	var err error
+
+	// This resource is used both from Cluster and MachineDeployment
+	// controllers so it must work with both types.
+	switch obj.(type) {
+	case v1alpha1.Cluster:
+		cluster, err = key.ToCluster(obj)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+	case v1alpha1.MachineDeployment:
+		cr, err := key.ToMachineDeployment(obj)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
 		m, err := r.cmaClient.ClusterV1alpha1().Clusters(corev1.NamespaceAll).Get(key.ClusterID(&cr), metav1.GetOptions{})
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
 		cluster = *m
+	}
+
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
 	}
 
 	var g8sClient versioned.Interface

--- a/service/service.go
+++ b/service/service.go
@@ -265,6 +265,7 @@ func New(config Config) (*Service, error) {
 			G8sClient:         g8sClient,
 			K8sExtClient:      k8sExtClient,
 			Logger:            config.Logger,
+			Tenant:            tenantCluster,
 
 			ProjectName: config.ProjectName,
 		}


### PR DESCRIPTION
In order to find out status of tenant K8s API and versions of worker nodes,
there must be tenant cluster client present in Cluster controller as well for
clusterstatus implementation.