### PR TITLE
refactor chartconfig resource

### DIFF
--- a/service/controller/clusterapi/v19/cluster_resource_set.go
+++ b/service/controller/clusterapi/v19/cluster_resource_set.go
@@ -41,6 +41,25 @@ type ClusterResourceSetConfig struct {
 func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.ResourceSet, error) {
 	var err error
 
+	//var chartConfigResource controller.Resource
+	//{
+	//	c := certconfig.Config{
+	//		Logger: config.Logger,
+	//
+	//		Provider: config.Provider,
+	//	}
+	//
+	//	ops, err := certconfig.New(c)
+	//	if err != nil {
+	//		return nil, microerror.Mask(err)
+	//	}
+	//
+	//	chartConfigResource, err = toCRUDResource(config.Logger, ops)
+	//	if err != nil {
+	//		return nil, microerror.Mask(err)
+	//	}
+	//}
+
 	var clusterIDResource controller.Resource
 	{
 		c := clusterid.Config{

--- a/service/controller/clusterapi/v19/resources/certconfig/resource.go
+++ b/service/controller/clusterapi/v19/resources/certconfig/resource.go
@@ -13,7 +13,9 @@ import (
 const (
 	// Name is the identifier of the resource.
 	Name = "certconfigv19"
+)
 
+const (
 	// listCertConfigLimit is the suggested maximum number of CertConfigs returned
 	// in one List() call to K8s API. Server may choose to not support this so
 	// this is not strict maximum.

--- a/service/controller/clusterapi/v19/resources/chartconfig/create.go
+++ b/service/controller/clusterapi/v19/resources/chartconfig/create.go
@@ -1,0 +1,63 @@
+package chartconfig
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/microerror"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/controllercontext"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	chartConfigs, err := toChartConfigs(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(chartConfigs) > 0 {
+		for _, chartConfig := range chartConfigs {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating chartconfig %#q in namespace %#q", chartConfig.Name, chartConfig.Namespace))
+
+			_, err := cc.Client.TenantCluster.G8s.CoreV1alpha1().ChartConfigs(chartConfig.Namespace).Create(chartConfig)
+			if apierrors.IsAlreadyExists(err) {
+				// fall through
+			} else if err != nil {
+				return microerror.Mask(err)
+			}
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created chartconfig %#q in namespace %#q", chartConfig.Name, chartConfig.Namespace))
+		}
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "did not create chartconfigs")
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) ([]*v1alpha1.ChartConfig, error) {
+	currentChartConfigs, err := toChartConfigs(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredChartConfigs, err := toChartConfigs(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var chartConfigsToCreate []*v1alpha1.ChartConfig
+
+	for _, desiredChartConfig := range desiredChartConfigs {
+		if !containsChartConfig(currentChartConfigs, desiredChartConfig) {
+			chartConfigsToCreate = append(chartConfigsToCreate, desiredChartConfig)
+		}
+	}
+
+	return chartConfigsToCreate, nil
+}

--- a/service/controller/clusterapi/v19/resources/chartconfig/current.go
+++ b/service/controller/clusterapi/v19/resources/chartconfig/current.go
@@ -1,0 +1,61 @@
+package chartconfig
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/cluster-operator/pkg/label"
+	"github.com/giantswarm/cluster-operator/pkg/project"
+	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/controllercontext"
+	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	cr, err := key.ToCluster(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	{
+		if cc.Client.TenantCluster.G8s == nil {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster clients not available")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+			resourcecanceledcontext.SetCanceled(ctx)
+			return nil, nil
+		}
+	}
+
+	var chartConfigs []*v1alpha1.ChartConfig
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding chart configs in tenant cluster %#q", key.ClusterID(&cr)))
+
+		o := metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("%s=%s", label.ManagedBy, project.Name()),
+		}
+
+		list, err := cc.Client.TenantCluster.G8s.CoreV1alpha1().ChartConfigs("giantswarm").List(o)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		for _, item := range list.Items {
+			// Make a copy of an Item in order to not refer to loop iterator
+			// variable. This is because we want to track a list of pointers.
+			item := item
+			chartConfigs = append(chartConfigs, &item)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d chart configs in tenant cluster %#q", len(chartConfigs), key.ClusterID(&cr)))
+	}
+
+	return chartConfigs, nil
+}

--- a/service/controller/clusterapi/v19/resources/chartconfig/delete.go
+++ b/service/controller/clusterapi/v19/resources/chartconfig/delete.go
@@ -1,4 +1,4 @@
-package chartoperator
+package chartconfig
 
 import (
 	"context"
@@ -6,13 +6,13 @@ import (
 	"github.com/giantswarm/operatorkit/controller"
 )
 
-// ApplyDeleteChange is a no-op because chart-operator in the tenant cluster is
+// ApplyDeleteChange is a no-op because ChartConfig CRs in the tenant cluster is
 // deleted with the tenant cluster itself.
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
 	return nil
 }
 
-// NewDeletePatch is a no-op because chart-operator in the tenant cluster is
+// NewDeletePatch is a no-op because ChartConfig CRs in the tenant cluster is
 // deleted with the tenant cluster itself.
 func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
 	return nil, nil

--- a/service/controller/clusterapi/v19/resources/chartconfig/desired.go
+++ b/service/controller/clusterapi/v19/resources/chartconfig/desired.go
@@ -1,0 +1,138 @@
+package chartconfig
+
+import (
+	"context"
+	"strconv"
+
+	g8sv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/errors/guest"
+	"github.com/giantswarm/microerror"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	cmav1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+
+	"github.com/giantswarm/cluster-operator/pkg/annotation"
+	"github.com/giantswarm/cluster-operator/pkg/label"
+	"github.com/giantswarm/cluster-operator/pkg/project"
+	pkgkey "github.com/giantswarm/cluster-operator/pkg/v19/key"
+	awskey "github.com/giantswarm/cluster-operator/service/controller/aws/v19/key"
+	azurekey "github.com/giantswarm/cluster-operator/service/controller/azure/v19/key"
+	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/controllercontext"
+	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/key"
+	kvmkey "github.com/giantswarm/cluster-operator/service/controller/kvm/v19/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	cr, err := key.ToCluster(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var chartConfigs []*g8sv1alpha1.ChartConfig
+
+	for _, chartSpec := range r.newChartSpecs() {
+		// App config maps are statically defined by cluster-operator. We put app
+		// config maps with user config maps together into the ChartConfig CRs below
+		// so they can be merged and take effect accordingly.
+		acmSpec, err := r.newConfigMapSpec(*cc, cr, chartSpec.ConfigMapName, chartSpec.Namespace)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		// User config maps are created by cluster-operator and modified by users to
+		// override chart values on demand. We put user config maps with app config
+		// maps together into the ChartConfig CRs below so they can be merged and
+		// take effect accordingly.
+		ucmSpec, err := r.newConfigMapSpec(*cc, cr, chartSpec.UserConfigMapName, chartSpec.Namespace)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		chartConfigs = append(chartConfigs, r.newChartConfig(cr, chartSpec, acmSpec, ucmSpec))
+	}
+
+	return chartConfigs, nil
+}
+
+func (r *Resource) newChartConfig(cr cmav1alpha1.Cluster, chartSpec pkgkey.ChartSpec, acmSpec g8sv1alpha1.ChartConfigSpecConfigMap, ucmSpec g8sv1alpha1.ChartConfigSpecConfigMap) *g8sv1alpha1.ChartConfig {
+	return &g8sv1alpha1.ChartConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ChartConfig",
+			APIVersion: "core.giantswarm.io",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				annotation.ForceHelmUpgrade: strconv.FormatBool(chartSpec.UseUpgradeForce),
+			},
+			Labels: map[string]string{
+				label.App:          chartSpec.AppName,
+				label.Cluster:      key.ClusterID(&cr),
+				label.ManagedBy:    project.Name(),
+				label.Organization: key.OrganizationID(&cr),
+				label.ServiceType:  label.ServiceTypeManaged,
+			},
+			Name:      chartSpec.ChartName,
+			Namespace: "giantswarm",
+		},
+		Spec: g8sv1alpha1.ChartConfigSpec{
+			Chart: g8sv1alpha1.ChartConfigSpecChart{
+				Name:      chartSpec.ChartName,
+				Namespace: chartSpec.Namespace,
+				Channel:   chartSpec.ChannelName,
+				Release:   chartSpec.ReleaseName,
+
+				ConfigMap:     acmSpec,
+				UserConfigMap: ucmSpec,
+			},
+			VersionBundle: g8sv1alpha1.ChartConfigSpecVersionBundle{
+				Version: "0.6.0",
+			},
+		},
+	}
+}
+
+func (r *Resource) newChartSpecs() []pkgkey.ChartSpec {
+	switch r.provider {
+	case "aws":
+		return append(pkgkey.CommonChartSpecs(), awskey.ChartSpecs()...)
+	case "azure":
+		return append(pkgkey.CommonChartSpecs(), azurekey.ChartSpecs()...)
+	case "kvm":
+		return append(pkgkey.CommonChartSpecs(), kvmkey.ChartSpecs()...)
+	default:
+		return pkgkey.CommonChartSpecs()
+	}
+}
+
+func (r *Resource) newConfigMapSpec(cc controllercontext.Context, cr cmav1alpha1.Cluster, name string, namespace string) (g8sv1alpha1.ChartConfigSpecConfigMap, error) {
+	if name == "" {
+		// Not all charts define a user config map. In case there is none given, we
+		// just retrun the zero value since this is the best we can do.
+		return g8sv1alpha1.ChartConfigSpecConfigMap{}, nil
+	}
+
+	configMapSpec := g8sv1alpha1.ChartConfigSpecConfigMap{
+		Name:      name,
+		Namespace: namespace,
+	}
+
+	cm, err := cc.Client.TenantCluster.K8s.CoreV1().ConfigMaps(namespace).Get(name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) || guest.IsAPINotAvailable(err) {
+		// Cannot get configmap resource version so leave it unset. We will check
+		// again after the next resync period.
+		return configMapSpec, nil
+	} else if err != nil {
+		return g8sv1alpha1.ChartConfigSpecConfigMap{}, microerror.Mask(err)
+	}
+
+	// Set the configmap resource version. When this changes it will generate an
+	// update event for chart-operator. chart-operator will recalculate the
+	// desired state including any updated config map values.
+	configMapSpec.ResourceVersion = cm.ResourceVersion
+
+	return configMapSpec, nil
+}

--- a/service/controller/clusterapi/v19/resources/chartconfig/error.go
+++ b/service/controller/clusterapi/v19/resources/chartconfig/error.go
@@ -1,0 +1,32 @@
+package chartconfig
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongType asserts wrongTypeError.
+func IsWrongType(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/clusterapi/v19/resources/chartconfig/resource.go
+++ b/service/controller/clusterapi/v19/resources/chartconfig/resource.go
@@ -1,0 +1,126 @@
+package chartconfig
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/cluster-operator/pkg/annotation"
+)
+
+const (
+	Name = "chartconfigv19"
+)
+
+// Config represents the configuration used to create a new chartconfig service.
+type Config struct {
+	Logger micrologger.Logger
+
+	Provider string
+}
+
+// Resource provides shared functionality for managing chartconfigs.
+type Resource struct {
+	logger micrologger.Logger
+
+	provider string
+}
+
+// New creates a new chartconfig service.
+func New(config Config) (*Resource, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	if config.Provider == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Provider must not be empty", config)
+	}
+
+	r := &Resource{
+		logger: config.Logger,
+
+		provider: config.Provider,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+// containsChartConfig checks if item is present within list
+// by comparing ChartConfig.Name property between item and list objects
+// and comparing list object namespace against resourceNamespace
+// which is the destination namespace for the item ChartConfig see ApplyCreateChange.
+func containsChartConfig(list []*v1alpha1.ChartConfig, item *v1alpha1.ChartConfig) bool {
+	for _, l := range list {
+		if item.Name == l.Name && item.Namespace == l.Namespace {
+			return true
+		}
+	}
+
+	return false
+}
+
+func filterChartOperatorAnnotations(cr *v1alpha1.ChartConfig) map[string]string {
+	annotations := map[string]string{}
+
+	for k, v := range cr.Annotations {
+		if k == annotation.CordonReason || k == annotation.CordonUntilDate {
+			continue
+		}
+		if strings.HasPrefix(k, annotation.ChartOperator) {
+			annotations[k] = v
+		}
+	}
+
+	return annotations
+}
+
+func getChartConfigByName(list []*v1alpha1.ChartConfig, name string) (*v1alpha1.ChartConfig, error) {
+	for _, l := range list {
+		if l.Name == name {
+			return l, nil
+		}
+	}
+
+	return nil, microerror.Mask(notFoundError)
+}
+
+func isChartConfigModified(a, b *v1alpha1.ChartConfig) bool {
+	// If the Spec section has changed we need to update.
+	if !reflect.DeepEqual(a.Spec, b.Spec) {
+		return true
+	}
+	// If the Labels have changed we also need to update.
+	if !reflect.DeepEqual(a.Labels, b.Labels) {
+		return true
+	}
+
+	// We only consider annotations with the chart-operator prefix.
+	filteredA := filterChartOperatorAnnotations(a)
+	filteredB := filterChartOperatorAnnotations(b)
+
+	if !reflect.DeepEqual(filteredA, filteredB) {
+		return true
+	}
+
+	return false
+}
+
+func toChartConfigs(v interface{}) ([]*v1alpha1.ChartConfig, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	t, ok := v.([]*v1alpha1.ChartConfig)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", t, v)
+	}
+
+	return t, nil
+}

--- a/service/controller/clusterapi/v19/resources/chartconfig/resource_test.go
+++ b/service/controller/clusterapi/v19/resources/chartconfig/resource_test.go
@@ -1,0 +1,63 @@
+package chartconfig
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/cluster-operator/pkg/annotation"
+)
+
+func Test_Resource_ChartConfig_filterChartOperatorAnnotations(t *testing.T) {
+	testCases := []struct {
+		name               string
+		chartConfig        *v1alpha1.ChartConfig
+		expectedAnnotation map[string]string
+	}{
+		{
+			name: "case 1: filter non chart-operator annotations",
+			chartConfig: &v1alpha1.ChartConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"chart-operator.giantswarm.io/mananged-by":  "giantswarm",
+						"chart-operator.giantswarm.io/organization": "giantswarm",
+						"random-generated-by":                       "kubeconfig",
+					},
+				},
+			},
+			expectedAnnotation: map[string]string{
+				"chart-operator.giantswarm.io/mananged-by":  "giantswarm",
+				"chart-operator.giantswarm.io/organization": "giantswarm",
+			},
+		},
+		{
+			name: "case 2: skip comparing cordon annotations",
+			chartConfig: &v1alpha1.ChartConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"chart-operator.giantswarm.io/mananged-by":  "giantswarm",
+						"chart-operator.giantswarm.io/organization": "giantswarm",
+						annotation.CordonReason:                     "managing cordns",
+						annotation.CordonUntilDate:                  "2019-12-31T23:59:59Z",
+					},
+				},
+			},
+			expectedAnnotation: map[string]string{
+				"chart-operator.giantswarm.io/mananged-by":  "giantswarm",
+				"chart-operator.giantswarm.io/organization": "giantswarm",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := filterChartOperatorAnnotations(tc.chartConfig)
+
+			if !reflect.DeepEqual(result, tc.expectedAnnotation) {
+				t.Fatalf("expected annotation %#q, got %#q", tc.expectedAnnotation, result)
+			}
+		})
+	}
+}

