### PR TITLE
add operatorversions resource

### DIFF
--- a/service/controller/clusterapi/v18/cluster_resource_set.go
+++ b/service/controller/clusterapi/v18/cluster_resource_set.go
@@ -19,6 +19,7 @@ import (
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v18/resources/awsclusterconfig"
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v18/resources/clusterid"
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v18/resources/clusterstatus"
+	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v18/resources/operatorversions"
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v18/resources/tenantclients"
 )
 
@@ -133,6 +134,19 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 	//	}
 	//}
 
+	var operatorVersionsResource controller.Resource
+	{
+		c := operatorversions.Config{
+			ClusterClient: config.ClusterClient,
+			Logger:        config.Logger,
+		}
+
+		operatorVersionsResource, err = operatorversions.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var tenantClientsResource controller.Resource
 	{
 		c := tenantclients.Config{
@@ -150,6 +164,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 
 	resources := []controller.Resource{
 		clusterIDResource,
+		operatorVersionsResource,
 		tenantClientsResource,
 		clusterStatusResource,
 

--- a/service/controller/clusterapi/v18/controllercontext/context.go
+++ b/service/controller/clusterapi/v18/controllercontext/context.go
@@ -12,6 +12,7 @@ const contextKey key = "controller"
 
 type Context struct {
 	Client ContextClient
+	Status ContextStatus
 }
 
 func NewContext(ctx context.Context, c Context) context.Context {

--- a/service/controller/clusterapi/v18/controllercontext/status.go
+++ b/service/controller/clusterapi/v18/controllercontext/status.go
@@ -1,0 +1,5 @@
+package controllercontext
+
+type ContextStatus struct {
+	Versions map[string]string
+}

--- a/service/controller/clusterapi/v18/resources/operatorversions/create.go
+++ b/service/controller/clusterapi/v18/resources/operatorversions/create.go
@@ -1,0 +1,16 @@
+package operatorversions
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	err := r.ensure(ctx, obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/service/controller/clusterapi/v18/resources/operatorversions/delete.go
+++ b/service/controller/clusterapi/v18/resources/operatorversions/delete.go
@@ -1,0 +1,16 @@
+package operatorversions
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	err := r.ensure(ctx, obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/service/controller/clusterapi/v18/resources/operatorversions/error.go
+++ b/service/controller/clusterapi/v18/resources/operatorversions/error.go
@@ -1,0 +1,14 @@
+package operatorversions
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/clusterapi/v18/resources/operatorversions/resource.go
+++ b/service/controller/clusterapi/v18/resources/operatorversions/resource.go
@@ -1,0 +1,80 @@
+package operatorversions
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/clusterclient"
+	"github.com/giantswarm/clusterclient/service/release/searcher"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/versionbundle"
+
+	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v18/controllercontext"
+	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v18/key"
+)
+
+const (
+	Name = "operatorversionsv18"
+)
+
+type Config struct {
+	ClusterClient *clusterclient.Client
+	Logger        micrologger.Logger
+}
+
+type Resource struct {
+	clusterClient *clusterclient.Client
+	logger        micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.ClusterClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ClusterClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		clusterClient: config.ClusterClient,
+		logger:        config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func (r *Resource) ensure(ctx context.Context, obj interface{}) error {
+	cr, err := key.ToCluster(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	var versionBundles []versionbundle.Bundle
+	{
+		req := searcher.Request{
+			ReleaseVersion: key.ReleaseVersion(&cr),
+		}
+
+		res, err := r.clusterClient.Release.Searcher.Search(ctx, req)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		versionBundles = res.VersionBundles
+	}
+
+	for _, b := range versionBundles {
+		cc.Status.Versions[fmt.Sprintf("%s.giantswarm.io/version", b.Name)] = b.Version
+	}
+
+	return nil
+}


### PR DESCRIPTION
Towards Node Pools. We want to improve the situation in `cluster-operator` a little bit. The operator manages resources consumed by other operators. Therefore it needs to know about certain versions associated to a release. Instead of letting each resource lookup these information separately we introduce a resource that fetches the version information and writes it to the controller context, which is then specific to the release of the reconciled object. Resources reading these information have it very easy to do so. 