### PR TITLE
Legacy app resource

### DIFF
--- a/pkg/v20/resource/app/current.go
+++ b/pkg/v20/resource/app/current.go
@@ -1,0 +1,59 @@
+package app
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/cluster-operator/pkg/label"
+	"github.com/giantswarm/cluster-operator/pkg/project"
+	"github.com/giantswarm/cluster-operator/pkg/v20/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) ([]*v1alpha1.App, error) {
+	objectMeta, err := r.getClusterObjectMetaFunc(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	// Cluster configMap is deleted by the provider operator when it deletes
+	// the tenant cluster namespace in the control plane cluster.
+	if key.IsDeleted(objectMeta) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "redirecting kubeconfig secret deletion to provider operators")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+
+		return nil, nil
+	}
+
+	clusterConfig, err := r.getClusterConfigFunc(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var apps []*v1alpha1.App
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding apps in tenant cluster %#q", clusterConfig.ID))
+
+		o := metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("%s=%s", label.ManagedBy, project.Name()),
+		}
+
+		list, err := r.g8sClient.ApplicationV1alpha1().Apps(clusterConfig.ID).List(o)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		for _, item := range list.Items {
+			apps = append(apps, item.DeepCopy())
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d apps in tenant cluster %#q", len(apps), clusterConfig.ID))
+	}
+
+	return apps, nil
+}

--- a/pkg/v20/resource/app/desired.go
+++ b/pkg/v20/resource/app/desired.go
@@ -1,0 +1,95 @@
+package app
+
+import (
+	"context"
+	"strconv"
+
+	g8sv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/microerror"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/cluster-operator/pkg/annotation"
+	"github.com/giantswarm/cluster-operator/pkg/label"
+	"github.com/giantswarm/cluster-operator/pkg/project"
+	"github.com/giantswarm/cluster-operator/pkg/v20/key"
+	awskey "github.com/giantswarm/cluster-operator/service/controller/aws/v20/key"
+	azurekey "github.com/giantswarm/cluster-operator/service/controller/azure/v20/key"
+	kvmkey "github.com/giantswarm/cluster-operator/service/controller/kvm/v20/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*g8sv1alpha1.App, error) {
+	clusterConfig, err := r.getClusterConfigFunc(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var apps []*g8sv1alpha1.App
+
+	for _, appSpec := range r.newAppSpecs() {
+		apps = append(apps, r.newApp(clusterConfig, appSpec))
+	}
+
+	return apps, nil
+}
+
+func (r *Resource) newApp(clusterConfig v1alpha1.ClusterGuestConfig, appSpec key.AppSpec) *g8sv1alpha1.App {
+	return &g8sv1alpha1.App{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "App",
+			APIVersion: "application.giantswarm.io",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				annotation.ForceHelmUpgrade: strconv.FormatBool(appSpec.UseUpgradeForce),
+			},
+			Labels: map[string]string{
+				label.App:                appSpec.App,
+				label.AppOperatorVersion: "1.0.0",
+				label.Cluster:            clusterConfig.ID,
+				label.ManagedBy:          project.Name(),
+				label.Organization:       clusterConfig.Owner,
+				label.ServiceType:        label.ServiceTypeManaged,
+			},
+			Name:      appSpec.App,
+			Namespace: clusterConfig.ID,
+		},
+		Spec: g8sv1alpha1.AppSpec{
+			Catalog:   appSpec.Catalog,
+			Name:      appSpec.Chart,
+			Namespace: appSpec.Namespace,
+			Version:   appSpec.Version,
+
+			Config: g8sv1alpha1.AppSpecConfig{
+				ConfigMap: g8sv1alpha1.AppSpecConfigConfigMap{
+					Name:      key.ClusterConfigMapName(clusterConfig),
+					Namespace: clusterConfig.ID,
+				},
+			},
+
+			KubeConfig: g8sv1alpha1.AppSpecKubeConfig{
+				Context: g8sv1alpha1.AppSpecKubeConfigContext{
+					Name: key.KubeConfigSecretName(clusterConfig),
+				},
+				InCluster: false,
+				Secret: g8sv1alpha1.AppSpecKubeConfigSecret{
+					Name:      key.KubeConfigSecretName(clusterConfig),
+					Namespace: clusterConfig.ID,
+				},
+			},
+		},
+	}
+}
+
+func (r *Resource) newAppSpecs() []key.AppSpec {
+	switch r.provider {
+	case "aws":
+		return append(key.CommonAppSpecs(), awskey.AppSpecs()...)
+	case "azure":
+		return append(key.CommonAppSpecs(), azurekey.AppSpecs()...)
+	case "kvm":
+		return append(key.CommonAppSpecs(), kvmkey.AppSpecs()...)
+	default:
+		return key.CommonAppSpecs()
+	}
+}

