### PR TITLE
configure toClusterFunc in workercount resource

### DIFF
--- a/service/controller/clusterapi/v19/cluster_resource_set.go
+++ b/service/controller/clusterapi/v19/cluster_resource_set.go
@@ -347,6 +347,8 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 	{
 		c := workercount.Config{
 			Logger: config.Logger,
+
+			ToClusterFunc: key.ToCluster,
 		}
 
 		workerCountResource, err = workercount.New(c)

--- a/service/controller/clusterapi/v19/machine_deployment_resource_set.go
+++ b/service/controller/clusterapi/v19/machine_deployment_resource_set.go
@@ -63,6 +63,8 @@ func NewMachineDeploymentResourceSet(config MachineDeploymentResourceSetConfig) 
 	{
 		c := workercount.Config{
 			Logger: config.Logger,
+
+			ToClusterFunc: newMachineDeploymentToClusterFunc(config.CMAClient),
 		}
 
 		workerCountResource, err = workercount.New(c)

--- a/service/controller/clusterapi/v19/resources/workercount/create.go
+++ b/service/controller/clusterapi/v19/resources/workercount/create.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
-	cr, err := key.ToMachineDeployment(obj)
+	cr, err := r.toClusterFunc(obj)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/clusterapi/v19/resources/workercount/resource.go
+++ b/service/controller/clusterapi/v19/resources/workercount/resource.go
@@ -3,6 +3,7 @@ package workercount
 import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
 const (
@@ -10,20 +11,26 @@ const (
 )
 
 type Config struct {
-	Logger micrologger.Logger
+	Logger        micrologger.Logger
+	ToClusterFunc func(v interface{}) (v1alpha1.Cluster, error)
 }
 
 type Resource struct {
-	logger micrologger.Logger
+	logger        micrologger.Logger
+	toClusterFunc func(v interface{}) (v1alpha1.Cluster, error)
 }
 
 func New(config Config) (*Resource, error) {
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
+	if config.ToClusterFunc == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ToClusterFunc must not be empty", config)
+	}
 
 	r := &Resource{
-		logger: config.Logger,
+		logger:        config.Logger,
+		toClusterFunc: config.ToClusterFunc,
 	}
 
 	return r, nil


### PR DESCRIPTION
We use the `workercount` resource for both controllers so just going with our common pattern to fix this. 

> {"caller":"github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/resource_wrapper.go:74","controller":"cluster-operator-cluster-controller","event":"update","level":"warning","loop":"4","message":"retrying due to error","object":"/apis/cluster.k8s.io/v1alpha1/namespaces/default/clusters/cl046","resource":"workercountv19","stack":"[{/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/resource_wrapper.go:67: } {/go/src/github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/resources/workercount/create.go:20: } {/go/src/github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/key/machine_deployment.go:19: expected '*v1alpha1.MachineDeployment', got '*v1alpha1.Cluster'} {wrong type error}]","time":"2019-08-26T13:44:32.286553+00:00","underlyingResource":"workercountv19","version":"2481476"}