### PR TITLE
Allow tenantclients to be missing from controllercontext

### DIFF
--- a/service/controller/clusterapi/v17/resources/tenantclients/create.go
+++ b/service/controller/clusterapi/v17/resources/tenantclients/create.go
@@ -51,12 +51,18 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	{
 		g8sClient, err = r.tenant.NewG8sClient(ctx, key.ClusterID(&cluster), key.ClusterAPIEndpoint(cluster))
 		if err != nil {
-			return microerror.Mask(err)
+			r.logger.LogCtx(ctx, "level", "warning", "message", "failed to create tenant cluster g8s client", "stack", microerror.Stack(microerror.Mask(err)))
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
 		}
 
 		k8sClient, err = r.tenant.NewK8sClient(ctx, key.ClusterID(&cluster), key.ClusterAPIEndpoint(cluster))
 		if err != nil {
-			return microerror.Mask(err)
+			r.logger.LogCtx(ctx, "level", "warning", "message", "failed to create tenant cluster k8s client", "stack", microerror.Stack(microerror.Mask(err)))
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
 		}
 	}
 

--- a/service/controller/clusterapi/v17/resources/tenantclients/delete.go
+++ b/service/controller/clusterapi/v17/resources/tenantclients/delete.go
@@ -51,12 +51,18 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 	{
 		g8sClient, err = r.tenant.NewG8sClient(ctx, key.ClusterID(&cluster), key.ClusterAPIEndpoint(cluster))
 		if err != nil {
-			return microerror.Mask(err)
+			r.logger.LogCtx(ctx, "level", "warning", "message", "failed to create tenant cluster g8s client", "stack", microerror.Stack(microerror.Mask(err)))
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
 		}
 
 		k8sClient, err = r.tenant.NewK8sClient(ctx, key.ClusterID(&cluster), key.ClusterAPIEndpoint(cluster))
 		if err != nil {
-			return microerror.Mask(err)
+			r.logger.LogCtx(ctx, "level", "warning", "message", "failed to create tenant cluster k8s client", "stack", microerror.Stack(microerror.Mask(err)))
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
 		}
 	}
 


### PR DESCRIPTION
Instead of canceling whole reconciliation round, only cancel the resource when
unable to construct tenant cluster clients. This is needed towards
clusterstatus resource functioning correctly in the beginning of cluster
creation.