### PR TITLE
Bump Ingress Controller release channel and tidy up changelogs

### DIFF
--- a/pkg/v19/key/key.go
+++ b/pkg/v19/key/key.go
@@ -116,7 +116,7 @@ func CommonChartSpecs() []ChartSpec {
 		},
 		{
 			AppName:       "nginx-ingress-controller",
-			ChannelName:   "0-9-stable",
+			ChannelName:   "0-10-stable",
 			ChartName:     "kubernetes-nginx-ingress-controller-chart",
 			ConfigMapName: "nginx-ingress-controller-values",
 			Namespace:     metav1.NamespaceSystem,

--- a/service/controller/aws/v19/version_bundle.go
+++ b/service/controller/aws/v19/version_bundle.go
@@ -8,26 +8,6 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "cert-exporter",
-				Description: "Add toleration for all taints",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "net-exporter",
-				Description: "Add toleration for all taints",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "node-exporter",
-				Description: "Add toleration for all taints",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "nginx-ingress-controller",
-				Description: "Update to 0.25.1. https://github.com/giantswarm/kubernetes-nginx-ingress-controller/blob/master/CHANGELOG.md",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
 				Component:   "coredns",
 				Description: "Update to 1.6.2. https://github.com/giantswarm/kubernetes-coredns/blob/master/CHANGELOG.md#v070",
 				Kind:        versionbundle.KindChanged,

--- a/service/controller/clusterapi/v19/version_bundle.go
+++ b/service/controller/clusterapi/v19/version_bundle.go
@@ -8,26 +8,6 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "cert-exporter",
-				Description: "Add toleration for all taints",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "net-exporter",
-				Description: "Add toleration for all taints",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "node-exporter",
-				Description: "Add toleration for all taints",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "nginx-ingress-controller",
-				Description: "Update to 0.25.0. https://github.com/giantswarm/kubernetes-nginx-ingress-controller/blob/master/CHANGELOG.md",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
 				Component:   "coredns",
 				Description: "Update to 1.6.2. https://github.com/giantswarm/kubernetes-coredns/blob/master/CHANGELOG.md#v070",
 				Kind:        versionbundle.KindChanged,

--- a/service/controller/kvm/v19/version_bundle.go
+++ b/service/controller/kvm/v19/version_bundle.go
@@ -8,11 +8,6 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "TODO",
-				Description: "TODO",
-				Kind:        versionbundle.KindAdded,
-			},
-			{
 				Component:   "kube-state-metrics",
 				Description: "Update to 1.7.2. https://github.com/giantswarm/kubernetes-kube-state-metrics/blob/master/CHANGELOG.md#v040",
 				Kind:        versionbundle.KindChanged,


### PR DESCRIPTION
We have a feature flag for IC HPA but to be extra careful this bumps the release channel.

I also found some problems with the changelogs so trying to get them straight.