### PR TITLE
Delete useless err check

### DIFF
--- a/pkg/v17/resource/namespace/create.go
+++ b/pkg/v17/resource/namespace/create.go
@@ -27,15 +27,6 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		_, err = tenantK8sClient.CoreV1().Namespaces().Create(namespaceToCreate)
 		if apierrors.IsAlreadyExists(err) {
 			// fall through
-		} else if apierrors.IsTimeout(err) {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster api timeout.")
-
-			// We should not hammer tenant API if it is not available, the tenant cluster
-			// might be initializing. We will retry on next reconciliation loop.
-			resourcecanceledcontext.SetCanceled(ctx)
-			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-
-			return nil
 		} else if tenant.IsAPINotAvailable(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available.")
 

--- a/pkg/v17/resource/namespace/current.go
+++ b/pkg/v17/resource/namespace/current.go
@@ -54,16 +54,6 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		if apierrors.IsNotFound(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the namespace in the tenant cluster")
 			// fall through
-		} else if apierrors.IsTimeout(err) {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster api timeout")
-
-			// We can't continue without a successful K8s connection. Cluster
-			// may not be up yet. We will retry during the next execution.
-			reconciliationcanceledcontext.SetCanceled(ctx)
-			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
-
-			return nil, nil
-
 		} else if tenant.IsAPINotAvailable(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
 


### PR DESCRIPTION
From https://github.com/giantswarm/app-operator/pull/101#discussion_r296192972

We found out we do not need to specifically using `APITimeout` if `tenant` package is in used. 