### PR TITLE
Ensure tenant client is available before proceeding with tiller

### DIFF
--- a/service/controller/clusterapi/v19/resources/tiller/create.go
+++ b/service/controller/clusterapi/v19/resources/tiller/create.go
@@ -38,7 +38,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("installing tiller in tenant cluster %#q", key.ClusterID(&cr)))
 
 		if cc.Client.TenantCluster.Helm == nil {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster clients not available")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster clients not available yet")
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			resourcecanceledcontext.SetCanceled(ctx)
 			return nil


### PR DESCRIPTION
During cluster creation the tenant clients are not available yet so resources
that need them must check whether those are initialized yet or if the resource
should be canceled for that round.