### PR TITLE
Bump Nginx Ingress Controller channel to 0-8-stable

### DIFF
--- a/pkg/v17/key/key.go
+++ b/pkg/v17/key/key.go
@@ -116,7 +116,7 @@ func CommonChartSpecs() []ChartSpec {
 		},
 		{
 			AppName:       "nginx-ingress-controller",
-			ChannelName:   "0-7-stable",
+			ChannelName:   "0-8-stable",
 			ChartName:     "kubernetes-nginx-ingress-controller-chart",
 			ConfigMapName: "nginx-ingress-controller-values",
 			Namespace:     metav1.NamespaceSystem,


### PR DESCRIPTION
We bumped the channel as part of adding a feature flag for HPA. Still disabled as we need to test more. cc @pipo02mix 