### PR TITLE
temporarily fix encryption key management via deprecated labels

### DIFF
--- a/service/controller/clusterapi/v19/resources/encryptionkey/desired.go
+++ b/service/controller/clusterapi/v19/resources/encryptionkey/desired.go
@@ -70,6 +70,13 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 					label.Cluster:   key.ClusterID(&cr),
 					label.ManagedBy: project.Name(),
 					label.RandomKey: label.RandomKeyTypeEncryption,
+
+					// TODO drop deprecated labels.
+					//
+					//     https://github.com/giantswarm/randomkeys/pull/15
+					//
+					"clusterID":  key.ClusterID(&cr),
+					"clusterKey": label.RandomKeyTypeEncryption,
 				},
 			},
 			StringData: map[string]string{


### PR DESCRIPTION
To fix node pool cluster creation now we add back the deprecated labels. We need to write some migration code to get all secrets on all installations in line before we can update the random key searcher magic. We will sort this out but it takes a bit longer so just going for a quick fix for now. I have this on my list. 