### PR TITLE
Add new version of coredns

### DIFF
--- a/pkg/v17/key/key.go
+++ b/pkg/v17/key/key.go
@@ -69,7 +69,7 @@ func CommonChartSpecs() []ChartSpec {
 	return []ChartSpec{
 		{
 			AppName:       "coredns",
-			ChannelName:   "0-5-stable",
+			ChannelName:   "0-6-stable",
 			ChartName:     "kubernetes-coredns-chart",
 			ConfigMapName: "coredns-values",
 			Namespace:     metav1.NamespaceSystem,

--- a/service/controller/aws/v16/version_bundle.go
+++ b/service/controller/aws/v16/version_bundle.go
@@ -33,6 +33,11 @@ func VersionBundle() versionbundle.Bundle {
 				Kind:        versionbundle.KindChanged,
 			},
 			{
+				Component:   "coredns",
+				Description: "Default container port changed from 53 to 1053. Please read project's changelog carefully https://github.com/giantswarm/kubernetes-coredns/blob/master/CHANGELOG.md#v050",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
 				Component:   "node-exporter",
 				Description: "Added separate podsecuritypolicy.",
 				Kind:        versionbundle.KindAdded,

--- a/service/controller/aws/v16/version_bundle.go
+++ b/service/controller/aws/v16/version_bundle.go
@@ -34,7 +34,7 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Component:   "coredns",
-				Description: "Default container port changed from 53 to 1053. Please read project's changelog carefully https://github.com/giantswarm/kubernetes-coredns/blob/master/CHANGELOG.md#v050",
+				Description: "Change default container port from 53 to 1053. Please read project's changelog carefully https://github.com/giantswarm/kubernetes-coredns/blob/master/CHANGELOG.md#v050",
 				Kind:        versionbundle.KindChanged,
 			},
 			{

--- a/service/controller/aws/v17/version_bundle.go
+++ b/service/controller/aws/v17/version_bundle.go
@@ -8,6 +8,11 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
+				Component:   "coredns",
+				Description: "Updated to 1.5.1. More info here: https://github.com/giantswarm/kubernetes-coredns/blob/master/CHANGELOG.md",
+				Kind:        versionbundle.KindRemoved,
+			},
+			{
 				Component:   "node-exporter",
 				Description: "Disable ipvs collector.",
 				Kind:        versionbundle.KindChanged,
@@ -38,7 +43,7 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Name:    "coredns",
-				Version: "1.5.0",
+				Version: "1.5.1",
 			},
 			{
 				Name:    "cluster-autoscaler",

--- a/service/controller/aws/v17/version_bundle.go
+++ b/service/controller/aws/v17/version_bundle.go
@@ -17,6 +17,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Fix monitored file system mount points.",
 				Kind:        versionbundle.KindFixed,
 			},
+			{
+				Component:   "node-exporter",
+				Description: "Fix systemd collector D-Bus connection. https://github.com/giantswarm/kubernetes-node-exporter/pull/44",
+				Kind:        versionbundle.KindFixed,
+			},
 		},
 		Components: []versionbundle.Component{
 			{

--- a/service/controller/aws/v17/version_bundle.go
+++ b/service/controller/aws/v17/version_bundle.go
@@ -9,7 +9,7 @@ func VersionBundle() versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "coredns",
-				Description: "Updated to 1.5.1. More info here: https://github.com/giantswarm/kubernetes-coredns/blob/master/CHANGELOG.md",
+				Description: "Update to 1.5.1. More info here: https://github.com/giantswarm/kubernetes-coredns/blob/master/CHANGELOG.md",
 				Kind:        versionbundle.KindRemoved,
 			},
 			{

--- a/service/controller/azure/v16/version_bundle.go
+++ b/service/controller/azure/v16/version_bundle.go
@@ -33,6 +33,11 @@ func VersionBundle() versionbundle.Bundle {
 				Kind:        versionbundle.KindChanged,
 			},
 			{
+				Component:   "coredns",
+				Description: "Default container port changed from 53 to 1053. Please read project's changelog carefully https://github.com/giantswarm/kubernetes-coredns/blob/master/CHANGELOG.md#v050",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
 				Component:   "node-exporter",
 				Description: "Added separate podsecuritypolicy.",
 				Kind:        versionbundle.KindAdded,

--- a/service/controller/azure/v16/version_bundle.go
+++ b/service/controller/azure/v16/version_bundle.go
@@ -34,7 +34,7 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Component:   "coredns",
-				Description: "Default container port changed from 53 to 1053. Please read project's changelog carefully https://github.com/giantswarm/kubernetes-coredns/blob/master/CHANGELOG.md#v050",
+				Description: "Change default container port from 53 to 1053. Please read project's changelog carefully https://github.com/giantswarm/kubernetes-coredns/blob/master/CHANGELOG.md#v050",
 				Kind:        versionbundle.KindChanged,
 			},
 			{

--- a/service/controller/azure/v17/version_bundle.go
+++ b/service/controller/azure/v17/version_bundle.go
@@ -8,6 +8,11 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
+				Component:   "coredns",
+				Description: "Updated to 1.5.1. More info here: https://github.com/giantswarm/kubernetes-coredns/blob/master/CHANGELOG.md",
+				Kind:        versionbundle.KindRemoved,
+			},
+			{
 				Component:   "node-exporter",
 				Description: "Disable ipvs collector.",
 				Kind:        versionbundle.KindChanged,
@@ -42,7 +47,7 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Name:    "coredns",
-				Version: "1.5.0",
+				Version: "1.5.1",
 			},
 			{
 				Name:    "metrics-server",

--- a/service/controller/azure/v17/version_bundle.go
+++ b/service/controller/azure/v17/version_bundle.go
@@ -17,6 +17,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Fix monitored file system mount points.",
 				Kind:        versionbundle.KindFixed,
 			},
+			{
+				Component:   "node-exporter",
+				Description: "Fix systemd collector D-Bus connection. https://github.com/giantswarm/kubernetes-node-exporter/pull/44",
+				Kind:        versionbundle.KindFixed,
+			},
 		},
 		Components: []versionbundle.Component{
 			{

--- a/service/controller/azure/v17/version_bundle.go
+++ b/service/controller/azure/v17/version_bundle.go
@@ -9,7 +9,7 @@ func VersionBundle() versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "coredns",
-				Description: "Updated to 1.5.1. More info here: https://github.com/giantswarm/kubernetes-coredns/blob/master/CHANGELOG.md",
+				Description: "Update to 1.5.1. More info here: https://github.com/giantswarm/kubernetes-coredns/blob/master/CHANGELOG.md",
 				Kind:        versionbundle.KindRemoved,
 			},
 			{

--- a/service/controller/clusterapi/v17/version_bundle.go
+++ b/service/controller/clusterapi/v17/version_bundle.go
@@ -16,7 +16,7 @@ func VersionBundle() versionbundle.Bundle {
 		Components: []versionbundle.Component{
 			{
 				Name:    "coredns",
-				Version: "1.5.0",
+				Version: "1.5.1",
 			},
 			{
 				Name:    "kube-state-metrics",

--- a/service/controller/kvm/v16/version_bundle.go
+++ b/service/controller/kvm/v16/version_bundle.go
@@ -33,6 +33,11 @@ func VersionBundle() versionbundle.Bundle {
 				Kind:        versionbundle.KindChanged,
 			},
 			{
+				Component:   "coredns",
+				Description: "Default container port changed from 53 to 1053. Please read project's changelog carefully https://github.com/giantswarm/kubernetes-coredns/blob/master/CHANGELOG.md#v050",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
 				Component:   "node-exporter",
 				Description: "Added separate podsecuritypolicy.",
 				Kind:        versionbundle.KindAdded,

--- a/service/controller/kvm/v16/version_bundle.go
+++ b/service/controller/kvm/v16/version_bundle.go
@@ -34,7 +34,7 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Component:   "coredns",
-				Description: "Default container port changed from 53 to 1053. Please read project's changelog carefully https://github.com/giantswarm/kubernetes-coredns/blob/master/CHANGELOG.md#v050",
+				Description: "Change default container port from 53 to 1053. Please read project's changelog carefully https://github.com/giantswarm/kubernetes-coredns/blob/master/CHANGELOG.md#v050",
 				Kind:        versionbundle.KindChanged,
 			},
 			{

--- a/service/controller/kvm/v17/version_bundle.go
+++ b/service/controller/kvm/v17/version_bundle.go
@@ -9,7 +9,7 @@ func VersionBundle() versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "coredns",
-				Description: "Updated to 1.5.1. More info here: https://github.com/giantswarm/kubernetes-coredns/blob/master/CHANGELOG.md",
+				Description: "Update to 1.5.1. More info here: https://github.com/giantswarm/kubernetes-coredns/blob/master/CHANGELOG.md",
 				Kind:        versionbundle.KindRemoved,
 			},
 			{

--- a/service/controller/kvm/v17/version_bundle.go
+++ b/service/controller/kvm/v17/version_bundle.go
@@ -22,6 +22,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Fix monitored file system mount points.",
 				Kind:        versionbundle.KindFixed,
 			},
+			{
+				Component:   "node-exporter",
+				Description: "Fix systemd collector D-Bus connection. https://github.com/giantswarm/kubernetes-node-exporter/pull/44",
+				Kind:        versionbundle.KindFixed,
+			},
 		},
 		Components: []versionbundle.Component{
 			{

--- a/service/controller/kvm/v17/version_bundle.go
+++ b/service/controller/kvm/v17/version_bundle.go
@@ -8,6 +8,11 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
+				Component:   "coredns",
+				Description: "Updated to 1.5.1. More info here: https://github.com/giantswarm/kubernetes-coredns/blob/master/CHANGELOG.md",
+				Kind:        versionbundle.KindRemoved,
+			},
+			{
 				Component:   "nginx-ingress-controller",
 				Description: "Disabled migration logic now migration to helm chart is complete.",
 				Kind:        versionbundle.KindRemoved,
@@ -31,7 +36,7 @@ func VersionBundle() versionbundle.Bundle {
 		Components: []versionbundle.Component{
 			{
 				Name:    "coredns",
-				Version: "1.5.0",
+				Version: "1.5.1",
 			},
 			{
 				Name:    "kube-state-metrics",


### PR DESCRIPTION
New release of coredns [1.5.1](https://github.com/giantswarm/kubernetes-coredns/blob/master/CHANGELOG.md)