### PR TITLE
Remove tenantclients resource from Cluster controller for now

### DIFF
--- a/service/controller/clusterapi/v17/cluster_resource_set.go
+++ b/service/controller/clusterapi/v17/cluster_resource_set.go
@@ -14,11 +14,9 @@ import (
 	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 
 	"github.com/giantswarm/cluster-operator/pkg/cluster"
-	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v17/controllercontext"
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v17/key"
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v17/resources/awsclusterconfig"
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v17/resources/clusterstatus"
-	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v17/resources/tenantclients"
 )
 
 // ClusterResourceSetConfig contains necessary dependencies and settings for
@@ -43,6 +41,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 			CMAClient: config.CMAClient,
 			G8sClient: config.G8sClient,
 			Logger:    config.Logger,
+			Tenant:    config.Tenant,
 		}
 
 		clusterstatusResource, err = clusterstatus.New(c)
@@ -67,22 +66,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		}
 	}
 
-	var tenantClientsResource controller.Resource
-	{
-		c := tenantclients.Config{
-			CMAClient: config.CMAClient,
-			Logger:    config.Logger,
-			Tenant:    config.Tenant,
-		}
-
-		tenantClientsResource, err = tenantclients.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
 	resources := []controller.Resource{
-		tenantClientsResource,
 		clusterstatusResource,
 		awsclusterconfigResource,
 	}
@@ -108,7 +92,6 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 	}
 
 	initCtxFunc := func(ctx context.Context, obj interface{}) (context.Context, error) {
-		ctx = controllercontext.NewContext(ctx, controllercontext.Context{})
 		return ctx, nil
 	}
 

--- a/service/controller/clusterapi/v17/resources/clusterstatus/resource.go
+++ b/service/controller/clusterapi/v17/resources/clusterstatus/resource.go
@@ -4,6 +4,7 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/tenantcluster"
 	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 )
 
@@ -15,12 +16,14 @@ type Config struct {
 	CMAClient clientset.Interface
 	G8sClient versioned.Interface
 	Logger    micrologger.Logger
+	Tenant    tenantcluster.Interface
 }
 
 type Resource struct {
 	cmaClient clientset.Interface
 	g8sClient versioned.Interface
 	logger    micrologger.Logger
+	tenant    tenantcluster.Interface
 }
 
 func New(config Config) (*Resource, error) {
@@ -33,11 +36,15 @@ func New(config Config) (*Resource, error) {
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
+	if config.Tenant == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Tenant must not be empty", config)
+	}
 
 	r := &Resource{
 		cmaClient: config.CMAClient,
 		g8sClient: config.G8sClient,
 		logger:    config.Logger,
+		tenant:    config.Tenant,
 	}
 
 	return r, nil

--- a/service/controller/clusterapi/v17/resources/tenantclients/create.go
+++ b/service/controller/clusterapi/v17/resources/tenantclients/create.go
@@ -15,35 +15,23 @@ import (
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	cr, err := key.ToMachineDeployment(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
 	var cluster v1alpha1.Cluster
-	var err error
-
-	// This resource is used both from Cluster and MachineDeployment
-	// controllers so it must work with both types.
-	switch obj.(type) {
-	case v1alpha1.Cluster:
-		cluster, err = key.ToCluster(obj)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-	case v1alpha1.MachineDeployment:
-		cr, err := key.ToMachineDeployment(obj)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
+	{
 		m, err := r.cmaClient.ClusterV1alpha1().Clusters(corev1.NamespaceAll).Get(key.ClusterID(&cr), metav1.GetOptions{})
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
 		cluster = *m
-	}
-
-	cc, err := controllercontext.FromContext(ctx)
-	if err != nil {
-		return microerror.Mask(err)
 	}
 
 	var g8sClient versioned.Interface

--- a/service/controller/clusterapi/v17/resources/tenantclients/delete.go
+++ b/service/controller/clusterapi/v17/resources/tenantclients/delete.go
@@ -15,35 +15,23 @@ import (
 )
 
 func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	cr, err := key.ToMachineDeployment(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
 	var cluster v1alpha1.Cluster
-	var err error
-
-	// This resource is used both from Cluster and MachineDeployment
-	// controllers so it must work with both types.
-	switch obj.(type) {
-	case v1alpha1.Cluster:
-		cluster, err = key.ToCluster(obj)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-	case v1alpha1.MachineDeployment:
-		cr, err := key.ToMachineDeployment(obj)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
+	{
 		m, err := r.cmaClient.ClusterV1alpha1().Clusters(corev1.NamespaceAll).Get(key.ClusterID(&cr), metav1.GetOptions{})
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
 		cluster = *m
-	}
-
-	cc, err := controllercontext.FromContext(ctx)
-	if err != nil {
-		return microerror.Mask(err)
 	}
 
 	var g8sClient versioned.Interface


### PR DESCRIPTION
In the very beginning of cluster creation, means to create tenant cluster
client don't exist. In order to move the world to a state where it is possible,
clusterstatus resource must get executed. Failing tenantcluster client creation
cancels whole reconciliation round so those required tenantcluster clients must
be constructed on-demand in clusterstatus resource.