### PR TITLE
Apply 0-9-stable-channel for ingress-nginx

### DIFF
--- a/pkg/v14patch2/key/key.go
+++ b/pkg/v14patch2/key/key.go
@@ -105,7 +105,7 @@ func CommonChartSpecs() []ChartSpec {
 		},
 		{
 			AppName:           "nginx-ingress-controller",
-			ChannelName:       "0-6-stable",
+			ChannelName:       "0-9-stable",
 			ChartName:         "kubernetes-nginx-ingress-controller-chart",
 			ConfigMapName:     "nginx-ingress-controller-values",
 			Namespace:         metav1.NamespaceSystem,

--- a/service/controller/aws/v14patch2/version_bundle.go
+++ b/service/controller/aws/v14patch2/version_bundle.go
@@ -9,6 +9,11 @@ func VersionBundle() versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "nginx-ingress-controller",
+				Description: "Updated to 0.25.1. More info here https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "nginx-ingress-controller",
 				Description: "Updated to 0.24.1. More info here https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md",
 				Kind:        versionbundle.KindChanged,
 			},
@@ -25,7 +30,7 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Name:    "nginx-ingress-controller",
-				Version: "0.24.1",
+				Version: "0.25.1",
 			},
 			{
 				Name:    "node-exporter",


### PR DESCRIPTION
To apply nginx 0.25.1, apply new channel into 0.14.2 