### PR TITLE
Add accessor interface & implementation to manipulate CommonClusterStatus

### DIFF
--- a/service/controller/clusterapi/v17/key/cluster_provider.go
+++ b/service/controller/clusterapi/v17/key/cluster_provider.go
@@ -60,3 +60,18 @@ func g8sClusterStatusFromCMAClusterStatus(cmaStatus *runtime.RawExtension) g8sv1
 
 	return g8sStatus
 }
+
+func setG8sClusterStatusToCMAClusterStatus(cluster cmav1alpha1.Cluster, status g8sv1alpha1.AWSClusterStatus) cmav1alpha1.Cluster {
+	var err error
+
+	if cluster.Status.ProviderStatus == nil {
+		cluster.Status.ProviderStatus = &runtime.RawExtension{}
+	}
+
+	cluster.Status.ProviderStatus.Raw, err = json.Marshal(status)
+	if err != nil {
+		panic(err)
+	}
+
+	return cluster
+}

--- a/service/controller/clusterapi/v17/key/cluster_status_accessor.go
+++ b/service/controller/clusterapi/v17/key/cluster_status_accessor.go
@@ -1,0 +1,18 @@
+package key
+
+import (
+	g8sv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/cluster/v1alpha1"
+	cmav1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+)
+
+type AWSClusterStatusAccessor struct{}
+
+func (a *AWSClusterStatusAccessor) GetCommonClusterStatus(c cmav1alpha1.Cluster) g8sv1alpha1.CommonClusterStatus {
+	return clusterProviderStatus(c).Cluster
+}
+
+func (a *AWSClusterStatusAccessor) SetCommonClusterStatus(c cmav1alpha1.Cluster, clusterStatus g8sv1alpha1.CommonClusterStatus) cmav1alpha1.Cluster {
+	status := clusterProviderStatus(c)
+	status.Cluster = clusterStatus
+	return setG8sClusterStatusToCMAClusterStatus(c, status)
+}

--- a/service/controller/clusterapi/v17/key/cluster_status_accessor_test.go
+++ b/service/controller/clusterapi/v17/key/cluster_status_accessor_test.go
@@ -1,0 +1,56 @@
+package key
+
+import (
+	"testing"
+	"time"
+
+	g8sv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/cluster/v1alpha1"
+	cmav1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+)
+
+func Test_AWSClusterStatusAccessor(t *testing.T) {
+	var accessor AWSClusterStatusAccessor
+	var cluster cmav1alpha1.Cluster
+
+	preSetClusterID := "abc12"
+	preSetClusterVersion := "1.2.3"
+
+	{
+		status := accessor.GetCommonClusterStatus(cluster)
+		status.ID = preSetClusterID
+		cluster = accessor.SetCommonClusterStatus(cluster, status)
+	}
+
+	{
+		status := accessor.GetCommonClusterStatus(cluster)
+		if status.ID != preSetClusterID {
+			t.Fatalf("expected cluster ID %s, got %s", preSetClusterID, status.ID)
+		}
+	}
+
+	{
+		status := accessor.GetCommonClusterStatus(cluster)
+		if len(status.Versions) != 0 {
+			t.Fatalf("expected cluster.Versions to be empty, found %d versions: %#v", len(status.Versions), status.Versions)
+		}
+
+		newVer := g8sv1alpha1.CommonClusterStatusVersion{
+			LastTransitionTime: g8sv1alpha1.DeepCopyTime{Time: time.Now()},
+			Version:            preSetClusterVersion,
+		}
+		status.Versions = append(status.Versions, newVer)
+
+		cluster = accessor.SetCommonClusterStatus(cluster, status)
+	}
+
+	{
+		status := accessor.GetCommonClusterStatus(cluster)
+		if len(status.Versions) != 1 {
+			t.Fatalf("expected cluster.Versions to have exactly one version, found %d versions: %#v", len(status.Versions), status.Versions)
+		}
+
+		if status.Versions[0].Version != preSetClusterVersion {
+			t.Fatalf("expected cluster version to be %s, got %s", preSetClusterVersion, status.Versions[0].Version)
+		}
+	}
+}

--- a/service/controller/clusterapi/v17/key/spec.go
+++ b/service/controller/clusterapi/v17/key/spec.go
@@ -1,8 +1,17 @@
 package key
 
 import (
+	"github.com/giantswarm/apiextensions/pkg/apis/cluster/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	cmav1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
+
+// CommonClusterStatusAccessor interface provides abstracted API to manipulate
+// provider specific types in provider independent way.
+type CommonClusterStatusAccessor interface {
+	GetCommonClusterStatus(c cmav1alpha1.Cluster) v1alpha1.CommonClusterStatus
+	SetCommonClusterStatus(c cmav1alpha1.Cluster, status v1alpha1.CommonClusterStatus) cmav1alpha1.Cluster
+}
 
 type DeletionTimestampGetter interface {
 	GetDeletionTimestamp() *metav1.Time


### PR DESCRIPTION
Provider independent CommonClusterStatus structure is stored in provider
specific extension inside Cluster CR so in order to have generic implementation
manipulating it, there must be interface & implementation for it.