### PR TITLE
Adds node-exporter changelog for aws and azure

### DIFF
--- a/service/controller/aws/v17/version_bundle.go
+++ b/service/controller/aws/v17/version_bundle.go
@@ -8,9 +8,14 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "TODO",
-				Description: "TODO",
-				Kind:        versionbundle.KindAdded,
+				Component:   "node-exporter",
+				Description: "Disabled ipvs collector.",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "node-exporter",
+				Description: "Fix monitored file system mount points.",
+				Kind:        versionbundle.KindFixed,
 			},
 		},
 		Components: []versionbundle.Component{

--- a/service/controller/aws/v17/version_bundle.go
+++ b/service/controller/aws/v17/version_bundle.go
@@ -9,7 +9,7 @@ func VersionBundle() versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "node-exporter",
-				Description: "Disabled ipvs collector.",
+				Description: "Disable ipvs collector.",
 				Kind:        versionbundle.KindChanged,
 			},
 			{

--- a/service/controller/azure/v17/version_bundle.go
+++ b/service/controller/azure/v17/version_bundle.go
@@ -8,9 +8,14 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "TODO",
-				Description: "TODO",
-				Kind:        versionbundle.KindAdded,
+				Component:   "node-exporter",
+				Description: "Disabled ipvs collector.",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "node-exporter",
+				Description: "Fix monitored file system mount points.",
+				Kind:        versionbundle.KindFixed,
 			},
 		},
 		Components: []versionbundle.Component{

--- a/service/controller/azure/v17/version_bundle.go
+++ b/service/controller/azure/v17/version_bundle.go
@@ -9,7 +9,7 @@ func VersionBundle() versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "node-exporter",
-				Description: "Disabled ipvs collector.",
+				Description: "Disable ipvs collector.",
 				Kind:        versionbundle.KindChanged,
 			},
 			{

--- a/service/controller/kvm/v17/version_bundle.go
+++ b/service/controller/kvm/v17/version_bundle.go
@@ -14,7 +14,7 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Component:   "node-exporter",
-				Description: "Disabled ipvs collector.",
+				Description: "Disable ipvs collector.",
 				Kind:        versionbundle.KindChanged,
 			},
 			{


### PR DESCRIPTION
Follow up to
https://github.com/giantswarm/cluster-operator/pull/510/files,
it looks like we missed updating changelogs for aws and azure.