### PR TITLE
Cancel resources when cluster namespace does not exist yet

### DIFF
--- a/pkg/v20/resource/app/resource.go
+++ b/pkg/v20/resource/app/resource.go
@@ -6,6 +6,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 const (
@@ -17,6 +18,7 @@ type Config struct {
 	G8sClient                versioned.Interface
 	GetClusterConfigFunc     func(obj interface{}) (v1alpha1.ClusterGuestConfig, error)
 	GetClusterObjectMetaFunc func(obj interface{}) (metav1.ObjectMeta, error)
+	K8sClient                kubernetes.Interface
 	Logger                   micrologger.Logger
 
 	Provider string
@@ -27,6 +29,7 @@ type Resource struct {
 	g8sClient                versioned.Interface
 	getClusterConfigFunc     func(obj interface{}) (v1alpha1.ClusterGuestConfig, error)
 	getClusterObjectMetaFunc func(obj interface{}) (metav1.ObjectMeta, error)
+	k8sClient                kubernetes.Interface
 	logger                   micrologger.Logger
 
 	provider string
@@ -43,6 +46,9 @@ func New(config Config) (*Resource, error) {
 	if config.G8sClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
 	}
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
+	}
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
@@ -55,6 +61,7 @@ func New(config Config) (*Resource, error) {
 		g8sClient:                config.G8sClient,
 		getClusterConfigFunc:     config.GetClusterConfigFunc,
 		getClusterObjectMetaFunc: config.GetClusterObjectMetaFunc,
+		k8sClient:                config.K8sClient,
 		logger:                   config.Logger,
 
 		provider: config.Provider,

--- a/pkg/v20/resource/clusterconfigmap/current.go
+++ b/pkg/v20/resource/clusterconfigmap/current.go
@@ -34,6 +34,15 @@ func (r *StateGetter) GetCurrentState(ctx context.Context, obj interface{}) ([]*
 		return nil, microerror.Mask(err)
 	}
 
+	// Cluster namespace is created by the provider operator. If it doesn't
+	// exist yet we should retry in the next reconciliation loop.
+	_, err = r.k8sClient.CoreV1().Namespaces().Get(clusterConfig.ID, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("cluster namespace %#q does not exist", clusterConfig.ID))
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+	}
+
 	name := key.ClusterConfigMapName(clusterConfig)
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding cluster configMap %#q in namespace %#q", name, clusterConfig.ID))

--- a/pkg/v20/resource/clusterconfigmap/current.go
+++ b/pkg/v20/resource/clusterconfigmap/current.go
@@ -23,8 +23,8 @@ func (r *StateGetter) GetCurrentState(ctx context.Context, obj interface{}) ([]*
 	// the tenant cluster namespace in the control plane cluster.
 	if key.IsDeleted(objectMeta) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "redirecting cluster configMap deletion to provider operators")
-		resourcecanceledcontext.SetCanceled(ctx)
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
 
 		return nil, nil
 	}

--- a/pkg/v20/resource/clusterconfigmap/current.go
+++ b/pkg/v20/resource/clusterconfigmap/current.go
@@ -41,6 +41,8 @@ func (r *StateGetter) GetCurrentState(ctx context.Context, obj interface{}) ([]*
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("cluster namespace %#q does not exist", clusterConfig.ID))
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		resourcecanceledcontext.SetCanceled(ctx)
+
+		return nil, nil
 	}
 
 	name := key.ClusterConfigMapName(clusterConfig)

--- a/pkg/v20/resource/kubeconfig/current.go
+++ b/pkg/v20/resource/kubeconfig/current.go
@@ -23,8 +23,8 @@ func (r *StateGetter) GetCurrentState(ctx context.Context, obj interface{}) ([]*
 	// the tenant cluster namespace in the control plane cluster.
 	if key.IsDeleted(objectMeta) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "redirecting kubeconfig secret deletion to provider operators")
-		resourcecanceledcontext.SetCanceled(ctx)
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
 
 		return nil, nil
 	}

