### PR TITLE
Add flesh to Cluster ID resource

### DIFF
--- a/helm/cluster-operator-chart/templates/rbac.yaml
+++ b/helm/cluster-operator-chart/templates/rbac.yaml
@@ -32,7 +32,9 @@ rules:
       - cluster.k8s.io
     resources:
       - clusters
+      - clusters/status
       - machinedeployments
+      - machinedeployments/status
     verbs:
       - get
       - list

--- a/helm/cluster-operator-chart/templates/rbac.yaml
+++ b/helm/cluster-operator-chart/templates/rbac.yaml
@@ -37,6 +37,7 @@ rules:
       - get
       - list
       - patch
+      - update
       - watch
   - apiGroups:
       - core.giantswarm.io

--- a/service/controller/clusterapi/v17/cluster_resource_set.go
+++ b/service/controller/clusterapi/v17/cluster_resource_set.go
@@ -41,9 +41,10 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 	var clusterIDResource controller.Resource
 	{
 		c := clusterid.Config{
-			CMAClient: config.CMAClient,
-			G8sClient: config.G8sClient,
-			Logger:    config.Logger,
+			CMAClient:                   config.CMAClient,
+			CommonClusterStatusAccessor: &key.AWSClusterStatusAccessor{},
+			G8sClient:                   config.G8sClient,
+			Logger:                      config.Logger,
 		}
 
 		clusterIDResource, err = clusterid.New(c)

--- a/service/controller/clusterapi/v17/resources/clusterid/create.go
+++ b/service/controller/clusterapi/v17/resources/clusterid/create.go
@@ -47,6 +47,9 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	r.logger.LogCtx(ctx, "level", "debug", "message", "ensured cluster status has cluster ID")
 	r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
 
+	// All further resources require cluster ID to be present in the status so
+	// it makes sense to cancel whole CR reconciliation here and start from the
+	// beginning.
 	reconciliationcanceledcontext.SetCanceled(ctx)
 
 	return nil

--- a/service/controller/clusterapi/v17/resources/clusterid/create.go
+++ b/service/controller/clusterapi/v17/resources/clusterid/create.go
@@ -2,8 +2,65 @@ package clusterid
 
 import (
 	"context"
+	"reflect"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/cluster/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+	cmav1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+
+	"github.com/giantswarm/cluster-operator/pkg/label"
+	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v17/key"
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	cr, err := key.ToCluster(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "ensuring cluster status has cluster ID")
+
+	currentStatus := r.commonClusterStatusAccessor.GetCommonClusterStatus(cr)
+
+	updatedStatus, err := r.ensureClusterHasID(ctx, cr, currentStatus)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	updatedCR := r.commonClusterStatusAccessor.SetCommonClusterStatus(cr, updatedStatus)
+
+	if !reflect.DeepEqual(currentStatus, updatedStatus) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "updating cluster status")
+
+		_, err = r.cmaClient.ClusterV1alpha1().Clusters(cr.Namespace).Update(&updatedCR)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "updated cluster status")
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+		reconciliationcanceledcontext.SetCanceled(ctx)
+
+		return nil
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "ensured cluster status has cluster ID")
+
 	return nil
+}
+
+func (r *Resource) ensureClusterHasID(ctx context.Context, cluster cmav1alpha1.Cluster, status v1alpha1.CommonClusterStatus) (v1alpha1.CommonClusterStatus, error) {
+	if status.ID != "" {
+		return status, nil
+	}
+
+	clusterID := cluster.Labels[label.Cluster]
+	if clusterID != "" {
+		status.ID = clusterID
+		return status, nil
+	}
+
+	return status, microerror.Maskf(notFoundError, "cluster ID")
 }

--- a/service/controller/clusterapi/v17/resources/clusterid/create.go
+++ b/service/controller/clusterapi/v17/resources/clusterid/create.go
@@ -38,7 +38,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", "updating cluster status")
 
-	_, err = r.cmaClient.ClusterV1alpha1().Clusters(cr.Namespace).Update(&updatedCR)
+	_, err = r.cmaClient.ClusterV1alpha1().Clusters(cr.Namespace).UpdateStatus(&updatedCR)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/clusterapi/v17/resources/clusterid/create.go
+++ b/service/controller/clusterapi/v17/resources/clusterid/create.go
@@ -2,14 +2,10 @@ package clusterid
 
 import (
 	"context"
-	"reflect"
 
-	"github.com/giantswarm/apiextensions/pkg/apis/cluster/v1alpha1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
-	cmav1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 
-	"github.com/giantswarm/cluster-operator/pkg/label"
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v17/key"
 )
 
@@ -21,46 +17,37 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", "ensuring cluster status has cluster ID")
 
-	currentStatus := r.commonClusterStatusAccessor.GetCommonClusterStatus(cr)
+	status := r.commonClusterStatusAccessor.GetCommonClusterStatus(cr)
 
