### PR TITLE
Improve tenant cluster wiring for AWS

### DIFF
--- a/service/controller/aws/legacy_cluster.go
+++ b/service/controller/aws/legacy_cluster.go
@@ -12,6 +12,7 @@ import (
 	"github.com/giantswarm/operatorkit/client/k8scrdclient"
 	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/informer"
+	"github.com/giantswarm/tenantcluster"
 	"github.com/spf13/afero"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
@@ -40,6 +41,7 @@ type LegacyClusterConfig struct {
 	K8sClient         kubernetes.Interface
 	K8sExtClient      apiextensionsclient.Interface
 	Logger            micrologger.Logger
+	Tenant            tenantcluster.Interface
 
 	CalicoAddress      string
 	CalicoPrefixLength string
@@ -101,6 +103,7 @@ func NewLegacyCluster(config LegacyClusterConfig) (*LegacyCluster, error) {
 			G8sClient:         config.G8sClient,
 			K8sClient:         config.K8sClient,
 			Logger:            config.Logger,
+			Tenant:            config.Tenant,
 
 			CalicoAddress:      config.CalicoAddress,
 			CalicoPrefixLength: config.CalicoPrefixLength,
@@ -125,6 +128,7 @@ func NewLegacyCluster(config LegacyClusterConfig) (*LegacyCluster, error) {
 			G8sClient:         config.G8sClient,
 			K8sClient:         config.K8sClient,
 			Logger:            config.Logger,
+			Tenant:            config.Tenant,
 
 			CalicoAddress:      config.CalicoAddress,
 			CalicoPrefixLength: config.CalicoPrefixLength,
@@ -149,6 +153,7 @@ func NewLegacyCluster(config LegacyClusterConfig) (*LegacyCluster, error) {
 			G8sClient:         config.G8sClient,
 			K8sClient:         config.K8sClient,
 			Logger:            config.Logger,
+			Tenant:            config.Tenant,
 
 			CalicoAddress:      config.CalicoAddress,
 			CalicoPrefixLength: config.CalicoPrefixLength,
@@ -173,6 +178,7 @@ func NewLegacyCluster(config LegacyClusterConfig) (*LegacyCluster, error) {
 			G8sClient:         config.G8sClient,
 			K8sClient:         config.K8sClient,
 			Logger:            config.Logger,
+			Tenant:            config.Tenant,
 
 			CalicoAddress:      config.CalicoAddress,
 			CalicoPrefixLength: config.CalicoPrefixLength,
@@ -197,6 +203,7 @@ func NewLegacyCluster(config LegacyClusterConfig) (*LegacyCluster, error) {
 			G8sClient:         config.G8sClient,
 			K8sClient:         config.K8sClient,
 			Logger:            config.Logger,
+			Tenant:            config.Tenant,
 
 			CalicoAddress:      config.CalicoAddress,
 			CalicoPrefixLength: config.CalicoPrefixLength,
@@ -222,6 +229,7 @@ func NewLegacyCluster(config LegacyClusterConfig) (*LegacyCluster, error) {
 			G8sClient:         config.G8sClient,
 			K8sClient:         config.K8sClient,
 			Logger:            config.Logger,
+			Tenant:            config.Tenant,
 
 			CalicoAddress:      config.CalicoAddress,
 			CalicoPrefixLength: config.CalicoPrefixLength,
@@ -247,6 +255,7 @@ func NewLegacyCluster(config LegacyClusterConfig) (*LegacyCluster, error) {
 			G8sClient:         config.G8sClient,
 			K8sClient:         config.K8sClient,
 			Logger:            config.Logger,
+			Tenant:            config.Tenant,
 
 			CalicoAddress:      config.CalicoAddress,
 			CalicoPrefixLength: config.CalicoPrefixLength,
@@ -272,6 +281,7 @@ func NewLegacyCluster(config LegacyClusterConfig) (*LegacyCluster, error) {
 			G8sClient:         config.G8sClient,
 			K8sClient:         config.K8sClient,
 			Logger:            config.Logger,
+			Tenant:            config.Tenant,
 
 			CalicoAddress:      config.CalicoAddress,
 			CalicoPrefixLength: config.CalicoPrefixLength,
@@ -297,6 +307,7 @@ func NewLegacyCluster(config LegacyClusterConfig) (*LegacyCluster, error) {
 			G8sClient:         config.G8sClient,
 			K8sClient:         config.K8sClient,
 			Logger:            config.Logger,
+			Tenant:            config.Tenant,
 
 			CalicoAddress:      config.CalicoAddress,
 			CalicoPrefixLength: config.CalicoPrefixLength,
@@ -322,6 +333,7 @@ func NewLegacyCluster(config LegacyClusterConfig) (*LegacyCluster, error) {
 			G8sClient:         config.G8sClient,
 			K8sClient:         config.K8sClient,
 			Logger:            config.Logger,
+			Tenant:            config.Tenant,
 
 			CalicoAddress:      config.CalicoAddress,
 			CalicoPrefixLength: config.CalicoPrefixLength,

--- a/service/controller/aws/v10/resource_set.go
+++ b/service/controller/aws/v10/resource_set.go
@@ -41,6 +41,7 @@ type ResourceSetConfig struct {
 	G8sClient         versioned.Interface
 	K8sClient         kubernetes.Interface
 	Logger            micrologger.Logger
+	Tenant            tenantcluster.Interface
 
 	CalicoAddress         string
 	CalicoPrefixLength    string
@@ -128,28 +129,13 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		}
 	}
 
-	var tenantClusterService tenantcluster.Interface
-	{
-		c := tenantcluster.Config{
-			CertsSearcher: config.CertSearcher,
-			Logger:        config.Logger,
-
-			CertID: certs.ClusterOperatorAPICert,
-		}
-
-		tenantClusterService, err = tenantcluster.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
 	var namespaceResource controller.Resource
 	{
 		c := namespace.Config{
 			BaseClusterConfig:        *config.BaseClusterConfig,
 			Logger:                   config.Logger,
 			ProjectName:              config.ProjectName,
-			Tenant:                   tenantClusterService,
+			Tenant:                   config.Tenant,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -177,7 +163,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			Logger:                   config.Logger,
 			ProjectName:              config.ProjectName,
 			RegistryDomain:           config.RegistryDomain,
-			Tenant:                   tenantClusterService,
+			Tenant:                   config.Tenant,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 		}
 
@@ -196,7 +182,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	{
 		c := configmapservice.Config{
 			Logger: config.Logger,
-			Tenant: tenantClusterService,
+			Tenant: config.Tenant,
 
 			ProjectName: config.ProjectName,
 		}
@@ -235,7 +221,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	{
 		c := chartconfigservice.Config{
 			Logger: config.Logger,
-			Tenant: tenantClusterService,
+			Tenant: config.Tenant,
 
 			ProjectName: config.ProjectName,
 		}

--- a/service/controller/aws/v11/resource_set.go
+++ b/service/controller/aws/v11/resource_set.go
@@ -3,6 +3,8 @@ package v11
 import (
 	"context"
 
+	"github.com/giantswarm/tenantcluster"
+
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/apprclient"
@@ -12,7 +14,6 @@ import (
 	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/resource/wrapper/metricsresource"
 	"github.com/giantswarm/operatorkit/resource/wrapper/retryresource"
-	"github.com/giantswarm/tenantcluster"
 	"github.com/spf13/afero"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -41,6 +42,7 @@ type ResourceSetConfig struct {
 	G8sClient         versioned.Interface
 	K8sClient         kubernetes.Interface
 	Logger            micrologger.Logger
+	Tenant            tenantcluster.Interface
 
 	CalicoAddress         string
 	CalicoPrefixLength    string
@@ -110,28 +112,13 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		}
 	}
 
-	var tenantClusterService tenantcluster.Interface
-	{
-		c := tenantcluster.Config{
-			CertsSearcher: config.CertSearcher,
-			Logger:        config.Logger,
-
-			CertID: certs.ClusterOperatorAPICert,
-		}
-
-		tenantClusterService, err = tenantcluster.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
 	var namespaceResource controller.Resource
 	{
 		c := namespace.Config{
 			BaseClusterConfig:        *config.BaseClusterConfig,
 			Logger:                   config.Logger,
 			ProjectName:              config.ProjectName,
-			Tenant:                   tenantClusterService,
+			Tenant:                   config.Tenant,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -159,7 +146,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			Logger:                   config.Logger,
 			ProjectName:              config.ProjectName,
 			RegistryDomain:           config.RegistryDomain,
-			Tenant:                   tenantClusterService,
+			Tenant:                   config.Tenant,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -179,7 +166,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	{
 		c := configmapservice.Config{
 			Logger: config.Logger,
-			Tenant: tenantClusterService,
+			Tenant: config.Tenant,
 
 			ProjectName: config.ProjectName,
 		}
@@ -218,7 +205,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	{
 		c := chartconfigservice.Config{
 			Logger: config.Logger,
-			Tenant: tenantClusterService,
+			Tenant: config.Tenant,
 
 			ProjectName: config.ProjectName,
 		}
@@ -254,7 +241,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		c := tiller.Config{
 			BaseClusterConfig:        *config.BaseClusterConfig,
 			Logger:                   config.Logger,
-			Tenant:                   tenantClusterService,
+			Tenant:                   config.Tenant,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 		}
 

--- a/service/controller/aws/v12/resource_set.go
+++ b/service/controller/aws/v12/resource_set.go
@@ -41,6 +41,7 @@ type ResourceSetConfig struct {
 	G8sClient         versioned.Interface
 	K8sClient         kubernetes.Interface
 	Logger            micrologger.Logger
+	Tenant            tenantcluster.Interface
 
 	CalicoAddress         string
 	CalicoPrefixLength    string
@@ -110,28 +111,13 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		}
 	}
 
-	var tenantClusterService tenantcluster.Interface
-	{
-		c := tenantcluster.Config{
-			CertsSearcher: config.CertSearcher,
-			Logger:        config.Logger,
-
-			CertID: certs.ClusterOperatorAPICert,
-		}
-
-		tenantClusterService, err = tenantcluster.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
 	var namespaceResource controller.Resource
 	{
 		c := namespace.Config{
 			BaseClusterConfig:        *config.BaseClusterConfig,
 			Logger:                   config.Logger,
 			ProjectName:              config.ProjectName,
-			Tenant:                   tenantClusterService,
+			Tenant:                   config.Tenant,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -159,7 +145,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			Logger:                   config.Logger,
 			ProjectName:              config.ProjectName,
 			RegistryDomain:           config.RegistryDomain,
-			Tenant:                   tenantClusterService,
+			Tenant:                   config.Tenant,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -179,7 +165,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	{
 		c := configmapservice.Config{
 			Logger: config.Logger,
-			Tenant: tenantClusterService,
+			Tenant: config.Tenant,
 
 			ProjectName: config.ProjectName,
 		}
@@ -218,7 +204,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	{
 		c := chartconfigservice.Config{
 			Logger: config.Logger,
-			Tenant: tenantClusterService,
+			Tenant: config.Tenant,
 
 			ProjectName: config.ProjectName,
 		}
@@ -254,7 +240,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		c := tiller.Config{
 			BaseClusterConfig:        *config.BaseClusterConfig,
 			Logger:                   config.Logger,
-			Tenant:                   tenantClusterService,
+			Tenant:                   config.Tenant,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 		}
 

--- a/service/controller/aws/v13/resource_set.go
+++ b/service/controller/aws/v13/resource_set.go
@@ -41,6 +41,7 @@ type ResourceSetConfig struct {
 	G8sClient         versioned.Interface
 	K8sClient         kubernetes.Interface
 	Logger            micrologger.Logger
+	Tenant            tenantcluster.Interface
 
 	CalicoAddress         string
 	CalicoPrefixLength    string
@@ -110,28 +111,13 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		}
 	}
 
-	var tenantClusterService tenantcluster.Interface
-	{
-		c := tenantcluster.Config{
-			CertsSearcher: config.CertSearcher,
-			Logger:        config.Logger,
-
-			CertID: certs.ClusterOperatorAPICert,
-		}
-
-		tenantClusterService, err = tenantcluster.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
 	var namespaceResource controller.Resource
 	{
 		c := namespace.Config{
 			BaseClusterConfig:        *config.BaseClusterConfig,
 			Logger:                   config.Logger,
 			ProjectName:              config.ProjectName,
-			Tenant:                   tenantClusterService,
+			Tenant:                   config.Tenant,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -159,7 +145,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			Logger:                   config.Logger,
 			ProjectName:              config.ProjectName,
 			RegistryDomain:           config.RegistryDomain,
-			Tenant:                   tenantClusterService,
+			Tenant:                   config.Tenant,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -179,7 +165,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	{
 		c := configmapservice.Config{
 			Logger: config.Logger,
-			Tenant: tenantClusterService,
+			Tenant: config.Tenant,
 
 			ProjectName: config.ProjectName,
 		}
@@ -218,7 +204,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	{
 		c := chartconfigservice.Config{
 			Logger: config.Logger,
-			Tenant: tenantClusterService,
+			Tenant: config.Tenant,
 
 			ProjectName: config.ProjectName,
 		}
@@ -254,7 +240,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		c := tiller.Config{
 			BaseClusterConfig:        *config.BaseClusterConfig,
 			Logger:                   config.Logger,
-			Tenant:                   tenantClusterService,
+			Tenant:                   config.Tenant,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 		}
 

--- a/service/controller/aws/v14/resource_set.go
+++ b/service/controller/aws/v14/resource_set.go
@@ -41,6 +41,7 @@ type ResourceSetConfig struct {
 	G8sClient         versioned.Interface
 	K8sClient         kubernetes.Interface
 	Logger            micrologger.Logger
+	Tenant            tenantcluster.Interface
 
 	CalicoAddress         string
 	CalicoPrefixLength    string
@@ -114,28 +115,13 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		}
 	}
 
-	var tenantClusterService tenantcluster.Interface
-	{
-		c := tenantcluster.Config{
-			CertsSearcher: config.CertSearcher,
-			Logger:        config.Logger,
-
-			CertID: certs.ClusterOperatorAPICert,
-		}
-
-		tenantClusterService, err = tenantcluster.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
 	var namespaceResource controller.Resource
 	{
 		c := namespace.Config{
 			BaseClusterConfig:        *config.BaseClusterConfig,
 			Logger:                   config.Logger,
 			ProjectName:              config.ProjectName,
-			Tenant:                   tenantClusterService,
+			Tenant:                   config.Tenant,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -163,7 +149,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			Logger:                   config.Logger,
 			ProjectName:              config.ProjectName,
 			RegistryDomain:           config.RegistryDomain,
-			Tenant:                   tenantClusterService,
+			Tenant:                   config.Tenant,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -183,7 +169,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	{
 		c := configmapservice.Config{
 			Logger: config.Logger,
-			Tenant: tenantClusterService,
+			Tenant: config.Tenant,
 
 			ProjectName: config.ProjectName,
 		}
@@ -222,7 +208,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	{
 		c := chartconfigservice.Config{
 			Logger: config.Logger,
-			Tenant: tenantClusterService,
+			Tenant: config.Tenant,
 
 			ProjectName: config.ProjectName,
 		}
@@ -258,7 +244,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		c := tiller.Config{
 			BaseClusterConfig:        *config.BaseClusterConfig,
 			Logger:                   config.Logger,
-			Tenant:                   tenantClusterService,
+			Tenant:                   config.Tenant,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}

--- a/service/controller/aws/v14patch1/resource_set.go
+++ b/service/controller/aws/v14patch1/resource_set.go
@@ -41,6 +41,7 @@ type ResourceSetConfig struct {
 	G8sClient         versioned.Interface
 	K8sClient         kubernetes.Interface
 	Logger            micrologger.Logger
+	Tenant            tenantcluster.Interface
 
 	CalicoAddress         string
 	CalicoPrefixLength    string
@@ -114,28 +115,13 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		}
 	}
 
-	var tenantClusterService tenantcluster.Interface
-	{
-		c := tenantcluster.Config{
-			CertsSearcher: config.CertSearcher,
-			Logger:        config.Logger,
-
-			CertID: certs.ClusterOperatorAPICert,
-		}
-
-		tenantClusterService, err = tenantcluster.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
 	var namespaceResource controller.Resource
 	{
 		c := namespace.Config{
 			BaseClusterConfig:        *config.BaseClusterConfig,
 			Logger:                   config.Logger,
 			ProjectName:              config.ProjectName,
-			Tenant:                   tenantClusterService,
+			Tenant:                   config.Tenant,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -163,7 +149,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			Logger:                   config.Logger,
 			ProjectName:              config.ProjectName,
 			RegistryDomain:           config.RegistryDomain,
-			Tenant:                   tenantClusterService,
+			Tenant:                   config.Tenant,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -183,7 +169,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	{
 		c := configmapservice.Config{
 			Logger: config.Logger,
-			Tenant: tenantClusterService,
+			Tenant: config.Tenant,
 
 			ProjectName: config.ProjectName,
 		}
@@ -222,7 +208,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	{
 		c := chartconfigservice.Config{
 			Logger: config.Logger,
-			Tenant: tenantClusterService,
+			Tenant: config.Tenant,
 
 			ProjectName: config.ProjectName,
 		}
@@ -258,7 +244,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		c := tiller.Config{
 			BaseClusterConfig:        *config.BaseClusterConfig,
 			Logger:                   config.Logger,
-			Tenant:                   tenantClusterService,
+			Tenant:                   config.Tenant,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}

--- a/service/controller/aws/v15/resource_set.go
+++ b/service/controller/aws/v15/resource_set.go
@@ -43,6 +43,7 @@ type ResourceSetConfig struct {
 	G8sClient         versioned.Interface
 	K8sClient         kubernetes.Interface
 	Logger            micrologger.Logger
+	Tenant            tenantcluster.Interface
 
 	CalicoAddress         string
 	CalicoPrefixLength    string
@@ -116,28 +117,13 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		}
 	}
 
-	var tenantClusterService tenantcluster.Interface
-	{
-		c := tenantcluster.Config{
-			CertsSearcher: config.CertSearcher,
-			Logger:        config.Logger,
-
-			CertID: certs.ClusterOperatorAPICert,
-		}
-
-		tenantClusterService, err = tenantcluster.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
 	var namespaceResource controller.Resource
 	{
 		c := namespace.Config{
 			BaseClusterConfig:        *config.BaseClusterConfig,
 			Logger:                   config.Logger,
 			ProjectName:              config.ProjectName,
-			Tenant:                   tenantClusterService,
+			Tenant:                   config.Tenant,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -165,7 +151,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			Logger:                   config.Logger,
 			ProjectName:              config.ProjectName,
 			RegistryDomain:           config.RegistryDomain,
-			Tenant:                   tenantClusterService,
+			Tenant:                   config.Tenant,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -185,7 +171,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	{
 		c := configmapservice.Config{
 			Logger: config.Logger,
-			Tenant: tenantClusterService,
+			Tenant: config.Tenant,
 
 			ProjectName: config.ProjectName,
 		}
@@ -224,7 +210,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	{
 		c := chartconfigservice.Config{
 			Logger: config.Logger,
-			Tenant: tenantClusterService,
+			Tenant: config.Tenant,
 
 			ProjectName: config.ProjectName,
 		}
@@ -295,7 +281,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		c := tiller.Config{
 			BaseClusterConfig:        *config.BaseClusterConfig,
 			Logger:                   config.Logger,
-			Tenant:                   tenantClusterService,
+			Tenant:                   config.Tenant,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}

--- a/service/controller/aws/v16/resource_set.go
+++ b/service/controller/aws/v16/resource_set.go
@@ -45,6 +45,7 @@ type ResourceSetConfig struct {
 	G8sClient         versioned.Interface
 	K8sClient         kubernetes.Interface
 	Logger            micrologger.Logger
+	Tenant            tenantcluster.Interface
 
 	CalicoAddress         string
 	CalicoPrefixLength    string
@@ -118,28 +119,13 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		}
 	}
 
-	var tenantClusterService tenantcluster.Interface
-	{
-		c := tenantcluster.Config{
-			CertsSearcher: config.CertSearcher,
-			Logger:        config.Logger,
-
-			CertID: certs.ClusterOperatorAPICert,
-		}
-
-		tenantClusterService, err = tenantcluster.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
 	var namespaceResource controller.Resource
 	{
 		c := namespace.Config{
 			BaseClusterConfig:        *config.BaseClusterConfig,
 			Logger:                   config.Logger,
 			ProjectName:              config.ProjectName,
-			Tenant:                   tenantClusterService,
+			Tenant:                   config.Tenant,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -167,7 +153,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			Logger:                   config.Logger,
 			ProjectName:              config.ProjectName,
 			RegistryDomain:           config.RegistryDomain,
-			Tenant:                   tenantClusterService,
+			Tenant:                   config.Tenant,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -187,7 +173,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	{
 		c := configmapservice.Config{
 			Logger: config.Logger,
-			Tenant: tenantClusterService,
+			Tenant: config.Tenant,
 
 			ProjectName: config.ProjectName,
 		}
@@ -226,7 +212,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	{
 		c := chartconfigservice.Config{
 			Logger: config.Logger,
-			Tenant: tenantClusterService,
+			Tenant: config.Tenant,
 
 			ProjectName: config.ProjectName,
 		}
@@ -333,7 +319,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		c := tiller.Config{
 			BaseClusterConfig:        *config.BaseClusterConfig,
 			Logger:                   config.Logger,
-			Tenant:                   tenantClusterService,
+			Tenant:                   config.Tenant,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}

--- a/service/controller/aws/v17/resource_set.go
+++ b/service/controller/aws/v17/resource_set.go
@@ -45,6 +45,7 @@ type ResourceSetConfig struct {
 	G8sClient         versioned.Interface
 	K8sClient         kubernetes.Interface
 	Logger            micrologger.Logger
+	Tenant            tenantcluster.Interface
 
 	CalicoAddress         string
 	CalicoPrefixLength    string
@@ -118,28 +119,13 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		}
 	}
 
-	var tenantClusterService tenantcluster.Interface
-	{
-		c := tenantcluster.Config{
-			CertsSearcher: config.CertSearcher,
-			Logger:        config.Logger,
-
-			CertID: certs.ClusterOperatorAPICert,
-		}
-
-		tenantClusterService, err = tenantcluster.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
 	var namespaceResource controller.Resource
 	{
 		c := namespace.Config{
 			BaseClusterConfig:        *config.BaseClusterConfig,
 			Logger:                   config.Logger,
 			ProjectName:              config.ProjectName,
-			Tenant:                   tenantClusterService,
+			Tenant:                   config.Tenant,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -167,7 +153,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			Logger:                   config.Logger,
 			ProjectName:              config.ProjectName,
 			RegistryDomain:           config.RegistryDomain,
-			Tenant:                   tenantClusterService,
+			Tenant:                   config.Tenant,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -187,7 +173,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	{
 		c := configmapservice.Config{
 			Logger: config.Logger,
-			Tenant: tenantClusterService,
+			Tenant: config.Tenant,
 
 			ProjectName: config.ProjectName,
 		}
@@ -226,7 +212,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	{
 		c := chartconfigservice.Config{
 			Logger: config.Logger,
-			Tenant: tenantClusterService,
+			Tenant: config.Tenant,
 
 			ProjectName: config.ProjectName,
 		}
@@ -333,7 +319,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		c := tiller.Config{
 			BaseClusterConfig:        *config.BaseClusterConfig,
 			Logger:                   config.Logger,
-			Tenant:                   tenantClusterService,
+			Tenant:                   config.Tenant,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}

--- a/service/controller/aws/v18/resource_set.go
+++ b/service/controller/aws/v18/resource_set.go
@@ -45,6 +45,7 @@ type ResourceSetConfig struct {
 	G8sClient         versioned.Interface
 	K8sClient         kubernetes.Interface
 	Logger            micrologger.Logger
+	Tenant            tenantcluster.Interface
 
 	CalicoAddress         string
 	CalicoPrefixLength    string
@@ -118,28 +119,13 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		}
 	}
 
-	var tenantClusterService tenantcluster.Interface
-	{
-		c := tenantcluster.Config{
-			CertsSearcher: config.CertSearcher,
-			Logger:        config.Logger,
-
-			CertID: certs.ClusterOperatorAPICert,
-		}
-
-		tenantClusterService, err = tenantcluster.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
 	var namespaceResource controller.Resource
 	{
 		c := namespace.Config{
 			BaseClusterConfig:        *config.BaseClusterConfig,
 			Logger:                   config.Logger,
 			ProjectName:              config.ProjectName,
-			Tenant:                   tenantClusterService,
+			Tenant:                   config.Tenant,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -167,7 +153,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			Logger:                   config.Logger,
 			ProjectName:              config.ProjectName,
 			RegistryDomain:           config.RegistryDomain,
-			Tenant:                   tenantClusterService,
+			Tenant:                   config.Tenant,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}
@@ -187,7 +173,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	{
 		c := configmapservice.Config{
 			Logger: config.Logger,
-			Tenant: tenantClusterService,
+			Tenant: config.Tenant,
 
 			ProjectName: config.ProjectName,
 		}
@@ -226,7 +212,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	{
 		c := chartconfigservice.Config{
 			Logger: config.Logger,
-			Tenant: tenantClusterService,
+			Tenant: config.Tenant,
 
 			ProjectName: config.ProjectName,
 		}
@@ -333,7 +319,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		c := tiller.Config{
 			BaseClusterConfig:        *config.BaseClusterConfig,
 			Logger:                   config.Logger,
-			Tenant:                   tenantClusterService,
+			Tenant:                   config.Tenant,
 			ToClusterGuestConfigFunc: toClusterGuestConfig,
 			ToClusterObjectMetaFunc:  toClusterObjectMeta,
 		}


### PR DESCRIPTION
Towards giantswarm/giantswarm#6561

In the legacy controllers the wiring was wrong for the tenant cluster service. Getting it straight so EnsureTillerInstalledMaxWait only needs to be set once.