--- a/pkg/v20/resource/kubeconfig/current.go
+++ b/pkg/v20/resource/kubeconfig/current.go
@@ -41,6 +41,8 @@ func (r *StateGetter) GetCurrentState(ctx context.Context, obj interface{}) ([]*
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("cluster namespace %#q does not exist", clusterConfig.ID))
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		resourcecanceledcontext.SetCanceled(ctx)
+
+		return nil, nil
 	}
 
 	secretName := key.KubeConfigSecretName(clusterConfig)

--- a/pkg/v20/resource/kubeconfig/current.go
+++ b/pkg/v20/resource/kubeconfig/current.go
@@ -34,6 +34,15 @@ func (r *StateGetter) GetCurrentState(ctx context.Context, obj interface{}) ([]*
 		return nil, microerror.Mask(err)
 	}
 
+	// Cluster namespace is created by the provider operator. If it doesn't
+	// exist yet we should retry in the next reconciliation loop.
+	_, err = r.k8sClient.CoreV1().Namespaces().Get(clusterConfig.ID, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("cluster namespace %#q does not exist", clusterConfig.ID))
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+	}
+
 	secretName := key.KubeConfigSecretName(clusterConfig)
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding kubeconfig secret %#q", secretName))

--- a/service/controller/aws/v20/resource_set.go
+++ b/service/controller/aws/v20/resource_set.go
@@ -80,6 +80,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			GetClusterConfigFunc:     getClusterConfig,
 			GetClusterObjectMetaFunc: getClusterObjectMeta,
 			G8sClient:                config.G8sClient,
+			K8sClient:                config.K8sClient,
 			Logger:                   config.Logger,
 
 			Provider: config.Provider,

--- a/service/controller/azure/v20/resource_set.go
+++ b/service/controller/azure/v20/resource_set.go
@@ -77,6 +77,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			G8sClient:                config.G8sClient,
 			GetClusterConfigFunc:     getClusterConfig,
 			GetClusterObjectMetaFunc: getClusterObjectMeta,
+			K8sClient:                config.K8sClient,
 			Logger:                   config.Logger,
 
 			Provider: config.Provider,

--- a/service/controller/kvm/v20/resource_set.go
+++ b/service/controller/kvm/v20/resource_set.go
@@ -76,6 +76,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			G8sClient:                config.G8sClient,
 			GetClusterConfigFunc:     getClusterConfig,
 			GetClusterObjectMetaFunc: getClusterObjectMeta,
+			K8sClient:                config.K8sClient,
 			Logger:                   config.Logger,
 
 			Provider: config.Provider,


### PR DESCRIPTION
For the legacy controllers the cluster namespace is created by aws-operator etc. In new tenant clusters we see these errors. This prevents these by cancelling the clusterconfigmap and kubeconfig resources.

In the clusterapi controller this was fixed by creating the tenant cluster namespace in cluster-operator. So long term we don't need this.

```
D 09/04 10:39:04 /apis/core.giantswarm.io/v1alpha1/namespaces/default/awsclusterconfigs/h2wqy-aws-cluster-config clusterconfigmapv19.ApplyCreateChange creating ConfigMap `h2wqy-cluster-values` in namespace `h2wqy` | operatorkit/resource/k8s/configmapresource/create.go:20 | controller=cluster-operator | event=update | loop=2 | version=4726013
W 09/04 10:39:04 /apis/core.giantswarm.io/v1alpha1/namespaces/default/awsclusterconfigs/h2wqy-aws-cluster-config clusterconfigmapv19.ApplyCreateChange retrying due to error | operatorkit/resource/wrapper/retryresource/crud_resource_ops_wrapper.go:169 | controller=cluster-operator | event=update | loop=2 | underlyingResource=clusterconfigmapv19 | version=4726013
	/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/crud_resource_ops_wrapper.go:162:
	/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/resource/k8s/configmapresource/create.go:26:
	namespaces "h2wqy" not found
```