--- a/pkg/v20/resource/app/error.go
+++ b/pkg/v20/resource/app/error.go
@@ -1,0 +1,14 @@
+package app
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfigError asserts invalidConfigError.
+func IsInvalidConfigError(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/pkg/v20/resource/app/resource.go
+++ b/pkg/v20/resource/app/resource.go
@@ -1,0 +1,68 @@
+package app
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	Name = "appv20"
+)
+
+// Config represents the configuration used to create a new chartconfig service.
+type Config struct {
+	G8sClient                versioned.Interface
+	GetClusterConfigFunc     func(obj interface{}) (v1alpha1.ClusterGuestConfig, error)
+	GetClusterObjectMetaFunc func(obj interface{}) (metav1.ObjectMeta, error)
+	Logger                   micrologger.Logger
+
+	Provider string
+}
+
+// Resource provides shared functionality for managing chartconfigs.
+type Resource struct {
+	g8sClient                versioned.Interface
+	getClusterConfigFunc     func(obj interface{}) (v1alpha1.ClusterGuestConfig, error)
+	getClusterObjectMetaFunc func(obj interface{}) (metav1.ObjectMeta, error)
+	logger                   micrologger.Logger
+
+	provider string
+}
+
+// New creates a new chartconfig service.
+func New(config Config) (*Resource, error) {
+	if config.GetClusterConfigFunc == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.GetClusterConfigFunc must not be empty", config)
+	}
+	if config.GetClusterObjectMetaFunc == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.GetClusterObjectMetaFunc must not be empty", config)
+	}
+	if config.G8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	if config.Provider == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Provider must not be empty", config)
+	}
+
+	r := &Resource{
+		g8sClient:                config.G8sClient,
+		getClusterConfigFunc:     config.GetClusterConfigFunc,
+		getClusterObjectMetaFunc: config.GetClusterObjectMetaFunc,
+		logger:                   config.Logger,
+
+		provider: config.Provider,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/aws/v20/resource_set.go
+++ b/service/controller/aws/v20/resource_set.go
@@ -6,7 +6,6 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/apprclient"
-	"github.com/giantswarm/appresource"
 	"github.com/giantswarm/certs"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -24,7 +23,6 @@ import (
 	"github.com/giantswarm/cluster-operator/pkg/label"
 	chartconfigservice "github.com/giantswarm/cluster-operator/pkg/v20/chartconfig"
 	configmapservice "github.com/giantswarm/cluster-operator/pkg/v20/configmap"
-	"github.com/giantswarm/cluster-operator/pkg/v20/resource/app"
 	"github.com/giantswarm/cluster-operator/pkg/v20/resource/certconfig"
 	"github.com/giantswarm/cluster-operator/pkg/v20/resource/chartoperator"
 	"github.com/giantswarm/cluster-operator/pkg/v20/resource/clusterconfigmap"
@@ -77,43 +75,45 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ResourceNamespace must not be empty", config)
 	}
 
-	var appGetter appresource.StateGetter
-	{
-		c := app.Config{
-			GetClusterConfigFunc:     getClusterConfig,
-			GetClusterObjectMetaFunc: getClusterObjectMeta,
-			G8sClient:                config.G8sClient,
-			Logger:                   config.Logger,
+	/*
+		var appGetter appresource.StateGetter
+		{
+			c := app.Config{
+				GetClusterConfigFunc:     getClusterConfig,
+				GetClusterObjectMetaFunc: getClusterObjectMeta,
+				G8sClient:                config.G8sClient,
+				Logger:                   config.Logger,
 
-			Provider: config.Provider,
+				Provider: config.Provider,
+			}
+
+			appGetter, err = app.New(c)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
 		}
 
-		appGetter, err = app.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
+		var appResource controller.Resource
+		{
+			c := appresource.Config{
+				G8sClient: config.G8sClient,
+				Logger:    config.Logger,
 
-	var appResource controller.Resource
-	{
-		c := appresource.Config{
-			G8sClient: config.G8sClient,
-			Logger:    config.Logger,
+				Name:        app.Name,
+				StateGetter: appGetter,
+			}
 
-			Name:        app.Name,
-			StateGetter: appGetter,
-		}
+			ops, err := appresource.New(c)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
 
-		ops, err := appresource.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
+			appResource, err = toCRUDResource(config.Logger, ops)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
 		}
-
-		appResource, err = toCRUDResource(config.Logger, ops)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
+	*/
 
 	var certConfigResource controller.Resource
 	{
@@ -370,7 +370,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		certConfigResource,
 		clusterConfigMapResource,
 		kubeConfigResource,
-		appResource,
+		// appResource,
 
 		// Following resources manage resources in tenant clusters so they
 		// should be executed last.

--- a/service/controller/aws/v20/resource_set.go
+++ b/service/controller/aws/v20/resource_set.go
@@ -6,6 +6,7 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/apprclient"
+	"github.com/giantswarm/appresource"
 	"github.com/giantswarm/certs"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -23,6 +24,7 @@ import (
 	"github.com/giantswarm/cluster-operator/pkg/label"
 	chartconfigservice "github.com/giantswarm/cluster-operator/pkg/v20/chartconfig"
 	configmapservice "github.com/giantswarm/cluster-operator/pkg/v20/configmap"
+	"github.com/giantswarm/cluster-operator/pkg/v20/resource/app"
 	"github.com/giantswarm/cluster-operator/pkg/v20/resource/certconfig"
 	"github.com/giantswarm/cluster-operator/pkg/v20/resource/chartoperator"
 	"github.com/giantswarm/cluster-operator/pkg/v20/resource/clusterconfigmap"
@@ -73,6 +75,44 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	}
 	if config.ResourceNamespace == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ResourceNamespace must not be empty", config)
+	}
+
+	var appGetter appresource.StateGetter
+	{
+		c := app.Config{
+			GetClusterConfigFunc:     getClusterConfig,
+			GetClusterObjectMetaFunc: getClusterObjectMeta,
+			G8sClient:                config.G8sClient,
+			Logger:                   config.Logger,
+
+			Provider: config.Provider,
+		}
+
+		appGetter, err = app.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var appResource controller.Resource
+	{
+		c := appresource.Config{
+			G8sClient: config.G8sClient,
+			Logger:    config.Logger,
+
+			Name:        app.Name,
+			StateGetter: appGetter,
+		}
+
+		ops, err := appresource.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		appResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
 	}
 
 	var certConfigResource controller.Resource
@@ -330,6 +370,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		certConfigResource,
 		clusterConfigMapResource,
 		kubeConfigResource,
+		appResource,
 
 		// Following resources manage resources in tenant clusters so they
 		// should be executed last.

--- a/service/controller/azure/v20/resource_set.go
+++ b/service/controller/azure/v20/resource_set.go
@@ -6,7 +6,6 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/apprclient"
-	"github.com/giantswarm/appresource"
 	"github.com/giantswarm/certs"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -24,7 +23,6 @@ import (
 	"github.com/giantswarm/cluster-operator/pkg/label"
 	chartconfigservice "github.com/giantswarm/cluster-operator/pkg/v20/chartconfig"
 	configmapservice "github.com/giantswarm/cluster-operator/pkg/v20/configmap"
-	"github.com/giantswarm/cluster-operator/pkg/v20/resource/app"
 	"github.com/giantswarm/cluster-operator/pkg/v20/resource/certconfig"
 	"github.com/giantswarm/cluster-operator/pkg/v20/resource/chartoperator"
 	"github.com/giantswarm/cluster-operator/pkg/v20/resource/clusterconfigmap"
@@ -74,43 +72,45 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ProjectName must not be empty", config)
 	}
 
-	var appGetter appresource.StateGetter
-	{
-		c := app.Config{
-			G8sClient:                config.G8sClient,
-			GetClusterConfigFunc:     getClusterConfig,
-			GetClusterObjectMetaFunc: getClusterObjectMeta,
-			Logger:                   config.Logger,
+	/*
+		var appGetter appresource.StateGetter
+		{
+			c := app.Config{
+				G8sClient:                config.G8sClient,
+				GetClusterConfigFunc:     getClusterConfig,
+				GetClusterObjectMetaFunc: getClusterObjectMeta,
+				Logger:                   config.Logger,
 
-			Provider: config.Provider,
+				Provider: config.Provider,
+			}
+
+			appGetter, err = app.New(c)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
 		}
 
-		appGetter, err = app.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
+		var appResource controller.Resource
+		{
+			c := appresource.Config{
+				G8sClient: config.G8sClient,
+				Logger:    config.Logger,
 
-	var appResource controller.Resource
-	{
-		c := appresource.Config{
-			G8sClient: config.G8sClient,
-			Logger:    config.Logger,
+				Name:        app.Name,
+				StateGetter: appGetter,
+			}
 
-			Name:        app.Name,
-			StateGetter: appGetter,
-		}
+			ops, err := appresource.New(c)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
 
-		ops, err := appresource.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
+			appResource, err = toCRUDResource(config.Logger, ops)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
 		}
-
-		appResource, err = toCRUDResource(config.Logger, ops)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
+	*/
 
 	var certConfigResource controller.Resource
 	{
@@ -367,7 +367,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		certConfigResource,
 		clusterConfigMapResource,
 		kubeConfigResource,
-		appResource,
+		// appResource,
 
 		// Following resources manage resources in tenant clusters so they
 		// should be executed last

--- a/service/controller/azure/v20/resource_set.go
+++ b/service/controller/azure/v20/resource_set.go
@@ -6,6 +6,7 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/apprclient"
+	"github.com/giantswarm/appresource"
 	"github.com/giantswarm/certs"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -23,6 +24,7 @@ import (
 	"github.com/giantswarm/cluster-operator/pkg/label"
 	chartconfigservice "github.com/giantswarm/cluster-operator/pkg/v20/chartconfig"
 	configmapservice "github.com/giantswarm/cluster-operator/pkg/v20/configmap"
+	"github.com/giantswarm/cluster-operator/pkg/v20/resource/app"
 	"github.com/giantswarm/cluster-operator/pkg/v20/resource/certconfig"
 	"github.com/giantswarm/cluster-operator/pkg/v20/resource/chartoperator"
 	"github.com/giantswarm/cluster-operator/pkg/v20/resource/clusterconfigmap"
@@ -70,6 +72,44 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 
 	if config.ProjectName == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ProjectName must not be empty", config)
+	}
+
+	var appGetter appresource.StateGetter
+	{
+		c := app.Config{
+			G8sClient:                config.G8sClient,
+			GetClusterConfigFunc:     getClusterConfig,
+			GetClusterObjectMetaFunc: getClusterObjectMeta,
+			Logger:                   config.Logger,
+
+			Provider: config.Provider,
+		}
+
+		appGetter, err = app.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var appResource controller.Resource
+	{
+		c := appresource.Config{
+			G8sClient: config.G8sClient,
+			Logger:    config.Logger,
+
+			Name:        app.Name,
+			StateGetter: appGetter,
+		}
+
+		ops, err := appresource.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		appResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
 	}
 
 	var certConfigResource controller.Resource
@@ -327,6 +367,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		certConfigResource,
 		clusterConfigMapResource,
 		kubeConfigResource,
+		appResource,
 
 		// Following resources manage resources in tenant clusters so they
 		// should be executed last

--- a/service/controller/kvm/v20/resource_set.go
+++ b/service/controller/kvm/v20/resource_set.go
@@ -6,6 +6,7 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/apprclient"
+	"github.com/giantswarm/appresource"
 	"github.com/giantswarm/certs"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -23,6 +24,7 @@ import (
 	"github.com/giantswarm/cluster-operator/pkg/label"
 	chartconfigservice "github.com/giantswarm/cluster-operator/pkg/v20/chartconfig"
 	configmapservice "github.com/giantswarm/cluster-operator/pkg/v20/configmap"
+	"github.com/giantswarm/cluster-operator/pkg/v20/resource/app"
 	"github.com/giantswarm/cluster-operator/pkg/v20/resource/certconfig"
 	"github.com/giantswarm/cluster-operator/pkg/v20/resource/chartoperator"
 	"github.com/giantswarm/cluster-operator/pkg/v20/resource/clusterconfigmap"
@@ -69,6 +71,44 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	}
 	if config.ProjectName == "" {
 		return nil, microerror.Maskf(invalidConfigError, "config.ProjectName must not be empty")
+	}
+
+	var appGetter appresource.StateGetter
+	{
+		c := app.Config{
+			G8sClient:                config.G8sClient,
+			GetClusterConfigFunc:     getClusterConfig,
+			GetClusterObjectMetaFunc: getClusterObjectMeta,
+			Logger:                   config.Logger,
+
+			Provider: config.Provider,
+		}
+
+		appGetter, err = app.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var appResource controller.Resource
+	{
+		c := appresource.Config{
+			G8sClient: config.G8sClient,
+			Logger:    config.Logger,
+
+			Name:        app.Name,
+			StateGetter: appGetter,
+		}
+
+		ops, err := appresource.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		appResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
 	}
 
 	var certConfigResource controller.Resource
@@ -326,6 +366,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		certConfigResource,
 		clusterConfigMapResource,
 		kubeConfigResource,
+		appResource,
 
 		// Following resources manage resources in tenant clusters so they
 		// should be executed last

--- a/service/controller/kvm/v20/resource_set.go
+++ b/service/controller/kvm/v20/resource_set.go
@@ -6,7 +6,6 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/apprclient"
-	"github.com/giantswarm/appresource"
 	"github.com/giantswarm/certs"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -24,7 +23,6 @@ import (
 	"github.com/giantswarm/cluster-operator/pkg/label"
 	chartconfigservice "github.com/giantswarm/cluster-operator/pkg/v20/chartconfig"
 	configmapservice "github.com/giantswarm/cluster-operator/pkg/v20/configmap"
-	"github.com/giantswarm/cluster-operator/pkg/v20/resource/app"
 	"github.com/giantswarm/cluster-operator/pkg/v20/resource/certconfig"
 	"github.com/giantswarm/cluster-operator/pkg/v20/resource/chartoperator"
 	"github.com/giantswarm/cluster-operator/pkg/v20/resource/clusterconfigmap"
@@ -73,43 +71,45 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		return nil, microerror.Maskf(invalidConfigError, "config.ProjectName must not be empty")
 	}
 
-	var appGetter appresource.StateGetter
-	{
-		c := app.Config{
-			G8sClient:                config.G8sClient,
-			GetClusterConfigFunc:     getClusterConfig,
-			GetClusterObjectMetaFunc: getClusterObjectMeta,
-			Logger:                   config.Logger,
+	/*
+		var appGetter appresource.StateGetter
+		{
+			c := app.Config{
+				G8sClient:                config.G8sClient,
+				GetClusterConfigFunc:     getClusterConfig,
+				GetClusterObjectMetaFunc: getClusterObjectMeta,
+				Logger:                   config.Logger,
 
-			Provider: config.Provider,
+				Provider: config.Provider,
+			}
+
+			appGetter, err = app.New(c)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
 		}
 
-		appGetter, err = app.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
+		var appResource controller.Resource
+		{
+			c := appresource.Config{
+				G8sClient: config.G8sClient,
+				Logger:    config.Logger,
 
-	var appResource controller.Resource
-	{
-		c := appresource.Config{
-			G8sClient: config.G8sClient,
-			Logger:    config.Logger,
+				Name:        app.Name,
+				StateGetter: appGetter,
+			}
 
-			Name:        app.Name,
-			StateGetter: appGetter,
-		}
+			ops, err := appresource.New(c)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
 
-		ops, err := appresource.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
+			appResource, err = toCRUDResource(config.Logger, ops)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
 		}
-
-		appResource, err = toCRUDResource(config.Logger, ops)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
+	*/
 
 	var certConfigResource controller.Resource
 	{
@@ -366,7 +366,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		certConfigResource,
 		clusterConfigMapResource,
 		kubeConfigResource,
-		appResource,
+		// appResource,
 
 		// Following resources manage resources in tenant clusters so they
 		// should be executed last


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6800

Adds the app resource to the legacy controllers. Commented out for now. It will be enabled later once the chartconfig migration logic is ready.