### PR TITLE
Adding clusterDNSIP for chartoperator setup

### DIFF
--- a/pkg/v18/resource/clusterconfigmap/desired.go
+++ b/pkg/v18/resource/clusterconfigmap/desired.go
@@ -20,6 +20,7 @@ func (r *StateGetter) GetDesiredState(ctx context.Context, obj interface{}) ([]*
 
 	configMapName := key.ClusterConfigMapName(clusterConfig)
 
+	// Calculating DNS IP from the IP range so we other operators could use it w/o processing it.
 	clusterDNSIP, err := key.DNSIP(r.clusterIPRange)
 	if err != nil {
 		return nil, microerror.Mask(err)

--- a/pkg/v18/resource/clusterconfigmap/desired.go
+++ b/pkg/v18/resource/clusterconfigmap/desired.go
@@ -21,7 +21,8 @@ func (r *StateGetter) GetDesiredState(ctx context.Context, obj interface{}) ([]*
 	configMapName := key.ClusterConfigMapName(clusterConfig)
 
 	values := map[string]string{
-		"baseDomain": key.DNSZone(clusterConfig),
+		"baseDomain":     key.DNSZone(clusterConfig),
+		"clusterIPRange": r.clusterIPRange,
 	}
 
 	yamlValues, err := yaml.Marshal(values)

--- a/pkg/v18/resource/clusterconfigmap/desired.go
+++ b/pkg/v18/resource/clusterconfigmap/desired.go
@@ -20,9 +20,14 @@ func (r *StateGetter) GetDesiredState(ctx context.Context, obj interface{}) ([]*
 
 	configMapName := key.ClusterConfigMapName(clusterConfig)
 
+	clusterDNSIP, err := key.DNSIP(r.clusterIPRange)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
 	values := map[string]string{
-		"baseDomain":     key.DNSZone(clusterConfig),
-		"clusterIPRange": r.clusterIPRange,
+		"baseDomain":   key.DNSZone(clusterConfig),
+		"clusterDNSIP": clusterDNSIP,
 	}
 
 	yamlValues, err := yaml.Marshal(values)

--- a/pkg/v18/resource/clusterconfigmap/desired_test.go
+++ b/pkg/v18/resource/clusterconfigmap/desired_test.go
@@ -47,7 +47,7 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 					},
 				},
 				Data: map[string]string{
-					"values": "baseDomain: giantswarm.io\n",
+					"values": "baseDomain: giantswarm.io\nclusterIPRange: 192.168.0.1/30\n",
 				},
 			},
 		},
@@ -61,7 +61,8 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 				K8sClient:                k8sfake.NewSimpleClientset(),
 				Logger:                   microloggertest.New(),
 
-				ProjectName: "cluster-operator",
+				ClusterIPRange: "192.168.0.1/30",
+				ProjectName:    "cluster-operator",
 			}
 			r, err := New(c)
 			if err != nil {

--- a/pkg/v18/resource/clusterconfigmap/desired_test.go
+++ b/pkg/v18/resource/clusterconfigmap/desired_test.go
@@ -47,7 +47,7 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 					},
 				},
 				Data: map[string]string{
-					"values": "baseDomain: giantswarm.io\nclusterIPRange: 192.168.0.1/30\n",
+					"values": "baseDomain: giantswarm.io\nclusterDNSIP: 172.31.0.10\n",
 				},
 			},
 		},
@@ -61,7 +61,7 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 				K8sClient:                k8sfake.NewSimpleClientset(),
 				Logger:                   microloggertest.New(),
 
-				ClusterIPRange: "192.168.0.1/30",
+				ClusterIPRange: "172.31.0.0/16",
 				ProjectName:    "cluster-operator",
 			}
 			r, err := New(c)

--- a/pkg/v18/resource/clusterconfigmap/resource.go
+++ b/pkg/v18/resource/clusterconfigmap/resource.go
@@ -25,7 +25,8 @@ type Config struct {
 	Logger                   micrologger.Logger
 
 	// Settings.
-	ProjectName string
+	ClusterIPRange string
+	ProjectName    string
 }
 
 // Resource implements the clusterConfigMap resource.
@@ -37,7 +38,8 @@ type StateGetter struct {
 	logger                   micrologger.Logger
 
 	// Settings.
-	projectName string
+	clusterIPRange string
+	projectName    string
 }
 
 // New creates a new configured clusterConfigMap resource.
@@ -57,6 +59,9 @@ func New(config Config) (*StateGetter, error) {
 	}
 
 	// Settings
+	if config.ClusterIPRange == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ClusterIPRange must not be empty", config)
+	}
 	if config.ProjectName == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ProjectName must not be empty", config)
 	}
@@ -69,7 +74,8 @@ func New(config Config) (*StateGetter, error) {
 		logger:                   config.Logger,
 
 		// Settings
-		projectName: config.ProjectName,
+		clusterIPRange: config.ClusterIPRange,
+		projectName:    config.ProjectName,
 	}
 
 	return r, nil

--- a/service/controller/aws/v18/resource_set.go
+++ b/service/controller/aws/v18/resource_set.go
@@ -251,7 +251,8 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			K8sClient:                config.K8sClient,
 			Logger:                   config.Logger,
 
-			ProjectName: config.ProjectName,
+			ClusterIPRange: config.ClusterIPRange,
+			ProjectName:    config.ProjectName,
 		}
 
 		stateGetter, err := clusterconfigmap.New(c)

--- a/service/controller/azure/v18/resource_set.go
+++ b/service/controller/azure/v18/resource_set.go
@@ -248,7 +248,8 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			K8sClient:                config.K8sClient,
 			Logger:                   config.Logger,
 
-			ProjectName: config.ProjectName,
+			ClusterIPRange: config.ClusterIPRange,
+			ProjectName:    config.ProjectName,
 		}
 
 		stateGetter, err := clusterconfigmap.New(c)

--- a/service/controller/kvm/v18/resource_set.go
+++ b/service/controller/kvm/v18/resource_set.go
@@ -247,7 +247,8 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			K8sClient:                config.K8sClient,
 			Logger:                   config.Logger,
 
-			ProjectName: config.ProjectName,
+			ClusterIPRange: config.ClusterIPRange,
+			ProjectName:    config.ProjectName,
 		}
 
 		stateGetter, err := clusterconfigmap.New(c)


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/6639

app-operator would check the `clusterIPRange` value from `clusterconfigmap`, rather than in the operator 's flags value. 