### PR TITLE
Align rbac with chart-operator tiller installation requirements

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -333,14 +333,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c7518bdf1fd5c30f3120e0a761d46d64b2e8d2e76b7718c1969c3a42845a7ebd"
+  digest = "1:0470bb250ddfe0c509019589654c48fc90889ab95e30b487d1321ea74d0f0a59"
   name = "github.com/giantswarm/helmclient"
   packages = [
     ".",
     "helmclienttest",
   ]
   pruneopts = "UT"
-  revision = "f871c9fb0576bca9d1583d70a01e3d5ca1f43b1a"
+  revision = "5e1cbbf7c6d67c4c1f883ff865111f6c2949e524"
 
 [[projects]]
   branch = "master"

--- a/helm/cluster-operator-chart/templates/rbac.yaml
+++ b/helm/cluster-operator-chart/templates/rbac.yaml
@@ -25,7 +25,6 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - services
       - serviceaccounts
       - networkpolicies
     verbs:

--- a/helm/cluster-operator-chart/templates/rbac.yaml
+++ b/helm/cluster-operator-chart/templates/rbac.yaml
@@ -23,6 +23,20 @@ rules:
       - delete
       - get
   - apiGroups:
+      - ""
+    resources:
+      - services
+      - serviceaccounts
+      - networkpolicies
+    verbs:
+      - create
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      - clusterrolebindings
+    verbs:
+      - create
+  - apiGroups:
       - apiextensions.k8s.io
     resources:
       - customresourcedefinitions

--- a/helm/cluster-operator-chart/templates/rbac.yaml
+++ b/helm/cluster-operator-chart/templates/rbac.yaml
@@ -26,6 +26,11 @@ rules:
       - ""
     resources:
       - serviceaccounts
+    verbs:
+      - create
+  - apiGroups:
+      - "networking.k8s.io"
+    resources:
       - networkpolicies
     verbs:
       - create


### PR DESCRIPTION
Towards change here https://github.com/giantswarm/helmclient/pull/106 and this issue https://github.com/giantswarm/giantswarm/issues/4033

The fact serviceaccount/clusterrolebinding rbac are missing means cluster-operator never run into an issue, where tiller was not already installed by chart-operator