### PR TITLE
Remove node-exporter, which is moved into ignition systemd unit

### DIFF
--- a/pkg/v18/chartconfig/desired_test.go
+++ b/pkg/v18/chartconfig/desired_test.go
@@ -23,7 +23,6 @@ func Test_ChartConfig_GetDesiredState(t *testing.T) {
 		"kubernetes-kube-state-metrics-chart",
 		"kubernetes-metrics-server-chart",
 		"kubernetes-nginx-ingress-controller-chart",
-		"kubernetes-node-exporter-chart",
 		"net-exporter-chart",
 	}
 

--- a/pkg/v18/configmap/desired_test.go
+++ b/pkg/v18/configmap/desired_test.go
@@ -162,10 +162,6 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 			Name:      "nginx-ingress-controller-user-values",
 			Namespace: metav1.NamespaceSystem,
 		},
-		{
-			Name:      "node-exporter-values",
-			Namespace: metav1.NamespaceSystem,
-		},
 	}
 
 	testCases := []struct {

--- a/pkg/v18/key/key.go
+++ b/pkg/v18/key/key.go
@@ -126,15 +126,6 @@ func CommonChartSpecs() []ChartSpec {
 			UseUpgradeForce:   false,
 			UserConfigMapName: "nginx-ingress-controller-user-values",
 		},
-		{
-			AppName:         "node-exporter",
-			ChannelName:     "0-5-stable",
-			ChartName:       "kubernetes-node-exporter-chart",
-			ConfigMapName:   "node-exporter-values",
-			Namespace:       metav1.NamespaceSystem,
-			ReleaseName:     "node-exporter",
-			UseUpgradeForce: true,
-		},
 	}
 }
 

--- a/service/controller/aws/v18/version_bundle.go
+++ b/service/controller/aws/v18/version_bundle.go
@@ -18,11 +18,6 @@ func VersionBundle() versionbundle.Bundle {
 				Kind:        versionbundle.KindChanged,
 			},
 			{
-				Component:   "node-exporter",
-				Description: "Add toleration for all taints",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
 				Component:   "nginx-ingress-controller",
 				Description: "Update to 0.25.0. https://github.com/giantswarm/kubernetes-nginx-ingress-controller/blob/master/CHANGELOG.md",
 				Kind:        versionbundle.KindChanged,
@@ -36,10 +31,6 @@ func VersionBundle() versionbundle.Bundle {
 			{
 				Name:    "nginx-ingress-controller",
 				Version: "0.25.0",
-			},
-			{
-				Name:    "node-exporter",
-				Version: "0.18.0",
 			},
 			{
 				Name:    "coredns",

--- a/service/controller/azure/v18/version_bundle.go
+++ b/service/controller/azure/v18/version_bundle.go
@@ -18,11 +18,6 @@ func VersionBundle() versionbundle.Bundle {
 				Kind:        versionbundle.KindChanged,
 			},
 			{
-				Component:   "node-exporter",
-				Description: "Add toleration for all taints",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
 				Component:   "nginx-ingress-controller",
 				Description: "Update to 0.25.0. https://github.com/giantswarm/kubernetes-nginx-ingress-controller/blob/master/CHANGELOG.md",
 				Kind:        versionbundle.KindChanged,
@@ -40,10 +35,6 @@ func VersionBundle() versionbundle.Bundle {
 			{
 				Name:    "kube-state-metrics",
 				Version: "1.5.0",
-			},
-			{
-				Name:    "node-exporter",
-				Version: "0.18.0",
 			},
 			{
 				Name:    "coredns",

--- a/service/controller/clusterapi/v18/version_bundle.go
+++ b/service/controller/clusterapi/v18/version_bundle.go
@@ -18,11 +18,6 @@ func VersionBundle() versionbundle.Bundle {
 				Kind:        versionbundle.KindChanged,
 			},
 			{
-				Component:   "node-exporter",
-				Description: "Add toleration for all taints",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
 				Component:   "nginx-ingress-controller",
 				Description: "Update to 0.25.0. https://github.com/giantswarm/kubernetes-nginx-ingress-controller/blob/master/CHANGELOG.md",
 				Kind:        versionbundle.KindChanged,
@@ -40,10 +35,6 @@ func VersionBundle() versionbundle.Bundle {
 			{
 				Name:    "nginx-ingress-controller",
 				Version: "0.25.0",
-			},
-			{
-				Name:    "node-exporter",
-				Version: "0.18.0",
 			},
 			{
 				Name:    "metrics-server",

--- a/service/controller/kvm/v18/version_bundle.go
+++ b/service/controller/kvm/v18/version_bundle.go
@@ -18,11 +18,6 @@ func VersionBundle() versionbundle.Bundle {
 				Kind:        versionbundle.KindChanged,
 			},
 			{
-				Component:   "node-exporter",
-				Description: "Add toleration for all taints",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
 				Component:   "nginx-ingress-controller",
 				Description: "Update to 0.25.0. https://github.com/giantswarm/kubernetes-nginx-ingress-controller/blob/master/CHANGELOG.md",
 				Kind:        versionbundle.KindChanged,
@@ -40,10 +35,6 @@ func VersionBundle() versionbundle.Bundle {
 			{
 				Name:    "nginx-ingress-controller",
 				Version: "0.25.0",
-			},
-			{
-				Name:    "node-exporter",
-				Version: "0.18.0",
 			},
 			{
 				Name:    "metrics-server",


### PR DESCRIPTION
Following https://github.com/giantswarm/k8scloudconfig/pull/570