### PR TITLE
fix wrong error handling

### DIFF
--- a/pkg/v19/resource/namespace/create.go
+++ b/pkg/v19/resource/namespace/create.go
@@ -37,7 +37,6 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 
 			return nil
 		} else if err != nil {
-		} else if err != nil {
 			return microerror.Mask(err)
 		}
 


### PR DESCRIPTION
During migrating namespace resource from cluster-operator, I found out we have a wrong error handling on namespace resource. 