### PR TITLE
basedomain name fixing for etcd client

### DIFF
--- a/pkg/v10/resource/certconfig/desired.go
+++ b/pkg/v10/resource/certconfig/desired.go
@@ -114,7 +114,7 @@ func prepareClusterConfig(baseClusterConfig cluster.Config, clusterGuestConfig v
 	if err != nil {
 		return cluster.Config{}, microerror.Mask(err)
 	}
-	clusterConfig.Domain.CalicoEtcdClient = fmt.Sprintf("calico.%s.%s", clusterConfig.ClusterID, key.DNSZone(clusterGuestConfig))
+	clusterConfig.Domain.CalicoEtcdClient = fmt.Sprintf("calico.%s", key.DNSZone(clusterGuestConfig))
 	clusterConfig.Domain.Etcd, err = newServerDomain(key.DNSZone(clusterGuestConfig), certs.EtcdCert)
 	if err != nil {
 		return cluster.Config{}, microerror.Mask(err)

--- a/pkg/v11/resource/certconfig/desired.go
+++ b/pkg/v11/resource/certconfig/desired.go
@@ -114,7 +114,7 @@ func prepareClusterConfig(baseClusterConfig cluster.Config, clusterGuestConfig v
 	if err != nil {
 		return cluster.Config{}, microerror.Mask(err)
 	}
-	clusterConfig.Domain.CalicoEtcdClient = fmt.Sprintf("calico.%s.%s", clusterConfig.ClusterID, key.DNSZone(clusterGuestConfig))
+	clusterConfig.Domain.CalicoEtcdClient = fmt.Sprintf("calico.%s", key.DNSZone(clusterGuestConfig))
 	clusterConfig.Domain.Etcd, err = newServerDomain(key.DNSZone(clusterGuestConfig), certs.EtcdCert)
 	if err != nil {
 		return cluster.Config{}, microerror.Mask(err)

--- a/pkg/v12/resource/certconfig/desired.go
+++ b/pkg/v12/resource/certconfig/desired.go
@@ -114,7 +114,7 @@ func prepareClusterConfig(baseClusterConfig cluster.Config, clusterGuestConfig v
 	if err != nil {
 		return cluster.Config{}, microerror.Mask(err)
 	}
-	clusterConfig.Domain.CalicoEtcdClient = fmt.Sprintf("calico.%s.%s", clusterConfig.ClusterID, key.DNSZone(clusterGuestConfig))
+	clusterConfig.Domain.CalicoEtcdClient = fmt.Sprintf("calico.%s", key.DNSZone(clusterGuestConfig))
 	clusterConfig.Domain.Etcd, err = newServerDomain(key.DNSZone(clusterGuestConfig), certs.EtcdCert)
 	if err != nil {
 		return cluster.Config{}, microerror.Mask(err)

--- a/pkg/v13/resource/certconfig/desired.go
+++ b/pkg/v13/resource/certconfig/desired.go
@@ -118,7 +118,7 @@ func prepareClusterConfig(baseClusterConfig cluster.Config, clusterGuestConfig v
 	if err != nil {
 		return cluster.Config{}, microerror.Mask(err)
 	}
-	clusterConfig.Domain.CalicoEtcdClient = fmt.Sprintf("calico.%s.%s", clusterConfig.ClusterID, key.DNSZone(clusterGuestConfig))
+	clusterConfig.Domain.CalicoEtcdClient = fmt.Sprintf("calico.%s", key.DNSZone(clusterGuestConfig))
 	clusterConfig.Domain.Etcd, err = newServerDomain(key.DNSZone(clusterGuestConfig), certs.EtcdCert)
 	if err != nil {
 		return cluster.Config{}, microerror.Mask(err)

--- a/pkg/v14/resource/certconfig/desired.go
+++ b/pkg/v14/resource/certconfig/desired.go
@@ -118,7 +118,7 @@ func prepareClusterConfig(baseClusterConfig cluster.Config, clusterGuestConfig v
 	if err != nil {
 		return cluster.Config{}, microerror.Mask(err)
 	}
-	clusterConfig.Domain.CalicoEtcdClient = fmt.Sprintf("calico.%s.%s", clusterConfig.ClusterID, key.DNSZone(clusterGuestConfig))
+	clusterConfig.Domain.CalicoEtcdClient = fmt.Sprintf("calico.%s", key.DNSZone(clusterGuestConfig))
 	clusterConfig.Domain.Etcd, err = newServerDomain(key.DNSZone(clusterGuestConfig), certs.EtcdCert)
 	if err != nil {
 		return cluster.Config{}, microerror.Mask(err)

--- a/pkg/v14patch1/resource/certconfig/desired.go
+++ b/pkg/v14patch1/resource/certconfig/desired.go
@@ -118,7 +118,7 @@ func prepareClusterConfig(baseClusterConfig cluster.Config, clusterGuestConfig v
 	if err != nil {
 		return cluster.Config{}, microerror.Mask(err)
 	}
-	clusterConfig.Domain.CalicoEtcdClient = fmt.Sprintf("calico.%s.%s", clusterConfig.ClusterID, key.DNSZone(clusterGuestConfig))
+	clusterConfig.Domain.CalicoEtcdClient = fmt.Sprintf("calico.%s", key.DNSZone(clusterGuestConfig))
 	clusterConfig.Domain.Etcd, err = newServerDomain(key.DNSZone(clusterGuestConfig), certs.EtcdCert)
 	if err != nil {
 		return cluster.Config{}, microerror.Mask(err)

--- a/pkg/v15/resource/certconfig/desired.go
+++ b/pkg/v15/resource/certconfig/desired.go
@@ -118,7 +118,7 @@ func prepareClusterConfig(baseClusterConfig cluster.Config, clusterGuestConfig v
 	if err != nil {
 		return cluster.Config{}, microerror.Mask(err)
 	}
-	clusterConfig.Domain.CalicoEtcdClient = fmt.Sprintf("calico.%s.%s", clusterConfig.ClusterID, key.DNSZone(clusterGuestConfig))
+	clusterConfig.Domain.CalicoEtcdClient = fmt.Sprintf("calico.%s", key.DNSZone(clusterGuestConfig))
 	clusterConfig.Domain.Etcd, err = newServerDomain(key.DNSZone(clusterGuestConfig), certs.EtcdCert)
 	if err != nil {
 		return cluster.Config{}, microerror.Mask(err)

--- a/pkg/v16/resource/certconfig/desired.go
+++ b/pkg/v16/resource/certconfig/desired.go
@@ -118,7 +118,7 @@ func prepareClusterConfig(baseClusterConfig cluster.Config, clusterGuestConfig v
 	if err != nil {
 		return cluster.Config{}, microerror.Mask(err)
 	}
-	clusterConfig.Domain.CalicoEtcdClient = fmt.Sprintf("calico.%s.%s", clusterConfig.ClusterID, key.DNSZone(clusterGuestConfig))
+	clusterConfig.Domain.CalicoEtcdClient = fmt.Sprintf("calico.%s", key.DNSZone(clusterGuestConfig))
 	clusterConfig.Domain.Etcd, err = newServerDomain(key.DNSZone(clusterGuestConfig), certs.EtcdCert)
 	if err != nil {
 		return cluster.Config{}, microerror.Mask(err)

--- a/pkg/v17/resource/certconfig/desired.go
+++ b/pkg/v17/resource/certconfig/desired.go
@@ -118,7 +118,7 @@ func prepareClusterConfig(baseClusterConfig cluster.Config, clusterGuestConfig v
 	if err != nil {
 		return cluster.Config{}, microerror.Mask(err)
 	}
-	clusterConfig.Domain.CalicoEtcdClient = fmt.Sprintf("calico.%s.%s", clusterConfig.ClusterID, key.DNSZone(clusterGuestConfig))
+	clusterConfig.Domain.CalicoEtcdClient = fmt.Sprintf("calico.%s", key.DNSZone(clusterGuestConfig))
 	clusterConfig.Domain.Etcd, err = newServerDomain(key.DNSZone(clusterGuestConfig), certs.EtcdCert)
 	if err != nil {
 		return cluster.Config{}, microerror.Mask(err)

--- a/pkg/v18/resource/certconfig/desired.go
+++ b/pkg/v18/resource/certconfig/desired.go
@@ -118,7 +118,7 @@ func prepareClusterConfig(baseClusterConfig cluster.Config, clusterGuestConfig v
 	if err != nil {
 		return cluster.Config{}, microerror.Mask(err)
 	}
-	clusterConfig.Domain.CalicoEtcdClient = fmt.Sprintf("calico.%s.%s", clusterConfig.ClusterID, key.DNSZone(clusterGuestConfig))
+	clusterConfig.Domain.CalicoEtcdClient = fmt.Sprintf("calico.%s", key.DNSZone(clusterGuestConfig))
 	clusterConfig.Domain.Etcd, err = newServerDomain(key.DNSZone(clusterGuestConfig), certs.EtcdCert)
 	if err != nil {
 		return cluster.Config{}, microerror.Mask(err)


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/6442

it will fix wrong base domain value for certconfig CRs. 

e.g. From 
```
 k get certconfigs h0cg9-calico-etcd-client -o yaml
apiVersion: core.giantswarm.io/v1alpha1
kind: CertConfig
metadata:
  creationTimestamp: "2018-05-03T08:18:12Z"
  finalizers:
  - operatorkit.giantswarm.io/cert-operator
  labels:
    clusterComponent: calico-etcd-client
    clusterID: h0cg9
  name: h0cg9-calico-etcd-client
  namespace: default
  resourceVersion: "128989997"
  selfLink: /apis/core.giantswarm.io/v1alpha1/namespaces/default/certconfigs/h0cg9-calico-etcd-client
  uid: 853f3998-4eaa-11e8-bc85-0894ef3abbd6
spec:
  cert:
    allowBareDomains: false
    altNames: null
    clusterComponent: calico-etcd-client
    clusterID: h0cg9
    commonName: calico.h0cg9.h0cg9.g8s.kc.cg.internal
```

To 

```
 k get certconfigs h0cg9-calico-etcd-client -o yaml
apiVersion: core.giantswarm.io/v1alpha1
kind: CertConfig
metadata:
  creationTimestamp: "2018-05-03T08:18:12Z"
  finalizers:
  - operatorkit.giantswarm.io/cert-operator
  labels:
    clusterComponent: calico-etcd-client
    clusterID: h0cg9
  name: h0cg9-calico-etcd-client
  namespace: default
  resourceVersion: "128989997"
  selfLink: /apis/core.giantswarm.io/v1alpha1/namespaces/default/certconfigs/h0cg9-calico-etcd-client
  uid: 853f3998-4eaa-11e8-bc85-0894ef3abbd6
spec:
  cert:
    allowBareDomains: false
    altNames: null
    clusterComponent: calico-etcd-client
    clusterID: h0cg9
    commonName: calico.h0cg9.g8s.kc.cg.internal
```