--- a/service/controller/clusterapi/v19/resources/chartconfig/update.go
+++ b/service/controller/clusterapi/v19/resources/chartconfig/update.go
@@ -1,0 +1,123 @@
+package chartconfig
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+
+	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/controllercontext"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	chartConfigs, err := toChartConfigs(updateChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(chartConfigs) > 0 {
+		for _, chartConfig := range chartConfigs {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating chartconfig %#q in namespace %#q", chartConfig.Name, chartConfig.Namespace))
+
+			_, err := cc.Client.TenantCluster.G8s.CoreV1alpha1().ChartConfigs(chartConfig.Namespace).Update(chartConfig)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updated chartconfig %#q in namespace %#q", chartConfig.Name, chartConfig.Namespace))
+		}
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "no need to update chartconfigs")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	delete, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetDeleteChange(delete)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+// newDeleteChange is specific to the update behaviour because we might want to
+// remove certain chart configs when a tenant cluster is reconciled. So the
+// delete change computed here is gathered for the update patch above.
+func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) ([]*v1alpha1.ChartConfig, error) {
+	currentChartConfigs, err := toChartConfigs(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredChartConfigs, err := toChartConfigs(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	chartConfigsToDelete := make([]*v1alpha1.ChartConfig, 0)
+
+	for _, currentChartConfig := range currentChartConfigs {
+		_, err := getChartConfigByName(desiredChartConfigs, currentChartConfig.Name)
+		// Existing ChartConfig is not desired anymore so it should be deleted.
+		if IsNotFound(err) {
+			chartConfigsToDelete = append(chartConfigsToDelete, currentChartConfig)
+		} else if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return chartConfigsToDelete, nil
+}
+
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) ([]*v1alpha1.ChartConfig, error) {
+	currentChartConfigs, err := toChartConfigs(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredChartConfigs, err := toChartConfigs(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	chartConfigsToUpdate := make([]*v1alpha1.ChartConfig, 0)
+
+	for _, currentChartConfig := range currentChartConfigs {
+		desiredChartConfig, err := getChartConfigByName(desiredChartConfigs, currentChartConfig.Name)
+		if IsNotFound(err) {
+			// Ignore here. These are handled by newDeleteChangeForUpdatePatch().
+			continue
+		} else if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		if isChartConfigModified(desiredChartConfig, currentChartConfig) {
+			// Make a copy and set the resource version so the CR can be updated.
+			chartConfigToUpdate := desiredChartConfig.DeepCopy()
+			chartConfigToUpdate.ObjectMeta.ResourceVersion = currentChartConfig.ObjectMeta.ResourceVersion
+
+			chartConfigsToUpdate = append(chartConfigsToUpdate, chartConfigToUpdate)
+		}
+	}
+
+	return chartConfigsToUpdate, nil
+}


### PR DESCRIPTION
I thought I am done with moving resources but discovered there are two more. The design did not make it obvious for me in the first place. So this PR is about moving the `chartconfig` resource over. 