### PR TITLE
fix RBAC rules by allowing namespace management

### DIFF
--- a/helm/cluster-operator-chart/templates/rbac.yaml
+++ b/helm/cluster-operator-chart/templates/rbac.yaml
@@ -18,6 +18,7 @@ rules:
       - ""
     resources:
       - configmaps
+      - namespaces
     verbs:
       - create
       - update


### PR DESCRIPTION
> {"caller":"github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/crud_resource_ops_wrapper.go:71","controller":"cluster-operator-cluster-controller","event":"update","function":"GetCurrentState","level":"warning","loop":"18","message":"retrying due to error","object":"/apis/cluster.k8s.io/v1alpha1/namespaces/default/clusters/cl051","resource":"cpnamespacev19","stack":"[{/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/crud_resource_ops_wrapper.go:64: } {/go/src/github.com/giantswarm/cluster-operator/service/controller/clusterapi/v19/resources/cpnamespace/current.go:31: } {namespaces \"cl051\" is forbidden: User \"system:serviceaccount:giantswarm:cluster-operator\" cannot get resource \"namespaces\" in API group \"\" in the namespace \"cl051\"}]","time":"2019-08-28T16:25:00.515834+00:00","underlyingResource":"cpnamespacev19","version":"2937045"}