### PR TITLE
disable legacy integration test code

### DIFF
--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -232,7 +232,7 @@ func resources(ctx context.Context, h *framework.Host, g *framework.Guest, s *k8
 	//		}
 	//	}
 
-	err = installCredential(h)
+	err := installCredential(h)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/giantswarm/cluster-operator/integration/env"
 	"github.com/giantswarm/cluster-operator/integration/teardown"
-	"github.com/giantswarm/cluster-operator/integration/template"
 )
 
 const (
@@ -178,18 +177,18 @@ func resources(ctx context.Context, h *framework.Host, g *framework.Guest, s *k8
 		}
 	}
 
-	err := h.InstallStableOperator("cert-operator", "certconfig", e2etemplates.CertOperatorChartValues)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-	err = h.InstallStableOperator("node-operator", "drainerconfig", e2etemplates.NodeOperatorChartValues)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-	err = h.InstallStableOperator("aws-operator", "awsconfig", e2etemplates.AWSOperatorChartValues)
-	if err != nil {
-		return microerror.Mask(err)
-	}
+	//err := h.InstallStableOperator("cert-operator", "certconfig", e2etemplates.CertOperatorChartValues)
+	//if err != nil {
+	//	return microerror.Mask(err)
+	//}
+	//err = h.InstallStableOperator("node-operator", "drainerconfig", e2etemplates.NodeOperatorChartValues)
+	//if err != nil {
+	//	return microerror.Mask(err)
+	//}
+	//err = h.InstallStableOperator("aws-operator", "awsconfig", e2etemplates.AWSOperatorChartValues)
+	//if err != nil {
+	//	return microerror.Mask(err)
+	//}
 
 	// NOTE that the release package has to be configured to make this work. Right
 	// now it is unclear in which direction the e2e tests go but this here should
@@ -247,15 +246,15 @@ func resources(ctx context.Context, h *framework.Host, g *framework.Guest, s *k8
 	//		return microerror.Mask(err)
 	//	}
 
-	err = h.InstallBranchOperator("cluster-operator", "awsclusterconfig", template.ClusterOperatorChartValues)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	err = h.InstallResource("apiextensions-aws-cluster-config-e2e", template.ClusterOperatorResourceChartValues, ":stable")
-	if err != nil {
-		return microerror.Mask(err)
-	}
+	//err = h.InstallBranchOperator("cluster-operator", "awsclusterconfig", template.ClusterOperatorChartValues)
+	//if err != nil {
+	//	return microerror.Mask(err)
+	//}
+	//
+	//err = h.InstallResource("apiextensions-aws-cluster-config-e2e", template.ClusterOperatorResourceChartValues, ":stable")
+	//if err != nil {
+	//	return microerror.Mask(err)
+	//}
 
 	return nil
 }


### PR DESCRIPTION
The e2e tests in this project are disabled completely. Once we get functionality clear we need to rework the e2e tests more or less anyway. Here we disable some legacy code which helps dropping it from the `e2e-harness` project, which is also on life support. This helps to get rid of it gradually. 