### PR TITLE
fix azure config validation

### DIFF
--- a/service/controller/clusterapi/v19/resources/configmap/resource.go
+++ b/service/controller/clusterapi/v19/resources/configmap/resource.go
@@ -15,7 +15,9 @@ const (
 type Config struct {
 	Logger micrologger.Logger
 
-	CalicoAddress      string
+	// CalicoAddress may be empty on certain installations.
+	CalicoAddress string
+	// CalicoPrefixLength may be empty on certain installations.
 	CalicoPrefixLength string
 	ClusterIPRange     string
 	DNSIP              string
@@ -39,12 +41,6 @@ func New(config Config) (*Resource, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 
-	if config.CalicoAddress == "" {
-		return nil, microerror.Maskf(invalidConfigError, "%T.CalicoAddress must not be empty", config)
-	}
-	if config.CalicoPrefixLength == "" {
-		return nil, microerror.Maskf(invalidConfigError, "%T.CalicoPrefixLength must not be empty", config)
-	}
 	if config.ClusterIPRange == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ClusterIPRange must not be empty", config)
 	}


### PR DESCRIPTION
```
panic: [{/go/src/github.com/giantswarm/cluster-operator/main.go:64: service.New} {/go/src/github.com/giantswarm/cluster-operator/service/service.go:303: } {/go/src/github.com/giantswarm/cluster-operator/service/controller/clusterapi/cluster.go:111: } {/go/src/github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/cluster_resource_set.go:212: } {/go/src/github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/resources/configmap/resource.go:43: configmap.Config.CalicoAddress must not be empty} {invalid config error}]


goroutine 1 [running]:
main.mainE.func1(0xc000130100, 0xc000130b00, 0xc000430530)
    /go/src/github.com/giantswarm/cluster-operator/main.go:64 +0x502
github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/microkit/command/daemon.(*command).Execute(0xc0001539b0, 0xc00047d180, 0xc000365240, 0x0, 0x2)
    /go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/microkit/command/daemon/command.go:104 +0x1ad
github.com/giantswarm/cluster-operator/vendor/github.com/spf13/cobra.(*Command).execute(0xc00047d180, 0xc0003651e0, 0x2, 0x2, 0xc00047d180, 0xc0003651e0)
    /go/src/github.com/giantswarm/cluster-operator/vendor/github.com/spf13/cobra/command.go:830 +0x2ae
github.com/giantswarm/cluster-operator/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc00047d680, 0xc00047d680, 0xc0000bf1c0, 0x15)
    /go/src/github.com/giantswarm/cluster-operator/vendor/github.com/spf13/cobra/command.go:914 +0x2fc
github.com/giantswarm/cluster-operator/vendor/github.com/spf13/cobra.(*Command).Execute(...)
    /go/src/github.com/giantswarm/cluster-operator/vendor/github.com/spf13/cobra/command.go:864
main.mainE(0x954c07, 0xc0000bdf88)
    /go/src/github.com/giantswarm/cluster-operator/main.go:130 +0xb47
main.main()
    /go/src/github.com/giantswarm/cluster-operator/main.go:24 +0x26
```