### PR TITLE
Add remaining migration logic and migrate kube-state-metrics and metrics-server to app CRs

### DIFF
--- a/pkg/v21/key/key.go
+++ b/pkg/v21/key/key.go
@@ -86,6 +86,14 @@ func CommonAppSpecs() []AppSpec {
 			UseUpgradeForce: true,
 			Version:         "0.5.0",
 		},
+		{
+			App:             "metrics-server",
+			Catalog:         "default",
+			Chart:           "metrics-server-app",
+			Namespace:       metav1.NamespaceSystem,
+			UseUpgradeForce: true,
+			Version:         "0.4.0",
+		},
 	}
 }
 
@@ -131,7 +139,7 @@ func CommonChartSpecs() []ChartSpec {
 			ChannelName:     "0-3-stable",
 			ChartName:       "kubernetes-metrics-server-chart",
 			ConfigMapName:   "metrics-server-values",
-			HasAppCR:        false,
+			HasAppCR:        true,
 			Namespace:       metav1.NamespaceSystem,
 			ReleaseName:     "metrics-server",
 			UseUpgradeForce: true,

--- a/pkg/v21/key/key.go
+++ b/pkg/v21/key/key.go
@@ -78,6 +78,14 @@ func CommonAppSpecs() []AppSpec {
 			Namespace: "giantswarm",
 			Version:   "0.10.4",
 		},
+		{
+			App:             "kube-state-metrics",
+			Catalog:         "default",
+			Chart:           "kube-state-metrics-app",
+			Namespace:       metav1.NamespaceSystem,
+			UseUpgradeForce: true,
+			Version:         "0.5.0",
+		},
 	}
 }
 
@@ -113,7 +121,7 @@ func CommonChartSpecs() []ChartSpec {
 			ChannelName:     "0-4-stable",
 			ChartName:       "kubernetes-kube-state-metrics-chart",
 			ConfigMapName:   "kube-state-metrics-values",
-			HasAppCR:        false,
+			HasAppCR:        true,
 			Namespace:       metav1.NamespaceSystem,
 			ReleaseName:     "kube-state-metrics",
 			UseUpgradeForce: true,

--- a/pkg/v21/key/key.go
+++ b/pkg/v21/key/key.go
@@ -76,7 +76,7 @@ func CommonAppSpecs() []AppSpec {
 			Catalog:   "default",
 			Chart:     "chart-operator",
 			Namespace: "giantswarm",
-			Version:   "0.10.3",
+			Version:   "0.10.4",
 		},
 	}
 }

--- a/pkg/v21/resource/appmigration/create.go
+++ b/pkg/v21/resource/appmigration/create.go
@@ -5,14 +5,21 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/backoff"
+	"github.com/giantswarm/errors/tenant"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/giantswarm/cluster-operator/pkg/annotation"
+	"github.com/giantswarm/cluster-operator/pkg/label"
+	"github.com/giantswarm/cluster-operator/pkg/project"
 	"github.com/giantswarm/cluster-operator/pkg/v21/key"
 	awskey "github.com/giantswarm/cluster-operator/service/controller/aws/v21/key"
 	azurekey "github.com/giantswarm/cluster-operator/service/controller/azure/v21/key"
@@ -42,6 +49,96 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return nil
 	}
 
+	clusterConfig, err := r.getClusterConfigFunc(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	tenantAPIDomain, err := key.APIDomain(clusterConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	tenantG8sClient, err := r.tenant.NewG8sClient(ctx, clusterConfig.ID, tenantAPIDomain)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	listOptions := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", label.ManagedBy, project.Name()),
+	}
+
+	chartConfigs, err := tenantG8sClient.CoreV1alpha1().ChartConfigs("giantswarm").List(listOptions)
+	if tenant.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available yet")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+		return nil
+	} else if apierrors.IsNotFound(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "chartconfig CRD does not exist")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	for _, chartSpec := range chartSpecsToMigrate {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding out if chartconfig CR %#q has been migrated", chartSpec.ChartName))
+
+		chartCR, err := getChartConfigByName(chartConfigs.Items, chartSpec.ChartName)
+		if IsNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("chartconfig CR %#q has been migrated, continuing", chartSpec.ChartName))
+			continue
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		// Cordon chartconfig CR so no changes are applied.
+		_, ok := chartCR.Annotations[annotation.CordonReason]
+		if !ok {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("cordoning chartconfig CR %#q", chartSpec.ChartName))
+
+			err = patchChartConfig(tenantG8sClient, chartCR, addCordonAnnotations())
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("cordoned chartconfig CR %#q", chartSpec.ChartName))
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("chartconfig CR %#q is already cordoned", chartSpec.ChartName))
+		}
+
+		// Check if there is a deployed app CR.
+		err = r.waitForDeployedApp(ctx, clusterConfig.ID, chartSpec.AppName)
+		if apierrors.IsNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("app CR %#q is not deployed, continuing", chartSpec.AppName))
+			continue
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("adding annotation for deleting chartconfig CR %#q", chartSpec.ChartName))
+
+		// Add deletion annotation which will trigger chart-operator to
+		// delete the chartconfig CR but not the Helm release.
+		err = patchChartConfig(tenantG8sClient, chartCR, addDeleteAnnotation())
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("added annotation to chartconfig CR %#q", chartSpec.ChartName))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting chartconfig CR %#q", chartSpec.ChartName))
+
+		// Lastly delete the chartconfig CR.
+		err = tenantG8sClient.CoreV1alpha1().ChartConfigs("giantswarm").Delete(chartCR.Name, &metav1.DeleteOptions{})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted chartconfig CR %#q", chartSpec.ChartName))
+	}
+
 	return nil
 }
 
