### PR TITLE
fix clusterapi management

### DIFF
--- a/service/controller/aws/v18/key/common.go
+++ b/service/controller/aws/v18/key/common.go
@@ -1,15 +1,8 @@
 package key
 
 import (
-	g8sv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/cluster/v1alpha1"
-	cmav1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
-
 	"github.com/giantswarm/cluster-operator/pkg/label"
 )
-
-func ClusterCommonStatus(cluster cmav1alpha1.Cluster) g8sv1alpha1.CommonClusterStatus {
-	return g8sClusterCommonStatusFromCMAClusterStatus(cluster.Status.ProviderStatus)
-}
 
 func ClusterID(getter LabelsGetter) string {
 	return getter.GetLabels()[label.Cluster]

--- a/service/controller/aws/v18/key/spec.go
+++ b/service/controller/aws/v18/key/spec.go
@@ -1,0 +1,5 @@
+package key
+
+type LabelsGetter interface {
+	GetLabels() map[string]string
+}

--- a/service/controller/aws/v18/resource_set.go
+++ b/service/controller/aws/v18/resource_set.go
@@ -374,12 +374,16 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	}
 
 	handlesFunc := func(obj interface{}) bool {
-		awsClusterConfig, err := key.ToCustomObject(obj)
+		cr, err := key.ToCustomObject(obj)
 		if err != nil {
 			return false
 		}
 
-		if key.VersionBundleVersion(awsClusterConfig) == VersionBundle().Version {
+		if key.OperatorVersion(&cr) == VersionBundle().Version {
+			return true
+		}
+
+		if key.VersionBundleVersion(cr) == VersionBundle().Version {
 			return true
 		}
 

--- a/service/controller/clusterapi/v18/cluster_resource_set.go
+++ b/service/controller/clusterapi/v18/cluster_resource_set.go
@@ -71,8 +71,9 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 	var awsclusterconfigResource controller.Resource
 	{
 		c := awsclusterconfig.Config{
-			G8sClient: config.G8sClient,
-			Logger:    config.Logger,
+			ClusterClient: config.ClusterClient,
+			G8sClient:     config.G8sClient,
+			Logger:        config.Logger,
 		}
 
 		awsclusterconfigResource, err = awsclusterconfig.New(c)

--- a/service/controller/clusterapi/v18/cluster_resource_set.go
+++ b/service/controller/clusterapi/v18/cluster_resource_set.go
@@ -71,11 +71,8 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 	var awsclusterconfigResource controller.Resource
 	{
 		c := awsclusterconfig.Config{
-			BaseClusterConfig: *config.BaseClusterConfig,
-			ClusterClient:     config.ClusterClient,
-			CMAClient:         config.CMAClient,
-			G8sClient:         config.G8sClient,
-			Logger:            config.Logger,
+			G8sClient: config.G8sClient,
+			Logger:    config.Logger,
 		}
 
 		awsclusterconfigResource, err = awsclusterconfig.New(c)

--- a/service/controller/clusterapi/v18/resources/awsclusterconfig/create.go
+++ b/service/controller/clusterapi/v18/resources/awsclusterconfig/create.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 
 	corev1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
-	"github.com/giantswarm/aws-operator/pkg/label"
 	"github.com/giantswarm/microerror"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 
+	"github.com/giantswarm/cluster-operator/pkg/label"
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v18/key"
 )
 

--- a/service/controller/clusterapi/v18/resources/awsclusterconfig/create.go
+++ b/service/controller/clusterapi/v18/resources/awsclusterconfig/create.go
@@ -3,19 +3,14 @@ package awsclusterconfig
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	corev1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
-	"github.com/giantswarm/clusterclient/service/release/searcher"
+	"github.com/giantswarm/aws-operator/pkg/label"
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/versionbundle"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 
-	"github.com/giantswarm/cluster-operator/pkg/label"
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v18/key"
 )
 
@@ -25,165 +20,47 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	if !key.IsProviderSpecForAWS(cr) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("provider extension in cluster %#q is not for AWS", cr.Name))
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-		return nil
-	}
-
-	// ClusterID is core part of e.g. PKI initialization etc. so it must be
-	// present before proceeding further.
-	if key.ClusterID(&cr) == "" {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("provider status in cluster %#q does not contain cluster ID", cr.Name))
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-		return nil
-	}
-
-	var machineDeployments []clusterv1alpha1.MachineDeployment
 	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", "finding MachineDeployments for tenant cluster")
