### PR TITLE
fix chartconfig deletion

### DIFF
--- a/service/controller/clusterapi/v19/resources/chartconfig/delete.go
+++ b/service/controller/clusterapi/v19/resources/chartconfig/delete.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/controllercontext"
@@ -29,7 +30,9 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting chartconfig %#q in namespace %#q", chartConfig.Name, chartConfig.Namespace))
 
 			err := cc.Client.TenantCluster.G8s.CoreV1alpha1().ChartConfigs(chartConfig.Namespace).Delete(chartConfig.Name, &metav1.DeleteOptions{})
-			if err != nil {
+			if apierrors.IsNotFound(err) {
+				// fall through
+			} else if err != nil {
 				return microerror.Mask(err)
 			}
 

--- a/service/controller/clusterapi/v19/resources/chartconfig/delete.go
+++ b/service/controller/clusterapi/v19/resources/chartconfig/delete.go
@@ -2,18 +2,48 @@ package chartconfig
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/controllercontext"
 )
 
-// ApplyDeleteChange is a no-op because ChartConfig CRs in the tenant cluster is
-// deleted with the tenant cluster itself.
+// ApplyDeleteChange is executed upon update events in case
+// newDeleteChangeForUpdatePatch figured out there are ChartConfig CRs to be
+// deleted.
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	chartConfigs, err := toChartConfigs(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(chartConfigs) > 0 {
+		for _, chartConfig := range chartConfigs {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting chartconfig %#q in namespace %#q", chartConfig.Name, chartConfig.Namespace))
+
+			err := cc.Client.TenantCluster.G8s.CoreV1alpha1().ChartConfigs(chartConfig.Namespace).Delete(chartConfig.Name, &v1.DeleteOptions{})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted chartconfig %#q in namespace %#q", chartConfig.Name, chartConfig.Namespace))
+		}
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "no need to delete chartconfigs")
+	}
+
 	return nil
 }
 
-// NewDeletePatch is a no-op because ChartConfig CRs in the tenant cluster is
-// deleted with the tenant cluster itself.
+// NewDeletePatch is a no-op because ChartConfig CRs in the tenant cluster are
+// deleted with the tenant cluster itself upon a delete event.
 func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
 	return nil, nil
 }

--- a/service/controller/clusterapi/v19/resources/chartconfig/delete.go
+++ b/service/controller/clusterapi/v19/resources/chartconfig/delete.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/controllercontext"
 )
@@ -28,7 +28,7 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 		for _, chartConfig := range chartConfigs {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting chartconfig %#q in namespace %#q", chartConfig.Name, chartConfig.Namespace))
 
-			err := cc.Client.TenantCluster.G8s.CoreV1alpha1().ChartConfigs(chartConfig.Namespace).Delete(chartConfig.Name, &v1.DeleteOptions{})
+			err := cc.Client.TenantCluster.G8s.CoreV1alpha1().ChartConfigs(chartConfig.Namespace).Delete(chartConfig.Name, &metav1.DeleteOptions{})
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -36,7 +36,7 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted chartconfig %#q in namespace %#q", chartConfig.Name, chartConfig.Namespace))
 		}
 	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "no need to delete chartconfigs")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "did not delete chartconfigs")
 	}
 
 	return nil


### PR DESCRIPTION
I noticed a little detail which is quite important. The deletion of `ChartConfig` CRs in the current way of management is not done during delete events, but eventually during update events. So we bring back functionality we dropped earlier during the refactoring. 