### PR TITLE
Fix registry domain in cluster-operator configmap

### DIFF
--- a/helm/cluster-operator-chart/templates/configmap.yaml
+++ b/helm/cluster-operator-chart/templates/configmap.yaml
@@ -25,6 +25,9 @@ data:
     service:
       clusterService:
         address: 'http://cluster-service:8000'
+      image:
+        registry:
+          domain: '{{ .Values.Installation.V1.Registry.Domain }}'
       kubeconfig:
         resource:
           namespace: 'giantswarm'
@@ -37,4 +40,3 @@ data:
           keyFile: ''
       provider:
         kind: '{{ .Values.Installation.V1.Provider.Kind }}'
-      registryDomain: '{{ .Values.Installation.V1.Registry.Domain }}'


### PR DESCRIPTION
The tenant cluster components in axolotl are using the wrong image registry. This was broken by me in https://github.com/giantswarm/cluster-operator/pull/407 when the flags got restructured 😞.