-
-		l := metav1.AddLabelToSelector(
-			&v1.LabelSelector{},
-			label.Cluster,
-			key.ClusterID(&cr),
-		)
-		o := metav1.ListOptions{
-			LabelSelector: labels.Set(l.MatchLabels).String(),
-		}
-
-		list, err := r.cmaClient.ClusterV1alpha1().MachineDeployments(cr.Namespace).List(o)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		machineDeployments = list.Items
-
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d MachineDeployments for tenant cluster", len(machineDeployments)))
-	}
-
-	var versionBundles []versionbundle.Bundle
-	{
-		req := searcher.Request{
-			ReleaseVersion: key.ReleaseVersion(&cr),
-		}
-
-		res, err := r.clusterClient.Release.Searcher.Search(ctx, req)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		versionBundles = res.VersionBundles
-	}
-
-	// Get existing AWSClusterConfig or create a new one.
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding out if AWSClusterConfig %#q/%#q exists", cr.Namespace, key.AWSClusterConfigName(cr)))
-
-	presentAWSClusterConfig, err := r.g8sClient.CoreV1alpha1().AWSClusterConfigs(cr.Namespace).Get(key.AWSClusterConfigName(cr), metav1.GetOptions{})
-	if errors.IsNotFound(err) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find AWSClusterConfig %#q/%#q", cr.Namespace, key.AWSClusterConfigName(cr)))
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating AWSClusterConfig %#q/%#q", cr.Namespace, key.AWSClusterConfigName(cr)))
-
-		newAWSClusterConfig := r.constructAWSClusterConfig(cr, machineDeployments, versionBundles)
-
-		_, err = r.g8sClient.CoreV1alpha1().AWSClusterConfigs(cr.Namespace).Create(&newAWSClusterConfig)
-		if errors.IsAlreadyExists(err) {
-			r.logger.LogCtx(ctx, "level", "warning", "message", fmt.Sprintf("AWSClusterConfig %#q/%#q already exists", newAWSClusterConfig.Namespace, newAWSClusterConfig.Name))
+		if !key.IsProviderSpecForAWS(cr) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("cluster %#q is not for aws", cr.Name))
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			return nil
-		} else if err != nil {
-			return microerror.Mask(err)
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created AWSClusterConfig %#q/%#q", newAWSClusterConfig.Namespace, newAWSClusterConfig.Name))
-		return nil
-	} else if err != nil {
-		return microerror.Mask(err)
+		if key.ClusterID(&cr) == "" {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("cluster %#q misses the cluster id label", cr.Name))
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+			return nil
+		}
 	}
 
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found AWSClusterConfig %#q/%#q", cr.Namespace, presentAWSClusterConfig.Name))
-
-	// Map desired state from Cluster to AWSClusterConfig.
-	newAWSClusterConfig := r.mapClusterToAWSClusterConfig(*presentAWSClusterConfig, cr, machineDeployments, versionBundles)
-
-	if reflect.DeepEqual(presentAWSClusterConfig.Spec, newAWSClusterConfig.Spec) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("current AWSClusterConfig %#q/%#q is up-to-date; no update needed.", newAWSClusterConfig.Namespace, newAWSClusterConfig.Name))
+	_, err = r.g8sClient.CoreV1alpha1().AWSClusterConfigs(cr.Namespace).Get(key.AWSClusterConfigName(cr), metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		// fall through
+	} else if err != nil {
+		return microerror.Mask(err)
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("aws cluster config for cluster %#q already created", cr.Name))
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		return nil
 	}
 
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating AWSClusterConfig %#q/%#q", newAWSClusterConfig.Namespace, newAWSClusterConfig.Name))
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating aws cluster config for cluster %#q", cr.Name))
 
-	_, err = r.g8sClient.CoreV1alpha1().AWSClusterConfigs(cr.Namespace).Update(&newAWSClusterConfig)
-	if err != nil {
-		return microerror.Mask(err)
+		_, err = r.g8sClient.CoreV1alpha1().AWSClusterConfigs(cr.Namespace).Create(newAWSClusterConfigFromCluster(cr))
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created aws cluster config for cluster %#q", cr.Name))
 	}
-
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updated AWSClusterConfig %#q/%#q", newAWSClusterConfig.Namespace, newAWSClusterConfig.Name))
 
 	return nil
 }
 
