### PR TITLE
Add boilerplate for Cluster ID resource

### DIFF
--- a/service/controller/clusterapi/v17/cluster_resource_set.go
+++ b/service/controller/clusterapi/v17/cluster_resource_set.go
@@ -17,6 +17,7 @@ import (
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v17/controllercontext"
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v17/key"
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v17/resources/awsclusterconfig"
+	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v17/resources/clusterid"
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v17/resources/clusterstatus"
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v17/resources/tenantclients"
 )
@@ -36,6 +37,20 @@ type ClusterResourceSetConfig struct {
 // ResourceSet.
 func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.ResourceSet, error) {
 	var err error
+
+	var clusterIDResource controller.Resource
+	{
+		c := clusterid.Config{
+			CMAClient: config.CMAClient,
+			G8sClient: config.G8sClient,
+			Logger:    config.Logger,
+		}
+
+		clusterIDResource, err = clusterid.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
 
 	var clusterstatusResource controller.Resource
 	{
@@ -82,6 +97,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 	}
 
 	resources := []controller.Resource{
+		clusterIDResource,
 		tenantClientsResource,
 		clusterstatusResource,
 		awsclusterconfigResource,

--- a/service/controller/clusterapi/v17/resources/clusterid/create.go
+++ b/service/controller/clusterapi/v17/resources/clusterid/create.go
@@ -1,0 +1,9 @@
+package clusterid
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/clusterapi/v17/resources/clusterid/delete.go
+++ b/service/controller/clusterapi/v17/resources/clusterid/delete.go
@@ -1,0 +1,9 @@
+package clusterid
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/clusterapi/v17/resources/clusterid/error.go
+++ b/service/controller/clusterapi/v17/resources/clusterid/error.go
@@ -1,0 +1,14 @@
+package clusterid
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/clusterapi/v17/resources/clusterid/resource.go
+++ b/service/controller/clusterapi/v17/resources/clusterid/resource.go
@@ -1,0 +1,48 @@
+package clusterid
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
+)
+
+const (
+	Name = "clusteridv17"
+)
+
+type Config struct {
+	CMAClient clientset.Interface
+	G8sClient versioned.Interface
+	Logger    micrologger.Logger
+}
+
+type Resource struct {
+	cmaClient clientset.Interface
+	g8sClient versioned.Interface
+	logger    micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.CMAClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CMAClient must not be empty", config)
+	}
+	if config.G8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		cmaClient: config.CMAClient,
+		g8sClient: config.G8sClient,
+		logger:    config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}


### PR DESCRIPTION
We decided to split clusterstatus resource into one that ensures that Cluster
CR status has cluster ID in it and one that takes care of cluster status
conditions. This PR here provides boilerplate for new cluster ID resource.