### PR TITLE
Updated chart-operator with PSP fix

### DIFF
--- a/pkg/v20/key/key.go
+++ b/pkg/v20/key/key.go
@@ -73,10 +73,10 @@ func CommonAppSpecs() []AppSpec {
 	return []AppSpec{
 		{
 			App:       "chart-operator",
-			Catalog:   "default",
+			Catalog:   "default-test",
 			Chart:     "chart-operator",
 			Namespace: "giantswarm",
-			Version:   "0.10.3",
+			Version:   "0.10.3-f2091465fe961a1435912ea35bb69a3b8bf0daed",
 		},
 	}
 }

--- a/pkg/v20/key/key.go
+++ b/pkg/v20/key/key.go
@@ -73,10 +73,10 @@ func CommonAppSpecs() []AppSpec {
 	return []AppSpec{
 		{
 			App:       "chart-operator",
-			Catalog:   "default-test",
+			Catalog:   "default",
 			Chart:     "chart-operator",
 			Namespace: "giantswarm",
-			Version:   "0.10.3-f2091465fe961a1435912ea35bb69a3b8bf0daed",
+			Version:   "0.10.4",
 		},
 	}
 }


### PR DESCRIPTION
Deploys chart-operator 0.10.4 with a fix for a failed chart-operator helm release that affects upgraded tenant clusters.

https://github.com/giantswarm/chart-operator/pull/294

This means we can safely upgrade clusters to 8.5.0. All other changes will come in the new v21 WIP version bundle I'm adding.