-func (r *Resource) mapClusterToAWSClusterConfig(awsClusterConfig corev1alpha1.AWSClusterConfig, cr clusterv1alpha1.Cluster, machineDeployments []clusterv1alpha1.MachineDeployment, versionBundles []versionbundle.Bundle) corev1alpha1.AWSClusterConfig {
-	awsClusterConfig.Spec.Guest.ClusterGuestConfig.AvailabilityZones = NumberOfAZsWithNodePools
-	awsClusterConfig.Spec.Guest.ClusterGuestConfig.DNSZone = key.ClusterDNSZone(cr)
-	awsClusterConfig.Spec.Guest.ClusterGuestConfig.ID = key.ClusterID(&cr)
-	awsClusterConfig.Spec.Guest.ClusterGuestConfig.Name = key.ClusterName(cr)
-	awsClusterConfig.Spec.Guest.ClusterGuestConfig.ReleaseVersion = key.ReleaseVersion(&cr)
-
-	var awsClusterConfigVersionBundle corev1alpha1.AWSClusterConfigSpecVersionBundle
-	var transformedVBs []corev1alpha1.ClusterGuestConfigVersionBundle
-	{
-		for _, b := range versionBundles {
-			bundle := corev1alpha1.ClusterGuestConfigVersionBundle{
-				Name:    b.Name,
-				Version: b.Version,
-			}
-
-			transformedVBs = append(transformedVBs, bundle)
-
-			if b.Name == "cluster-operator" {
-				awsClusterConfigVersionBundle.Version = b.Version
-			}
-		}
-	}
-
-	awsClusterConfig.Spec.Guest.ClusterGuestConfig.VersionBundles = transformedVBs
-	awsClusterConfig.Spec.Guest.CredentialSecret.Name = key.ClusterCredentialSecretName(cr)
-	awsClusterConfig.Spec.Guest.CredentialSecret.Namespace = key.ClusterCredentialSecretNamespace(cr)
-	awsClusterConfig.Spec.VersionBundle = awsClusterConfigVersionBundle
-
-	awsClusterConfig.Spec.Guest.Masters = []corev1alpha1.AWSClusterConfigSpecGuestMaster{
-		{
-			AWSClusterConfigSpecGuestNode: corev1alpha1.AWSClusterConfigSpecGuestNode{
-				InstanceType: key.ClusterMasterInstanceType(cr),
-			},
-		},
-	}
-
-	var workers []corev1alpha1.AWSClusterConfigSpecGuestWorker
-	for _, md := range machineDeployments {
-		for i := 0; i < int(md.Status.Replicas); i++ {
-			w := corev1alpha1.AWSClusterConfigSpecGuestWorker{
-				AWSClusterConfigSpecGuestNode: corev1alpha1.AWSClusterConfigSpecGuestNode{
-					InstanceType: key.MachineDeploymentWorkerInstanceType(md),
-				},
-				Labels: map[string]string{
-					label.Cluster:           key.ClusterID(&cr),
-					label.ReleaseVersion:    key.ReleaseVersion(&md),
-					label.MachineDeployment: key.MachineDeployment(&md),
-				},
-			}
-			workers = append(workers, w)
-		}
-	}
-	awsClusterConfig.Spec.Guest.Workers = workers
-
-	return awsClusterConfig
-}
-
-func (r *Resource) constructAWSClusterConfig(cr clusterv1alpha1.Cluster, machineDeployments []clusterv1alpha1.MachineDeployment, versionBundles []versionbundle.Bundle) corev1alpha1.AWSClusterConfig {
-	cc := corev1alpha1.AWSClusterConfig{
+func newAWSClusterConfigFromCluster(cr clusterv1alpha1.Cluster) *corev1alpha1.AWSClusterConfig {
+	return &corev1alpha1.AWSClusterConfig{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "AWSClusterConfig",
 			APIVersion: "v1alpha1",
@@ -191,8 +68,24 @@ func (r *Resource) constructAWSClusterConfig(cr clusterv1alpha1.Cluster, machine
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      key.AWSClusterConfigName(cr),
 			Namespace: cr.Namespace,
+			Labels: map[string]string{
+				label.Cluster:         key.ClusterID(&cr),
+				label.OperatorVersion: key.OperatorVersion(&cr),
+				label.Organization:    key.OrganizationID(&cr),
+				label.ReleaseVersion:  key.ReleaseVersion(&cr),
+			},
+		},
+		Spec: corev1alpha1.AWSClusterConfigSpec{
+			Guest: corev1alpha1.AWSClusterConfigSpecGuest{
+				ClusterGuestConfig: corev1alpha1.ClusterGuestConfig{
+					DNSZone: key.ClusterDNSZone(cr),
+					ID:      key.ClusterID(&cr),
+				},
+				CredentialSecret: corev1alpha1.AWSClusterConfigSpecGuestCredentialSecret{
+					Name:      key.ClusterCredentialSecretName(cr),
+					Namespace: key.ClusterCredentialSecretNamespace(cr),
+				},
+			},
 		},
 	}
-
-	return r.mapClusterToAWSClusterConfig(cc, cr, machineDeployments, versionBundles)
 }

--- a/service/controller/clusterapi/v18/resources/awsclusterconfig/create.go
+++ b/service/controller/clusterapi/v18/resources/awsclusterconfig/create.go
@@ -30,7 +30,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		}
 
 		if key.ClusterID(&cr) == "" {
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("cluster %#q misses the cluster id label", cr.Name))
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("cluster %#q misses cluster id in labels", cr.Name))
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			return nil
 		}

