### PR TITLE
Use default catalog and v0.10.1 for chart-operator

### DIFF
--- a/pkg/v20/key/key.go
+++ b/pkg/v20/key/key.go
@@ -68,10 +68,10 @@ func CommonAppSpecs() []AppSpec {
 	return []AppSpec{
 		{
 			App:       "chart-operator",
-			Catalog:   "default",
+			Catalog:   "default-test",
 			Chart:     "chart-operator",
 			Namespace: "giantswarm",
-			Version:   "0.10.0",
+			Version:   "0.10.0-fa3dd687cd2a9b896b00951d3851a22d85aa4cbe",
 		},
 	}
 }

--- a/pkg/v20/key/key.go
+++ b/pkg/v20/key/key.go
@@ -71,7 +71,7 @@ func CommonAppSpecs() []AppSpec {
 			Catalog:   "default-test",
 			Chart:     "chart-operator",
 			Namespace: "giantswarm",
-			Version:   "0.10.0-bbd79bd6bbbfa78f643f85d03688d1f757e15eab"
+			Version:   "0.10.0-bbd79bd6bbbfa78f643f85d03688d1f757e15eab",
 		},
 	}
 }

--- a/pkg/v20/key/key.go
+++ b/pkg/v20/key/key.go
@@ -71,7 +71,7 @@ func CommonAppSpecs() []AppSpec {
 			Catalog:   "default-test",
 			Chart:     "chart-operator",
 			Namespace: "giantswarm",
-			Version:   "0.10.0-fa3dd687cd2a9b896b00951d3851a22d85aa4cbe",
+			Version:   "0.10.0-bbd79bd6bbbfa78f643f85d03688d1f757e15eab"
 		},
 	}
 }

--- a/pkg/v20/key/key.go
+++ b/pkg/v20/key/key.go
@@ -68,10 +68,10 @@ func CommonAppSpecs() []AppSpec {
 	return []AppSpec{
 		{
 			App:       "chart-operator",
-			Catalog:   "giantswarm",
+			Catalog:   "default",
 			Chart:     "chart-operator",
 			Namespace: "giantswarm",
-			Version:   "0.9.2",
+			Version:   "0.10.0",
 		},
 	}
 }

--- a/pkg/v20/key/key.go
+++ b/pkg/v20/key/key.go
@@ -68,10 +68,10 @@ func CommonAppSpecs() []AppSpec {
 	return []AppSpec{
 		{
 			App:       "chart-operator",
-			Catalog:   "default-test",
+			Catalog:   "default",
 			Chart:     "chart-operator",
 			Namespace: "giantswarm",
-			Version:   "0.10.0-bbd79bd6bbbfa78f643f85d03688d1f757e15eab",
+			Version:   "0.10.1",
 		},
 	}
 }


### PR DESCRIPTION
There were multiple problems with the chart-operator chart being pushed to app catalog. Now uses the new v0.10.1 tag.

https://github.com/giantswarm/chart-operator/pull/287