-	updatedStatus, err := r.ensureClusterHasID(ctx, cr, currentStatus)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	updatedCR := r.commonClusterStatusAccessor.SetCommonClusterStatus(cr, updatedStatus)
-
-	if !reflect.DeepEqual(currentStatus, updatedStatus) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "updating cluster status")
-
-		_, err = r.cmaClient.ClusterV1alpha1().Clusters(cr.Namespace).Update(&updatedCR)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		r.logger.LogCtx(ctx, "level", "debug", "message", "updated cluster status")
-
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
-		reconciliationcanceledcontext.SetCanceled(ctx)
+	if status.ID != "" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "ensured cluster status has cluster ID")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 
 		return nil
 	}
 
+	clusterID := key.ClusterID(&cr)
+
+	if clusterID == "" {
+		return microerror.Maskf(executionFailedError, "cluster ID missing from CR")
+	}
+
+	status.ID = clusterID
+
+	updatedCR := r.commonClusterStatusAccessor.SetCommonClusterStatus(cr, status)
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "updating cluster status")
+
+	_, err = r.cmaClient.ClusterV1alpha1().Clusters(cr.Namespace).Update(&updatedCR)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "updated cluster status")
 	r.logger.LogCtx(ctx, "level", "debug", "message", "ensured cluster status has cluster ID")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+
+	reconciliationcanceledcontext.SetCanceled(ctx)
 
 	return nil
-}
-
-func (r *Resource) ensureClusterHasID(ctx context.Context, cluster cmav1alpha1.Cluster, status v1alpha1.CommonClusterStatus) (v1alpha1.CommonClusterStatus, error) {
-	if status.ID != "" {
-		return status, nil
-	}
-
-	clusterID := cluster.Labels[label.Cluster]
-	if clusterID != "" {
-		status.ID = clusterID
-		return status, nil
-	}
-
-	return status, microerror.Maskf(notFoundError, "cluster ID")
 }

--- a/service/controller/clusterapi/v17/resources/clusterid/error.go
+++ b/service/controller/clusterapi/v17/resources/clusterid/error.go
@@ -4,6 +4,15 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
+// IsExecutionFailed asserts executionFailedError.
+func IsExecutionFailed(err error) bool {
+	return microerror.Cause(err) == executionFailedError
+}
+
 var invalidConfigError = &microerror.Error{
 	Kind: "invalidConfigError",
 }
@@ -11,13 +20,4 @@ var invalidConfigError = &microerror.Error{
 // IsInvalidConfig asserts invalidConfigError.
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
-}
-
-var notFoundError = &microerror.Error{
-	Kind: "notFoundError",
-}
-
-// IsNotFound asserts notFoundError.
-func IsNotFound(err error) bool {
-	return microerror.Cause(err) == notFoundError
 }

--- a/service/controller/clusterapi/v17/resources/clusterid/error.go
+++ b/service/controller/clusterapi/v17/resources/clusterid/error.go
@@ -12,3 +12,12 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}

--- a/service/controller/clusterapi/v17/resources/clusterid/resource.go
+++ b/service/controller/clusterapi/v17/resources/clusterid/resource.go
@@ -5,6 +5,8 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
+
+	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v17/key"
 )
 
 const (
@@ -12,20 +14,25 @@ const (
 )
 
 type Config struct {
-	CMAClient clientset.Interface
-	G8sClient versioned.Interface
-	Logger    micrologger.Logger
+	CMAClient                   clientset.Interface
+	CommonClusterStatusAccessor key.CommonClusterStatusAccessor
+	G8sClient                   versioned.Interface
+	Logger                      micrologger.Logger
 }
 
 type Resource struct {
-	cmaClient clientset.Interface
-	g8sClient versioned.Interface
-	logger    micrologger.Logger
+	cmaClient                   clientset.Interface
+	commonClusterStatusAccessor key.CommonClusterStatusAccessor
+	g8sClient                   versioned.Interface
+	logger                      micrologger.Logger
 }
 
 func New(config Config) (*Resource, error) {
 	if config.CMAClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.CMAClient must not be empty", config)
+	}
+	if config.CommonClusterStatusAccessor == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CommonClusterStatusAccessor must not be empty", config)
 	}
 	if config.G8sClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)

--- a/service/controller/clusterapi/v17/resources/clusterid/resource.go
+++ b/service/controller/clusterapi/v17/resources/clusterid/resource.go
@@ -42,9 +42,10 @@ func New(config Config) (*Resource, error) {
 	}
 
 	r := &Resource{
-		cmaClient: config.CMAClient,
-		g8sClient: config.G8sClient,
-		logger:    config.Logger,
+		cmaClient:                   config.CMAClient,
+		commonClusterStatusAccessor: config.CommonClusterStatusAccessor,
+		g8sClient:                   config.G8sClient,
+		logger:                      config.Logger,
 	}
 
 	return r, nil


### PR DESCRIPTION
Cluster ID resource ensures that Cluster CR has cluster ID present in its
provider extension status.