@@ -68,6 +165,39 @@ func (r *Resource) newChartSpecsToMigrate() []key.ChartSpec {
 	}
 
 	return chartSpecsToMigrate
+}
+
+// waitForDeployedApp waits until the newly created app CR has a deployed helm
+// release and the chartconfig CR can be safely deleted.
+func (r *Resource) waitForDeployedApp(ctx context.Context, namespace, appName string) error {
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waiting for deployed app CR %#q", appName))
+
+	o := func() error {
+		appCR, err := r.g8sClient.ApplicationV1alpha1().Apps(namespace).Get(appName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return microerror.Maskf(notFoundError, "app CR %#q", appName)
+		}
+
+		if appCR.Status.Release.Status != "DEPLOYED" {
+			return microerror.Maskf(notDeployedError, "app CR %#q has status %#q", appName, appCR.Status.Release.Status)
+		}
+
+		return nil
+	}
+
+	b := backoff.NewConstant(10*time.Second, 2*time.Second)
+	n := func(err error, delay time.Duration) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("app CR %#q is not deployed retrying in %s", appName, delay), "stack", fmt.Sprintf("%#v", err))
+	}
+
+	err := backoff.RetryNotify(o, b, n)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("app CR %#q is deployed", appName))
+
+	return nil
 }
 
 func addCordonAnnotations() map[string]string {

--- a/pkg/v21/resource/appmigration/error.go
+++ b/pkg/v21/resource/appmigration/error.go
@@ -13,15 +13,6 @@ func IsInvalidConfigError(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
 
-var notDeployedError = &microerror.Error{
-	Kind: "notDeployedError",
-}
-
-// IsNotDeployed asserts notDeployedError.
-func IsNotDeployed(err error) bool {
-	return microerror.Cause(err) == notDeployedError
-}
-
 var notFoundError = &microerror.Error{
 	Kind: "notFoundError",
 }

--- a/pkg/v21/resource/appmigration/error.go
+++ b/pkg/v21/resource/appmigration/error.go
@@ -13,6 +13,15 @@ func IsInvalidConfigError(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
 
+var notDeployedError = &microerror.Error{
+	Kind: "notDeployedError",
+}
+
+// IsNotDeployed asserts notDeployedError.
+func IsNotDeployed(err error) bool {
+	return microerror.Cause(err) == notDeployedError
+}
+
 var notFoundError = &microerror.Error{
 	Kind: "notFoundError",
 }

--- a/service/controller/aws/v21/version_bundle.go
+++ b/service/controller/aws/v21/version_bundle.go
@@ -8,8 +8,8 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "TODO",
-				Description: "Add your changes here.",
+				Component:   "kube-state-metrics",
+				Description: "Migrated to use default app catalog.",
 				Kind:        versionbundle.KindChanged,
 			},
 		},

--- a/service/controller/aws/v21/version_bundle.go
+++ b/service/controller/aws/v21/version_bundle.go
@@ -12,6 +12,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Migrated to use default app catalog.",
 				Kind:        versionbundle.KindChanged,
 			},
+			{
+				Component:   "metrics-server",
+				Description: "Migrated to use default app catalog.",
+				Kind:        versionbundle.KindChanged,
+			},
 		},
 		Components: []versionbundle.Component{
 			{

--- a/service/controller/azure/v21/version_bundle.go
+++ b/service/controller/azure/v21/version_bundle.go
@@ -8,8 +8,8 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "Add your changes here.",
-				Description: "Add your changes here.",
+				Component:   "kube-state-metrics",
+				Description: "Migrated to use default app catalog.",
 				Kind:        versionbundle.KindChanged,
 			},
 		},

--- a/service/controller/azure/v21/version_bundle.go
+++ b/service/controller/azure/v21/version_bundle.go
@@ -12,6 +12,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Migrated to use default app catalog.",
 				Kind:        versionbundle.KindChanged,
 			},
+			{
+				Component:   "metrics-server",
+				Description: "Migrated to use default app catalog.",
+				Kind:        versionbundle.KindChanged,
+			},
 		},
 		Components: []versionbundle.Component{
 			{

--- a/service/controller/kvm/v21/version_bundle.go
+++ b/service/controller/kvm/v21/version_bundle.go
@@ -8,8 +8,8 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "TODO",
-				Description: "Add your changes here.",
+				Component:   "kube-state-metrics",
+				Description: "Migrated to use default app catalog.",
 				Kind:        versionbundle.KindChanged,
 			},
 		},

--- a/service/controller/kvm/v21/version_bundle.go
+++ b/service/controller/kvm/v21/version_bundle.go
@@ -12,6 +12,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Migrated to use default app catalog.",
 				Kind:        versionbundle.KindChanged,
 			},
+			{
+				Component:   "metrics-server",
+				Description: "Migrated to use default app catalog.",
+				Kind:        versionbundle.KindChanged,
+			},
 		},
 		Components: []versionbundle.Component{
 			{


### PR DESCRIPTION
Towards giantswarm/giantswarm#6800

Implements the rest of the migration process. See spec PR https://github.com/giantswarm/giantswarm/pull/7111 for more details.