### PR TITLE
fix nil map assignment panic

### DIFF
--- a/service/controller/clusterapi/v18/resources/operatorversions/resource.go
+++ b/service/controller/clusterapi/v18/resources/operatorversions/resource.go
@@ -72,8 +72,13 @@ func (r *Resource) ensure(ctx context.Context, obj interface{}) error {
 		versionBundles = res.VersionBundles
 	}
 
-	for _, b := range versionBundles {
-		cc.Status.Versions[fmt.Sprintf("%s.giantswarm.io/version", b.Name)] = b.Version
+	{
+		if cc.Status.Versions == nil {
+			cc.Status.Versions = map[string]string{}
+		}
+		for _, b := range versionBundles {
+			cc.Status.Versions[fmt.Sprintf("%s.giantswarm.io/version", b.Name)] = b.Version
+		}
 	}
 
 	return nil


### PR DESCRIPTION
```
panic: assignment to entry in nil map

goroutine 14 [running]:
github.com/giantswarm/cluster-operator/service/controller/clusterapi/v18/resources/operatorversions.(*Resource).ensure(0xc000402ec0, 0x1bdf520, 0xc000276540, 0x1907b60, 0xc00028bd40, 0x7f1a0827f6d0, 0x0)
        /go/src/github.com/giantswarm/cluster-operator/service/controller/clusterapi/v18/resources/operatorversions/resource.go:76 +0x37e
github.com/giantswarm/cluster-operator/service/controller/clusterapi/v18/resources/operatorversions.(*Resource).EnsureCreated(0xc000402ec0, 0x1bdf520, 0xc000276540, 0x1907b60, 0xc00028bd40, 0x17e3860, 0x116216c)
...
```