### PR TITLE
Add cluster ID prefix to base domain in key function

### DIFF
--- a/service/controller/clusterapi/v17/key/cluster.go
+++ b/service/controller/clusterapi/v17/key/cluster.go
@@ -44,7 +44,7 @@ func ClusterCredentialSecretNamespace(cluster v1alpha1.Cluster) string {
 }
 
 func ClusterDNSZone(cluster v1alpha1.Cluster) string {
-	return clusterProviderSpec(cluster).Cluster.DNS.Domain
+	return fmt.Sprintf("%s.%s", ClusterID(&cluster), clusterProviderSpec(cluster).Cluster.DNS.Domain)
 }
 
 func ClusterMasterAZ(cluster v1alpha1.Cluster) string {


### PR DESCRIPTION
ClusterDNSZone is expected to have cluster ID prefix, but Cluster CR only has
base domain present so cluster ID must be added there.