### PR TITLE
Use 0.9.1 of chart-operator so CoreDNS will start in tenant clusters

### DIFF
--- a/pkg/v19/key/key.go
+++ b/pkg/v19/key/key.go
@@ -66,16 +66,7 @@ func ClusterOrganization(clusterGuestConfig v1alpha1.ClusterGuestConfig) string 
 // Note: When adding app specs you also need to add the chart name to the
 // desired state tests in the chartconfig and configmap services.
 func CommonAppSpecs() []AppSpec {
-	return []AppSpec{
-		{
-			App:             "kube-state-metrics",
-			Catalog:         "giantswarm",
-			Chart:           "kube-state-metrics-app",
-			Namespace:       metav1.NamespaceSystem,
-			UseUpgradeForce: true,
-			Version:         "0.5.0",
-		},
-	}
+	return []AppSpec{}
 }
 
 // CommonChartSpecs returns charts installed for all providers.

--- a/pkg/v20/key/key.go
+++ b/pkg/v20/key/key.go
@@ -70,7 +70,7 @@ func CommonAppSpecs() []AppSpec {
 			Catalog:   "giantswarm",
 			Chart:     "chart-operator",
 			Namespace: "giantswarm",
-			Version:   "0.9.0",
+			Version:   "0.9.1",
 		},
 	}
 }


### PR DESCRIPTION
The 0.9.0 tag is a month old and misses some fixes for bootstrapping CoreDNS in new tenant clusters. This meant no core components would start.