### PR TITLE
rename namespace resource to tcnamespace

### DIFF
--- a/service/controller/clusterapi/v19/cluster_resource_set.go
+++ b/service/controller/clusterapi/v19/cluster_resource_set.go
@@ -30,8 +30,8 @@ import (
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/resources/configmap"
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/resources/encryptionkey"
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/resources/kubeconfig"
-	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/resources/namespace"
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/resources/operatorversions"
+	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/resources/tcnamespace"
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/resources/tenantclients"
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/resources/tiller"
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/resources/workercount"
@@ -287,18 +287,18 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		}
 	}
 
-	var namespaceResource controller.Resource
+	var tcNamespaceResource controller.Resource
 	{
-		c := namespace.Config{
+		c := tcnamespace.Config{
 			Logger: config.Logger,
 		}
 
-		ops, err := namespace.New(c)
+		ops, err := tcnamespace.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 
-		namespaceResource, err = toCRUDResource(config.Logger, ops)
+		tcNamespaceResource, err = toCRUDResource(config.Logger, ops)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -374,7 +374,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 
 		// Following resources manage resources in tenant clusters so they
 		// should be executed last.
-		namespaceResource,
+		tcNamespaceResource,
 		tillerResource,
 		chartOperatorResource,
 		configMapResource,

--- a/service/controller/clusterapi/v19/resources/tcnamespace/create.go
+++ b/service/controller/clusterapi/v19/resources/tcnamespace/create.go
@@ -1,4 +1,4 @@
-package namespace
+package tcnamespace
 
 import (
 	"context"

--- a/service/controller/clusterapi/v19/resources/tcnamespace/current.go
+++ b/service/controller/clusterapi/v19/resources/tcnamespace/current.go
@@ -1,4 +1,4 @@
-package namespace
+package tcnamespace
 
 import (
 	"context"

--- a/service/controller/clusterapi/v19/resources/tcnamespace/delete.go
+++ b/service/controller/clusterapi/v19/resources/tcnamespace/delete.go
@@ -1,4 +1,4 @@
-package namespace
+package tcnamespace
 
 import (
 	"context"

--- a/service/controller/clusterapi/v19/resources/tcnamespace/desired.go
+++ b/service/controller/clusterapi/v19/resources/tcnamespace/desired.go
@@ -1,4 +1,4 @@
-package namespace
+package tcnamespace
 
 import (
 	"context"

--- a/service/controller/clusterapi/v19/resources/tcnamespace/error.go
+++ b/service/controller/clusterapi/v19/resources/tcnamespace/error.go
@@ -1,4 +1,4 @@
-package namespace
+package tcnamespace
 
 import "github.com/giantswarm/microerror"
 

--- a/service/controller/clusterapi/v19/resources/tcnamespace/resource.go
+++ b/service/controller/clusterapi/v19/resources/tcnamespace/resource.go
@@ -1,4 +1,4 @@
-package namespace
+package tcnamespace
 
 import (
 	"github.com/giantswarm/microerror"
@@ -8,7 +8,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "namespacev19"
+	Name = "tcnamespacev19"
 )
 
 const (

--- a/service/controller/clusterapi/v19/resources/tcnamespace/update.go
+++ b/service/controller/clusterapi/v19/resources/tcnamespace/update.go
@@ -1,4 +1,4 @@
-package namespace
+package tcnamespace
 
 import (
 	"context"


### PR DESCRIPTION
Renaming because we also have a `cpnamespace`resource which was moved from `aws-operator`. 