### PR TITLE
add cpnamespace resource

### DIFF
--- a/service/controller/clusterapi/v19/resources/cpnamespace/create.go
+++ b/service/controller/clusterapi/v19/resources/cpnamespace/create.go
@@ -1,0 +1,58 @@
+package cpnamespace
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/key"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	cr, err := key.ToCluster(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	ns, err := toNamespace(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if ns != nil {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating namespace %#q in control plane", ns.Name))
+
+		_, err = r.k8sClient.CoreV1().Namespaces().Create(ns)
+		if apierrors.IsAlreadyExists(err) {
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created namespace %#q in control plane", ns.Name))
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not create namespace %#q in control plane", key.ClusterID(&cr)))
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentNamespace, err := toNamespace(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredNamespace, err := toNamespace(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var namespaceToCreate *corev1.Namespace
+	if currentNamespace == nil {
+		namespaceToCreate = desiredNamespace
+	}
+
+	return namespaceToCreate, nil
+}

--- a/service/controller/clusterapi/v19/resources/cpnamespace/current.go
+++ b/service/controller/clusterapi/v19/resources/cpnamespace/current.go
@@ -1,0 +1,65 @@
+package cpnamespace
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/finalizerskeptcontext"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	cr, err := key.ToCluster(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var ns *corev1.Namespace
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding namespace %#q in control plane", key.ClusterID(&cr)))
+
+		m, err := r.k8sClient.CoreV1().Namespaces().Get(key.ClusterID(&cr), metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find namespace %#q in control plane", key.ClusterID(&cr)))
+		} else if err != nil {
+			return nil, microerror.Mask(err)
+		} else {
+			ns = m
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found namespace %#q in control plane", key.ClusterID(&cr)))
+		}
+	}
+
+	// In case the namespace is already terminating we do not need to do any
+	// further work. We cancel the namespace resource to prevent any further work,
+	// but keep the finalizers until the namespace got finally deleted. This is to
+	// prevent issues with the monitoring and alerting systems. The cluster status
+	// conditions of the watched CR are used to inhibit alerts, for instance when
+	// the cluster is being deleted.
+	if ns != nil && ns.Status.Phase == corev1.NamespaceTerminating {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("namespace is %#q", corev1.NamespaceTerminating))
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "keeping finalizers")
+		finalizerskeptcontext.SetKept(ctx)
+
+		return nil, nil
+	}
+
+	if ns == nil && key.IsDeleted(&cr) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "resource deletion completed")
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+
+		return nil, nil
+	}
+
+	return ns, nil
+}

--- a/service/controller/clusterapi/v19/resources/cpnamespace/delete.go
+++ b/service/controller/clusterapi/v19/resources/cpnamespace/delete.go
@@ -1,0 +1,63 @@
+package cpnamespace
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/key"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	cr, err := key.ToCluster(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	ns, err := toNamespace(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if ns != nil {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting namespace %#q in control plane", ns.Name))
+
+		err = r.k8sClient.CoreV1().Namespaces().Delete(ns.Name, &metav1.DeleteOptions{})
+		if apierrors.IsNotFound(err) {
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted namespace %#q in control plane", ns.Name))
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not delete namespace %#q in control plane", key.ClusterID(&cr)))
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	delete, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetDeleteChange(delete)
+
+	return patch, nil
+}
+
+func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (*corev1.Namespace, error) {
+	currentNamespace, err := toNamespace(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return currentNamespace, nil
+}

--- a/service/controller/clusterapi/v19/resources/cpnamespace/desired.go
+++ b/service/controller/clusterapi/v19/resources/cpnamespace/desired.go
@@ -1,0 +1,35 @@
+package cpnamespace
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/cluster-operator/pkg/label"
+	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	cr, err := key.ToCluster(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	namespace := &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Namespace",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: key.ClusterID(&cr),
+			Labels: map[string]string{
+				label.Cluster:      key.ClusterID(&cr),
+				label.Organization: key.OrganizationID(&cr),
+			},
+		},
+	}
+
+	return namespace, nil
+}

--- a/service/controller/clusterapi/v19/resources/cpnamespace/error.go
+++ b/service/controller/clusterapi/v19/resources/cpnamespace/error.go
@@ -1,0 +1,21 @@
+package cpnamespace
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/clusterapi/v19/resources/cpnamespace/resource.go
+++ b/service/controller/clusterapi/v19/resources/cpnamespace/resource.go
@@ -1,0 +1,59 @@
+package cpnamespace
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "cpnamespacev29"
+)
+
+// Config represents the configuration used to create a new namespace resource.
+type Config struct {
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+// Resource implements the namespace resource.
+type Resource struct {
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+// New creates a new configured namespace resource.
+func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func toNamespace(v interface{}) (*corev1.Namespace, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	namespace, ok := v.(*corev1.Namespace)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &corev1.Namespace{}, v)
+	}
+
+	return namespace, nil
+}

--- a/service/controller/clusterapi/v19/resources/cpnamespace/update.go
+++ b/service/controller/clusterapi/v19/resources/cpnamespace/update.go
@@ -1,0 +1,24 @@
+package cpnamespace
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetCreateChange(create)
+
+	return patch, nil
+}


### PR DESCRIPTION
This adds a namespace resource to reconcile the TC namespace on the control plane. More or less copied from `aws-operator`. I will wire the resource in a separate PR. I will also rename the existing `namespace` resource to `tcnamespace` in a separate PR. 