### PR TITLE
Add provider to all controllers

### DIFF
--- a/service/controller/aws/legacy_cluster.go
+++ b/service/controller/aws/legacy_cluster.go
@@ -45,6 +45,7 @@ type LegacyClusterConfig struct {
 	CalicoPrefixLength string
 	ClusterIPRange     string
 	ProjectName        string
+	Provider           string
 	RegistryDomain     string
 	ResourceNamespace  string
 }
@@ -288,6 +289,7 @@ func NewLegacyCluster(config LegacyClusterConfig) (*LegacyCluster, error) {
 			CalicoPrefixLength: config.CalicoPrefixLength,
 			ClusterIPRange:     config.ClusterIPRange,
 			ProjectName:        config.ProjectName,
+			Provider:           config.Provider,
 			RegistryDomain:     config.RegistryDomain,
 			ResourceNamespace:  config.ResourceNamespace,
 		}

--- a/service/controller/aws/v19/resource_set.go
+++ b/service/controller/aws/v19/resource_set.go
@@ -52,6 +52,7 @@ type ResourceSetConfig struct {
 	ClusterIPRange        string
 	HandledVersionBundles []string
 	ProjectName           string
+	Provider              string
 	RegistryDomain        string
 	ResourceNamespace     string
 }

--- a/service/controller/azure/legacy_cluster.go
+++ b/service/controller/azure/legacy_cluster.go
@@ -43,6 +43,7 @@ type LegacyClusterConfig struct {
 	CalicoPrefixLength string
 	ClusterIPRange     string
 	ProjectName        string
+	Provider           string
 	RegistryDomain     string
 	ResourceNamespace  string
 }
@@ -282,6 +283,7 @@ func NewLegacyCluster(config LegacyClusterConfig) (*LegacyCluster, error) {
 			CalicoPrefixLength: config.CalicoPrefixLength,
 			ClusterIPRange:     config.ClusterIPRange,
 			ProjectName:        config.ProjectName,
+			Provider:           config.Provider,
 			RegistryDomain:     config.RegistryDomain,
 			ResourceNamespace:  config.ResourceNamespace,
 		}

--- a/service/controller/azure/v19/resource_set.go
+++ b/service/controller/azure/v19/resource_set.go
@@ -52,6 +52,7 @@ type ResourceSetConfig struct {
 	ClusterIPRange        string
 	HandledVersionBundles []string
 	ProjectName           string
+	Provider              string
 	RegistryDomain        string
 	ResourceNamespace     string
 }

--- a/service/controller/kvm/legacy_cluster.go
+++ b/service/controller/kvm/legacy_cluster.go
@@ -41,6 +41,7 @@ type LegacyClusterConfig struct {
 	CalicoPrefixLength string
 	ClusterIPRange     string
 	ProjectName        string
+	Provider           string
 	RegistryDomain     string
 	ResourceNamespace  string
 }
@@ -229,6 +230,7 @@ func NewLegacyCluster(config LegacyClusterConfig) (*LegacyCluster, error) {
 			CalicoPrefixLength: config.CalicoPrefixLength,
 			ClusterIPRange:     config.ClusterIPRange,
 			ProjectName:        config.ProjectName,
+			Provider:           config.Provider,
 			RegistryDomain:     config.RegistryDomain,
 			ResourceNamespace:  config.ResourceNamespace,
 		}

--- a/service/controller/kvm/v19/resource_set.go
+++ b/service/controller/kvm/v19/resource_set.go
@@ -52,6 +52,7 @@ type ResourceSetConfig struct {
 	ClusterIPRange        string
 	HandledVersionBundles []string
 	ProjectName           string
+	Provider              string
 	RegistryDomain        string
 	ResourceNamespace     string
 }

--- a/service/service.go
+++ b/service/service.go
@@ -83,6 +83,7 @@ func New(config Config) (*Service, error) {
 	clusterIPRange := config.Viper.GetString(config.Flag.Guest.Cluster.Kubernetes.API.ClusterIPRange)
 	calicoAddress := config.Viper.GetString(config.Flag.Guest.Cluster.Calico.Subnet)
 	calicoPrefixLength := config.Viper.GetString(config.Flag.Guest.Cluster.Calico.CIDR)
+	provider := config.Viper.GetString(config.Flag.Service.Provider.Kind)
 
 	var restConfig *rest.Config
 	{
@@ -233,6 +234,7 @@ func New(config Config) (*Service, error) {
 			CalicoPrefixLength: calicoPrefixLength,
 			ProjectName:        config.ProjectName,
 			RegistryDomain:     registryDomain,
+			Provider:           provider,
 			ResourceNamespace:  resourceNamespace,
 		}
 
@@ -264,6 +266,7 @@ func New(config Config) (*Service, error) {
 			CalicoAddress:      calicoAddress,
 			CalicoPrefixLength: calicoPrefixLength,
 			ProjectName:        config.ProjectName,
+			Provider:           provider,
 			RegistryDomain:     registryDomain,
 			ResourceNamespace:  resourceNamespace,
 		}
@@ -294,7 +297,7 @@ func New(config Config) (*Service, error) {
 			CertTTL:            config.Viper.GetString(config.Flag.Guest.Cluster.Vault.Certificate.TTL),
 			ClusterIPRange:     clusterIPRange,
 			DNSIP:              dnsIP,
-			Provider:           config.Viper.GetString(config.Flag.Service.Provider.Kind),
+			Provider:           provider,
 			RegistryDomain:     registryDomain,
 		}
 
@@ -344,6 +347,7 @@ func New(config Config) (*Service, error) {
 			CalicoAddress:      calicoAddress,
 			CalicoPrefixLength: calicoPrefixLength,
 			ProjectName:        config.ProjectName,
+			Provider:           provider,
 			RegistryDomain:     registryDomain,
 			ResourceNamespace:  resourceNamespace,
 		}


### PR DESCRIPTION
Towards giantswarm/giantswarm#6800

This is prep for the migration to app CRs.

I'd like the app resource for the clusterapi and legacy controllers to use the same design. So this adds the provider setting to the legacy controllers.