--- a/service/controller/clusterapi/v18/resources/awsclusterconfig/create.go
+++ b/service/controller/clusterapi/v18/resources/awsclusterconfig/create.go
@@ -86,6 +86,9 @@ func newAWSClusterConfigFromCluster(cr clusterv1alpha1.Cluster) *corev1alpha1.AW
 					Namespace: key.ClusterCredentialSecretNamespace(cr),
 				},
 			},
+			VersionBundle: corev1alpha1.AWSClusterConfigSpecVersionBundle{
+				Version: key.OperatorVersion(&cr),
+			},
 		},
 	}
 }

--- a/service/controller/clusterapi/v18/resources/awsclusterconfig/resource.go
+++ b/service/controller/clusterapi/v18/resources/awsclusterconfig/resource.go
@@ -1,57 +1,29 @@
 package awsclusterconfig
 
 import (
-	"reflect"
-
-	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
-	"github.com/giantswarm/clusterclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
-
-	"github.com/giantswarm/cluster-operator/pkg/cluster"
-	"github.com/giantswarm/cluster-operator/pkg/v18/key"
 )
 
 const (
 	Name = "awsclusterconfigv18"
-
-	// With first version of Node Pools implementation, the maximum number of
-	// AZs for a tenant cluster is always 4. This is due to restrictions in
-	// current network design.
-	NumberOfAZsWithNodePools = 4
 )
 
 // Config represents the configuration used to create a new awsclusterconfig resource.
 type Config struct {
-	BaseClusterConfig cluster.Config
-	ClusterClient     *clusterclient.Client
-	CMAClient         clientset.Interface
-	G8sClient         versioned.Interface
-	Logger            micrologger.Logger
+	G8sClient versioned.Interface
+	Logger    micrologger.Logger
 }
 
 // Resource implements the awsclusterconfig resource.
 type Resource struct {
-	baseClusterConfig cluster.Config
-	clusterClient     *clusterclient.Client
-	cmaClient         clientset.Interface
-	g8sClient         versioned.Interface
-	logger            micrologger.Logger
+	g8sClient versioned.Interface
+	logger    micrologger.Logger
 }
 
 // New creates a new configured tiller resource.
 func New(config Config) (*Resource, error) {
-	if reflect.DeepEqual(config.BaseClusterConfig, cluster.Config{}) {
-		return nil, microerror.Maskf(invalidConfigError, "%T.BaseClusterConfig must not be empty", config)
-	}
-	if config.ClusterClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.ClusterClient must not be empty", config)
-	}
-	if config.CMAClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.CMAClient must not be empty", config)
-	}
 	if config.G8sClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
 	}
@@ -60,11 +32,8 @@ func New(config Config) (*Resource, error) {
 	}
 
 	r := &Resource{
-		baseClusterConfig: config.BaseClusterConfig,
-		clusterClient:     config.ClusterClient,
-		cmaClient:         config.CMAClient,
-		g8sClient:         config.G8sClient,
-		logger:            config.Logger,
+		g8sClient: config.G8sClient,
+		logger:    config.Logger,
 	}
 
 	return r, nil
