### PR TITLE
Inject the missing k8s label to cluster domain

### DIFF
--- a/service/controller/clusterapi/v17/key/cluster.go
+++ b/service/controller/clusterapi/v17/key/cluster.go
@@ -42,7 +42,7 @@ func ClusterCredentialSecretNamespace(cluster v1alpha1.Cluster) string {
 }
 
 func ClusterDNSZone(cluster v1alpha1.Cluster) string {
-	return fmt.Sprintf("%s.%s", ClusterID(&cluster), clusterProviderSpec(cluster).Cluster.DNS.Domain)
+	return fmt.Sprintf("%s.k8s.%s", ClusterID(&cluster), clusterProviderSpec(cluster).Cluster.DNS.Domain)
 }
 
 func ClusterMasterAZ(cluster v1alpha1.Cluster) string {


### PR DESCRIPTION
Lets have only the installation base domain in Cluster CR and add the missing
`$clusterId.k8s.` labels into its DNS zone during mapping. This then matches
how aws-operator works and we can keep plain installation base domain in
Cluster CR.