### PR TITLE
fix panic in TC namespace resource

### DIFF
--- a/service/controller/clusterapi/v19/resources/namespace/create.go
+++ b/service/controller/clusterapi/v19/resources/namespace/create.go
@@ -46,7 +46,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created namespace %#q in tenant cluster %#q", ns.Name, key.ClusterID(&cr)))
 	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not create namespace %#q in tenant cluster %#q", ns.Name, key.ClusterID(&cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not create namespace %#q in tenant cluster %#q", namespace, key.ClusterID(&cr)))
 	}
 
 	return nil


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x15bdddb]

goroutine 57 [running]:
github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/resources/namespace.(*Resource).ApplyCreateChange(0xc0002ff990, 0x1c33760, 0xc0004c3320, 0x194f520, 0xc0000a44e0, 0x1963160, 0x0, 0x1179f1c, 0xc0002ab478)
	/go/src/github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/resources/namespace/create.go:49 +0xb2b
github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource.(*crudResourceWrapperOps).ApplyCreateChange.func1(0xc000312240, 0xc00094e700)
	/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/crud_resource_ops_wrapper.go:160 +0x6d
...
```