@@ -72,20 +41,4 @@ func New(config Config) (*Resource, error) {
 
 func (r *Resource) Name() string {
 	return Name
-}
-
-func prepareClusterConfig(baseClusterConfig cluster.Config, clusterGuestConfig v1alpha1.ClusterGuestConfig) (cluster.Config, error) {
-	var err error
-
-	// Use baseClusterConfig as a basis and supplement it with information from
-	// clusterGuestConfig.
-	clusterConfig := baseClusterConfig
-
-	clusterConfig.ClusterID = key.ClusterID(clusterGuestConfig)
-	clusterConfig.Domain.API, err = key.APIDomain(clusterGuestConfig)
-	if err != nil {
-		return cluster.Config{}, microerror.Mask(err)
-	}
-
-	return clusterConfig, nil
 }

--- a/service/controller/clusterapi/v18/resources/awsclusterconfig/resource.go
+++ b/service/controller/clusterapi/v18/resources/awsclusterconfig/resource.go
@@ -2,6 +2,7 @@ package awsclusterconfig
 
 import (
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/clusterclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 )
@@ -12,18 +13,23 @@ const (
 
 // Config represents the configuration used to create a new awsclusterconfig resource.
 type Config struct {
-	G8sClient versioned.Interface
-	Logger    micrologger.Logger
+	ClusterClient *clusterclient.Client
+	G8sClient     versioned.Interface
+	Logger        micrologger.Logger
 }
 
 // Resource implements the awsclusterconfig resource.
 type Resource struct {
-	g8sClient versioned.Interface
-	logger    micrologger.Logger
+	clusterClient *clusterclient.Client
+	g8sClient     versioned.Interface
+	logger        micrologger.Logger
 }
 
 // New creates a new configured tiller resource.
 func New(config Config) (*Resource, error) {
+	if config.ClusterClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ClusterClient must not be empty", config)
+	}
 	if config.G8sClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
 	}
@@ -32,8 +38,9 @@ func New(config Config) (*Resource, error) {
 	}
 
 	r := &Resource{
-		g8sClient: config.G8sClient,
-		logger:    config.Logger,
+		clusterClient: config.ClusterClient,
+		g8sClient:     config.G8sClient,
+		logger:        config.Logger,
 	}
 
 	return r, nil

--- a/service/controller/clusterapi/v18/resources/clusterid/create.go
+++ b/service/controller/clusterapi/v18/resources/clusterid/create.go
@@ -2,55 +2,72 @@ package clusterid
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v18/key"
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
-	cr, err := key.ToCluster(obj)
+	old, err := key.ToCluster(obj)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "level", "debug", "message", "ensuring cluster status has cluster ID")
+	var cr v1alpha1.Cluster
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finding latest cluster")
 
-	status := r.commonClusterStatusAccessor.GetCommonClusterStatus(cr)
+		cl, err := r.cmaClient.ClusterV1alpha1().Clusters(old.Namespace).Get(old.Name, metav1.GetOptions{})
+		if err != nil {
+			return microerror.Mask(err)
+		}
 
-	if status.ID != "" {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "ensured cluster status has cluster ID")
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		cr = *cl
 
-		return nil
+		r.logger.LogCtx(ctx, "level", "debug", "message", "found latest cluster")
 	}
 
-	clusterID := key.ClusterID(&cr)
+	status := key.ClusterCommonStatus(cr)
 
-	if clusterID == "" {
-		return microerror.Maskf(executionFailedError, "cluster ID missing from CR")
+	{
+		if status.ID != "" {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("cluster %#q has cluster id in status", cr.Name))
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		}
+
+		if key.ClusterID(&cr) == "" {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("cluster %#q misses cluster id in labels", cr.Name))
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+			return nil
+		}
 	}
 
-	status.ID = clusterID
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "updating cluster status")
 
-	updatedCR := r.commonClusterStatusAccessor.SetCommonClusterStatus(cr, status)
+		status.ID = key.ClusterID(&cr)
+		new := r.commonClusterStatusAccessor.SetCommonClusterStatus(cr, status)
 
-	r.logger.LogCtx(ctx, "level", "debug", "message", "updating cluster status")
+		_, err = r.cmaClient.ClusterV1alpha1().Clusters(cr.Namespace).UpdateStatus(&new)
+		if err != nil {
+			return microerror.Mask(err)
+		}
 
-	_, err = r.cmaClient.ClusterV1alpha1().Clusters(cr.Namespace).UpdateStatus(&updatedCR)
-	if err != nil {
-		return microerror.Mask(err)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "updated cluster status")
+
+		// All further resources require cluster ID to be present in the status so
+		// it makes sense to cancel whole CR reconciliation here and start from the
+		// beginning.
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+		reconciliationcanceledcontext.SetCanceled(ctx)
 	}
-
-	r.logger.LogCtx(ctx, "level", "debug", "message", "updated cluster status")
-	r.logger.LogCtx(ctx, "level", "debug", "message", "ensured cluster status has cluster ID")
-	r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
-
-	// All further resources require cluster ID to be present in the status so
-	// it makes sense to cancel whole CR reconciliation here and start from the
-	// beginning.
-	reconciliationcanceledcontext.SetCanceled(ctx)
 
 	return nil
 }


### PR DESCRIPTION
Towards Node Pools. This fixes the version bundle references in the `AWSClusterConfig` CR we generate upon the `Cluster` CR reconciliation. I dropped the update mechanism which was premature. We get to updates next week and rethink the approach. 