### PR TITLE
configure cluster cr lookup to ease tenantclients resource

### DIFF
--- a/service/controller/clusterapi/v17/cluster_resource_set.go
+++ b/service/controller/clusterapi/v17/cluster_resource_set.go
@@ -70,9 +70,10 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 	var tenantClientsResource controller.Resource
 	{
 		c := tenantclients.Config{
-			CMAClient: config.CMAClient,
-			Logger:    config.Logger,
-			Tenant:    config.Tenant,
+			CMAClient:     config.CMAClient,
+			Logger:        config.Logger,
+			Tenant:        config.Tenant,
+			ToClusterFunc: key.ToCluster,
 		}
 
 		tenantClientsResource, err = tenantclients.New(c)

--- a/service/controller/clusterapi/v17/resources/tenantclients/create.go
+++ b/service/controller/clusterapi/v17/resources/tenantclients/create.go
@@ -3,66 +3,13 @@ package tenantclients
 import (
 	"context"
 
-	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/microerror"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
-
-	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v17/controllercontext"
-	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v17/key"
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
-	var cluster v1alpha1.Cluster
-	var err error
-
-	// This resource is used both from Cluster and MachineDeployment
-	// controllers so it must work with both types.
-	switch obj.(type) {
-	case v1alpha1.Cluster:
-		cluster, err = key.ToCluster(obj)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-	case v1alpha1.MachineDeployment:
-		cr, err := key.ToMachineDeployment(obj)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		m, err := r.cmaClient.ClusterV1alpha1().Clusters(corev1.NamespaceAll).Get(key.ClusterID(&cr), metav1.GetOptions{})
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		cluster = *m
-	}
-
-	cc, err := controllercontext.FromContext(ctx)
+	err := r.ensure(ctx, obj)
 	if err != nil {
 		return microerror.Mask(err)
-	}
-
-	var g8sClient versioned.Interface
-	var k8sClient kubernetes.Interface
-	{
-		g8sClient, err = r.tenant.NewG8sClient(ctx, key.ClusterID(&cluster), key.ClusterAPIEndpoint(cluster))
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		k8sClient, err = r.tenant.NewK8sClient(ctx, key.ClusterID(&cluster), key.ClusterAPIEndpoint(cluster))
-		if err != nil {
-			return microerror.Mask(err)
-		}
-	}
-
-	{
-		cc.Client.TenantCluster.G8s = g8sClient
-		cc.Client.TenantCluster.K8s = k8sClient
 	}
 
 	return nil

--- a/service/controller/clusterapi/v17/resources/tenantclients/delete.go
+++ b/service/controller/clusterapi/v17/resources/tenantclients/delete.go
@@ -3,66 +3,13 @@ package tenantclients
 import (
 	"context"
 
-	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/microerror"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
-
-	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v17/controllercontext"
-	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v17/key"
 )
 
 func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
-	var cluster v1alpha1.Cluster
-	var err error
-
-	// This resource is used both from Cluster and MachineDeployment
-	// controllers so it must work with both types.
-	switch obj.(type) {
-	case v1alpha1.Cluster:
-		cluster, err = key.ToCluster(obj)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-	case v1alpha1.MachineDeployment:
-		cr, err := key.ToMachineDeployment(obj)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		m, err := r.cmaClient.ClusterV1alpha1().Clusters(corev1.NamespaceAll).Get(key.ClusterID(&cr), metav1.GetOptions{})
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		cluster = *m
-	}
-
-	cc, err := controllercontext.FromContext(ctx)
+	err := r.ensure(ctx, obj)
 	if err != nil {
 		return microerror.Mask(err)
-	}
-
-	var g8sClient versioned.Interface
-	var k8sClient kubernetes.Interface
-	{
-		g8sClient, err = r.tenant.NewG8sClient(ctx, key.ClusterID(&cluster), key.ClusterAPIEndpoint(cluster))
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		k8sClient, err = r.tenant.NewK8sClient(ctx, key.ClusterID(&cluster), key.ClusterAPIEndpoint(cluster))
-		if err != nil {
-			return microerror.Mask(err)
-		}
-	}
-
-	{
-		cc.Client.TenantCluster.G8s = g8sClient
-		cc.Client.TenantCluster.K8s = k8sClient
 	}
 
 	return nil

--- a/service/controller/clusterapi/v17/resources/tenantclients/resource.go
+++ b/service/controller/clusterapi/v17/resources/tenantclients/resource.go
@@ -1,10 +1,18 @@
 package tenantclients
 
 import (
+	"context"
+
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/tenantcluster"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
+
+	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v17/controllercontext"
+	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v17/key"
 )
 
 const (
@@ -12,15 +20,17 @@ const (
 )
 
 type Config struct {
-	CMAClient clientset.Interface
-	Logger    micrologger.Logger
-	Tenant    tenantcluster.Interface
+	CMAClient     clientset.Interface
+	Logger        micrologger.Logger
+	Tenant        tenantcluster.Interface
+	ToClusterFunc func(v interface{}) (v1alpha1.Cluster, error)
 }
 
 type Resource struct {
-	cmaClient clientset.Interface
-	logger    micrologger.Logger
-	tenant    tenantcluster.Interface
+	cmaClient     clientset.Interface
+	logger        micrologger.Logger
+	tenant        tenantcluster.Interface
+	toClusterFunc func(v interface{}) (v1alpha1.Cluster, error)
 }
 
 func New(config Config) (*Resource, error) {
@@ -33,11 +43,15 @@ func New(config Config) (*Resource, error) {
 	if config.Tenant == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Tenant must not be empty", config)
 	}
+	if config.ToClusterFunc == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ToClusterFunc must not be empty", config)
+	}
 
 	r := &Resource{
-		cmaClient: config.CMAClient,
-		logger:    config.Logger,
-		tenant:    config.Tenant,
+		cmaClient:     config.CMAClient,
+		logger:        config.Logger,
+		tenant:        config.Tenant,
+		toClusterFunc: config.ToClusterFunc,
 	}
 
 	return r, nil
@@ -45,4 +59,36 @@ func New(config Config) (*Resource, error) {
 
 func (r *Resource) Name() string {
 	return Name
+}
+
+func (r *Resource) ensure(ctx context.Context, obj interface{}) error {
+	cr, err := r.toClusterFunc(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	var g8sClient versioned.Interface
+	var k8sClient kubernetes.Interface
+	{
+		g8sClient, err = r.tenant.NewG8sClient(ctx, key.ClusterID(&cr), key.ClusterAPIEndpoint(cr))
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		k8sClient, err = r.tenant.NewK8sClient(ctx, key.ClusterID(&cr), key.ClusterAPIEndpoint(cr))
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	{
+		cc.Client.TenantCluster.G8s = g8sClient
+		cc.Client.TenantCluster.K8s = k8sClient
+	}
+
+	return nil
 }


### PR DESCRIPTION
We introduced some type switch which was weird but we had a cool idea now. This PR should improve the situation and the `tenantclients` resource should be nice and clean again. 