### PR TITLE
Rename Cluster's status provider extension "setter"

### DIFF
--- a/service/controller/clusterapi/v17/key/cluster_provider.go
+++ b/service/controller/clusterapi/v17/key/cluster_provider.go
@@ -61,7 +61,7 @@ func g8sClusterStatusFromCMAClusterStatus(cmaStatus *runtime.RawExtension) g8sv1
 	return g8sStatus
 }
 
-func setG8sClusterStatusToCMAClusterStatus(cluster cmav1alpha1.Cluster, status g8sv1alpha1.AWSClusterStatus) cmav1alpha1.Cluster {
+func withG8sClusterStatusToCMAClusterStatus(cluster cmav1alpha1.Cluster, status g8sv1alpha1.AWSClusterStatus) cmav1alpha1.Cluster {
 	var err error
 
 	if cluster.Status.ProviderStatus == nil {

--- a/service/controller/clusterapi/v17/key/cluster_status_accessor.go
+++ b/service/controller/clusterapi/v17/key/cluster_status_accessor.go
@@ -14,5 +14,5 @@ func (a *AWSClusterStatusAccessor) GetCommonClusterStatus(c cmav1alpha1.Cluster)
 func (a *AWSClusterStatusAccessor) SetCommonClusterStatus(c cmav1alpha1.Cluster, clusterStatus g8sv1alpha1.CommonClusterStatus) cmav1alpha1.Cluster {
 	status := clusterProviderStatus(c)
 	status.Cluster = clusterStatus
-	return setG8sClusterStatusToCMAClusterStatus(c, status)
+	return withG8sClusterStatusToCMAClusterStatus(c, status)
 }


### PR DESCRIPTION
When this function was introduced, shortly after merge there was a comment
suggesting to either modify Cluster in-place or rename the function. I took the
rename path as we tend to use type copying instead of in-place modifications in
general.