### PR TITLE
add workercount resource

### DIFF
--- a/service/controller/clusterapi/v19/cluster_resource_set.go
+++ b/service/controller/clusterapi/v19/cluster_resource_set.go
@@ -21,6 +21,7 @@ import (
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/resources/clusterstatus"
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/resources/operatorversions"
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/resources/tenantclients"
+	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/resources/workercount"
 )
 
 // ClusterResourceSetConfig contains necessary dependencies and settings for
@@ -311,10 +312,23 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 	//	}
 	//}
 
+	var workerCountResource controller.Resource
+	{
+		c := workercount.Config{
+			Logger: config.Logger,
+		}
+
+		workerCountResource, err = workercount.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	resources := []controller.Resource{
 		clusterIDResource,
 		operatorVersionsResource,
 		tenantClientsResource,
+		workerCountResource,
 		clusterStatusResource,
 
 		// TODO drop this once the resources below are all actiavted.

--- a/service/controller/clusterapi/v19/controllercontext/status.go
+++ b/service/controller/clusterapi/v19/controllercontext/status.go
@@ -2,4 +2,10 @@ package controllercontext
 
 type ContextStatus struct {
 	Versions map[string]string
+	Worker   ContextStatusWorker
+}
+
+type ContextStatusWorker struct {
+	Nodes int
+	Ready int
 }

--- a/service/controller/clusterapi/v19/machine_deployment_resource_set.go
+++ b/service/controller/clusterapi/v19/machine_deployment_resource_set.go
@@ -18,6 +18,7 @@ import (
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/key"
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/resources/machinedeploymentstatus"
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/resources/tenantclients"
+	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/resources/workercount"
 )
 
 type MachineDeploymentResourceSetConfig struct {
@@ -59,8 +60,21 @@ func NewMachineDeploymentResourceSet(config MachineDeploymentResourceSetConfig) 
 		}
 	}
 
+	var workerCountResource controller.Resource
+	{
+		c := workercount.Config{
+			Logger: config.Logger,
+		}
+
+		workerCountResource, err = workercount.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	resources := []controller.Resource{
 		tenantClientsResource,
+		workerCountResource,
 		machineDeploymentStatusResource,
 	}
 

--- a/service/controller/clusterapi/v19/resources/machinedeploymentstatus/resource.go
+++ b/service/controller/clusterapi/v19/resources/machinedeploymentstatus/resource.go
@@ -2,19 +2,15 @@ package machinedeploymentstatus
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
-	"github.com/giantswarm/errors/tenant"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 
-	"github.com/giantswarm/cluster-operator/pkg/label"
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/controllercontext"
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/key"
 )
@@ -60,8 +56,6 @@ func (r *Resource) Name() string {
 }
 
 func (r *Resource) ensure(ctx context.Context, obj interface{}) error {
-	var err error
-
 	cr, err := key.ToMachineDeployment(obj)
 	if err != nil {
 		return microerror.Mask(err)
@@ -71,54 +65,11 @@ func (r *Resource) ensure(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	var nodes []corev1.Node
-	var ready []corev1.Node
-	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", "finding nodes of tenant cluster")
-
-		if cc.Client.TenantCluster.K8s == nil {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster k8s client is not initialized")
-			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-
-			return nil
-		}
-
-		o := metav1.ListOptions{
-			// This label selector excludes the master nodes from node list.
-			//
-			// Constructing this LabelSelector is not currently possible with
-			// k8s types and functions. Therefore it's hardcoded here.
-			LabelSelector: fmt.Sprintf("!%s", label.MasterNodeRole),
-		}
-
-		l, err := cc.Client.TenantCluster.K8s.CoreV1().Nodes().List(o)
-		if tenant.IsAPINotAvailable(err) {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant API not available", "stack", microerror.Stack(err))
-			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-
-			return nil
-		} else if err != nil {
-			return microerror.Mask(err)
-		}
-
-		nodes = l.Items
-
-		for _, n := range nodes {
-			for _, c := range n.Status.Conditions {
-				if c.Type == corev1.NodeReady && c.Status == corev1.ConditionTrue {
-					ready = append(ready, n)
-				}
-			}
-		}
-
-		r.logger.LogCtx(ctx, "level", "debug", "message", "found nodes of tenant cluster")
-	}
-
 	{
 		r.logger.LogCtx(ctx, "level", "debug", "message", "checking if status of machine deployment needs to be updated")
 
-		replicasChanged := cr.Status.Replicas != int32(len(nodes))
-		readyReplicasChanged := cr.Status.ReadyReplicas != int32(len(ready))
+		replicasChanged := cr.Status.Replicas != int32(cc.Status.Worker.Nodes)
+		readyReplicasChanged := cr.Status.ReadyReplicas != int32(cc.Status.Worker.Ready)
 
 		if !replicasChanged && !readyReplicasChanged {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "status of machine deployment does not need to be updated")
@@ -134,11 +85,9 @@ func (r *Resource) ensure(ctx context.Context, obj interface{}) error {
 		if err != nil {
 			return microerror.Mask(err)
 		}
-	}
 
-	{
-		md.Status.Replicas = int32(len(nodes))
-		md.Status.ReadyReplicas = int32(len(ready))
+		md.Status.Replicas = int32(cc.Status.Worker.Nodes)
+		md.Status.ReadyReplicas = int32(cc.Status.Worker.Ready)
 	}
 
 	{
@@ -150,7 +99,6 @@ func (r *Resource) ensure(ctx context.Context, obj interface{}) error {
 		}
 
 		r.logger.LogCtx(ctx, "level", "debug", "message", "updated status of machine deployment")
-
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
 		reconciliationcanceledcontext.SetCanceled(ctx)
 	}

--- a/service/controller/clusterapi/v19/resources/workercount/create.go
+++ b/service/controller/clusterapi/v19/resources/workercount/create.go
@@ -1,0 +1,77 @@
+package workercount
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/errors/tenant"
+	"github.com/giantswarm/microerror"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/cluster-operator/pkg/label"
+	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/controllercontext"
+	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/key"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	cr, err := key.ToMachineDeployment(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	{
+		if cc.Client.TenantCluster.K8s == nil {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster clients not available yet")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+			return nil
+		}
+	}
+
+	var nodes []corev1.Node
+	var ready []corev1.Node
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding nodes of tenant cluster %#q", key.ClusterID(&cr)))
+
+		o := metav1.ListOptions{
+			// This label selector excludes the master nodes from node list.
+			//
+			// Constructing this LabelSelector is not currently possible with
+			// k8s types and functions. Therefore it's hardcoded here.
+			LabelSelector: fmt.Sprintf("!%s", label.MasterNodeRole),
+		}
+
+		l, err := cc.Client.TenantCluster.K8s.CoreV1().Nodes().List(o)
+		if tenant.IsAPINotAvailable(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant API not available yet")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+			return nil
+
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		nodes = l.Items
+
+		for _, n := range nodes {
+			for _, c := range n.Status.Conditions {
+				if c.Type == corev1.NodeReady && c.Status == corev1.ConditionTrue {
+					ready = append(ready, n)
+				}
+			}
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found nodes of tenant cluster %#q", key.ClusterID(&cr)))
+	}
+
+	{
+		cc.Status.Worker.Nodes = len(nodes)
+		cc.Status.Worker.Ready = len(ready)
+	}
+
+	return nil
+}

--- a/service/controller/clusterapi/v19/resources/workercount/delete.go
+++ b/service/controller/clusterapi/v19/resources/workercount/delete.go
@@ -1,0 +1,9 @@
+package workercount
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/clusterapi/v19/resources/workercount/error.go
+++ b/service/controller/clusterapi/v19/resources/workercount/error.go
@@ -1,0 +1,14 @@
+package workercount
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/clusterapi/v19/resources/workercount/resource.go
+++ b/service/controller/clusterapi/v19/resources/workercount/resource.go
@@ -1,0 +1,34 @@
+package workercount
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+const (
+	Name = "workercountv19"
+)
+
+type Config struct {
+	Logger micrologger.Logger
+}
+
+type Resource struct {
+	logger micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		logger: config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}


### PR DESCRIPTION
Towards Node Pools. We need the worker count information to be available so we can use them in certain places like the `configmap` resource. 