### PR TITLE
Install chart-operator from default catalog

### DIFF
--- a/pkg/v20/key/key.go
+++ b/pkg/v20/key/key.go
@@ -73,10 +73,10 @@ func CommonAppSpecs() []AppSpec {
 	return []AppSpec{
 		{
 			App:       "chart-operator",
-			Catalog:   "default",
+			Catalog:   "default-test",
 			Chart:     "chart-operator",
 			Namespace: "giantswarm",
-			Version:   "0.10.2",
+			Version:   "0.10.2-31ce304acf1142d8b38a2bf6eccc61107238efa8",
 		},
 	}
 }

--- a/pkg/v20/key/key.go
+++ b/pkg/v20/key/key.go
@@ -73,10 +73,10 @@ func CommonAppSpecs() []AppSpec {
 	return []AppSpec{
 		{
 			App:       "chart-operator",
-			Catalog:   "default-test",
+			Catalog:   "default",
 			Chart:     "chart-operator",
 			Namespace: "giantswarm",
-			Version:   "0.10.2-31ce304acf1142d8b38a2bf6eccc61107238efa8",
+			Version:   "0.10.3",
 		},
 	}
 }

--- a/service/controller/aws/v20/version_bundle.go
+++ b/service/controller/aws/v20/version_bundle.go
@@ -12,6 +12,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Add internal Kubernetes API domain into API certificate alternative names.",
 				Kind:        versionbundle.KindChanged,
 			},
+			{
+				Component:   "chart-operator",
+				Description: "Install chart-operator from default catalog.",
+				Kind:        versionbundle.KindChanged,
+			},
 		},
 		Components: []versionbundle.Component{
 			{

--- a/service/controller/azure/v20/version_bundle.go
+++ b/service/controller/azure/v20/version_bundle.go
@@ -12,6 +12,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Add internal Kubernetes API domain into API certificate alternative names.",
 				Kind:        versionbundle.KindChanged,
 			},
+			{
+				Component:   "chart-operator",
+				Description: "Install chart-operator from default catalog.",
+				Kind:        versionbundle.KindChanged,
+			},
 		},
 		Components: []versionbundle.Component{
 			{

--- a/service/controller/clusterapi/v20/version_bundle.go
+++ b/service/controller/clusterapi/v20/version_bundle.go
@@ -12,6 +12,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Add internal Kubernetes API domain into API certificate alternative names.",
 				Kind:        versionbundle.KindChanged,
 			},
+			{
+				Component:   "chart-operator",
+				Description: "Install chart-operator from default catalog.",
+				Kind:        versionbundle.KindChanged,
+			},
 		},
 		Components: []versionbundle.Component{
 			{

--- a/service/controller/kvm/v20/version_bundle.go
+++ b/service/controller/kvm/v20/version_bundle.go
@@ -12,6 +12,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Add internal Kubernetes API domain into API certificate alternative names.",
 				Kind:        versionbundle.KindChanged,
 			},
+			{
+				Component:   "chart-operator",
+				Description: "Install chart-operator from default catalog.",
+				Kind:        versionbundle.KindChanged,
+			},
 		},
 		Components: []versionbundle.Component{
 			{


### PR DESCRIPTION
Towards giantswarm/giantswarm#6800

- Deploys https://github.com/giantswarm/chart-operator/pull/292 which uses an init container to wait for quay.io to be resolvable. 
- This is so chart-operator can install coredns.

