### PR TITLE
Disable Ingress Controller migration on KVM

### DIFF
--- a/pkg/v17/configmap/desired_test.go
+++ b/pkg/v17/configmap/desired_test.go
@@ -315,7 +315,7 @@ func Test_ConfigMap_newConfigMap(t *testing.T) {
 				Name:      "test-app-values",
 				Namespace: metav1.NamespaceSystem,
 				Labels: map[string]string{
-					"app": "test-app",
+					"app":                   "test-app",
 					"giantswarm.io/cluster": "5xchu",
 				},
 			},
@@ -324,7 +324,7 @@ func Test_ConfigMap_newConfigMap(t *testing.T) {
 					Name:      "test-app-values",
 					Namespace: metav1.NamespaceSystem,
 					Labels: map[string]string{
-						"app": "test-app",
+						"app":                   "test-app",
 						"giantswarm.io/cluster": "5xchu",
 					},
 				},
@@ -338,7 +338,7 @@ func Test_ConfigMap_newConfigMap(t *testing.T) {
 				Name:      "test-app-values",
 				Namespace: metav1.NamespaceSystem,
 				Labels: map[string]string{
-					"app": "test-app",
+					"app":                   "test-app",
 					"giantswarm.io/cluster": "5xchu",
 				},
 				ValuesJSON: "{\"image\":{\"registry\":\"quay.io\"}}",
@@ -348,7 +348,7 @@ func Test_ConfigMap_newConfigMap(t *testing.T) {
 					Name:      "test-app-values",
 					Namespace: metav1.NamespaceSystem,
 					Labels: map[string]string{
-						"app": "test-app",
+						"app":                   "test-app",
 						"giantswarm.io/cluster": "5xchu",
 					},
 				},

--- a/pkg/v17/configmap/desired_test.go
+++ b/pkg/v17/configmap/desired_test.go
@@ -315,7 +315,7 @@ func Test_ConfigMap_newConfigMap(t *testing.T) {
 				Name:      "test-app-values",
 				Namespace: metav1.NamespaceSystem,
 				Labels: map[string]string{
-					"app":                   "test-app",
+					"app": "test-app",
 					"giantswarm.io/cluster": "5xchu",
 				},
 			},
@@ -324,7 +324,7 @@ func Test_ConfigMap_newConfigMap(t *testing.T) {
 					Name:      "test-app-values",
 					Namespace: metav1.NamespaceSystem,
 					Labels: map[string]string{
-						"app":                   "test-app",
+						"app": "test-app",
 						"giantswarm.io/cluster": "5xchu",
 					},
 				},
@@ -338,7 +338,7 @@ func Test_ConfigMap_newConfigMap(t *testing.T) {
 				Name:      "test-app-values",
 				Namespace: metav1.NamespaceSystem,
 				Labels: map[string]string{
-					"app":                   "test-app",
+					"app": "test-app",
 					"giantswarm.io/cluster": "5xchu",
 				},
 				ValuesJSON: "{\"image\":{\"registry\":\"quay.io\"}}",
@@ -348,7 +348,7 @@ func Test_ConfigMap_newConfigMap(t *testing.T) {
 					Name:      "test-app-values",
 					Namespace: metav1.NamespaceSystem,
 					Labels: map[string]string{
-						"app":                   "test-app",
+						"app": "test-app",
 						"giantswarm.io/cluster": "5xchu",
 					},
 				},
@@ -586,7 +586,6 @@ func Test_ConfigMap_ingressControllerValues(t *testing.T) {
 	testCases := []struct {
 		name               string
 		configMapValues    ConfigMapValues
-		hasLegacyIC        bool
 		errorMatcher       func(error) bool
 		expectedValuesJSON string
 	}{
@@ -601,7 +600,6 @@ func Test_ConfigMap_ingressControllerValues(t *testing.T) {
 				RegistryDomain: "quay.io",
 				WorkerCount:    3,
 			},
-			hasLegacyIC:        true,
 			expectedValuesJSON: basicMatchJSON,
 		},
 		{
@@ -615,7 +613,6 @@ func Test_ConfigMap_ingressControllerValues(t *testing.T) {
 				RegistryDomain: "quay.io",
 				WorkerCount:    7,
 			},
-			hasLegacyIC:        true,
 			expectedValuesJSON: differentWorkerCountJSON,
 		},
 		{
@@ -629,28 +626,13 @@ func Test_ConfigMap_ingressControllerValues(t *testing.T) {
 				RegistryDomain: "quay.io",
 				WorkerCount:    1,
 			},
-			hasLegacyIC:        true,
 			expectedValuesJSON: differentSettingsJSON,
-		},
-		{
-			name: "case 3: already migrated",
-			configMapValues: ConfigMapValues{
-				IngressController: IngressControllerValues{
-					ControllerServiceEnabled: false,
-					MigrationEnabled:         true,
-					UseProxyProtocol:         false,
-				},
-				RegistryDomain: "quay.io",
-				WorkerCount:    3,
-			},
-			hasLegacyIC:        false,
-			expectedValuesJSON: alreadyMigratedJSON,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			values, err := ingressControllerValues(tc.configMapValues, tc.hasLegacyIC)
+			values, err := ingressControllerValues(tc.configMapValues)
 
 			switch {
 			case err == nil && tc.errorMatcher == nil:

--- a/service/controller/kvm/v17/resource/configmap/desired.go
+++ b/service/controller/kvm/v17/resource/configmap/desired.go
@@ -38,9 +38,8 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 			// Controller service is disabled because manifest is created by
 			// Ignition.
 			ControllerServiceEnabled: false,
-			// Migration is enabled so existing k8scloudconfig resources are
-			// replaced.
-			MigrationEnabled: true,
+			// Migration is disabled because KVM is already migrated.
+			MigrationEnabled: false,
 			// Proxy protocol is disabled for KVM clusters.
 			UseProxyProtocol: false,
 		},

--- a/service/controller/kvm/v17/version_bundle.go
+++ b/service/controller/kvm/v17/version_bundle.go
@@ -8,9 +8,9 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "TODO",
-				Description: "TODO",
-				Kind:        versionbundle.KindAdded,
+				Component:   "nginx-ingress-controller",
+				Description: "Disabled migration logic now migration to helm chart is complete.",
+				Kind:        versionbundle.KindRemoved,
 			},
 		},
 		Components: []versionbundle.Component{


### PR DESCRIPTION
Follow up to #498.

Disables the IC migration logic on KVM as all clusters now use the Helm chart. AWS and Azure have been disabled for a while.

Also removes some unused code. The rest of the cleanup will be done when migrating IC from using a `chartconfig` CR to using an `app` CR.