### PR TITLE
WIP: Check whether chartconfig crd are installed in TC first

### DIFF
--- a/pkg/v21/key/error_internal.go
+++ b/pkg/v21/key/error_internal.go
@@ -1,0 +1,21 @@
+package key
+
+import (
+	"strings"
+
+	"github.com/giantswarm/microerror"
+)
+
+const (
+	errorSentence = "the server could not find the requested resource (get chartconfigs.core.giantswarm.io)"
+)
+
+func IsChartConfigNotInstalled(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	c := microerror.Cause(err)
+
+	return strings.Contains(c.Error(), errorSentence)
+}

--- a/service/controller/kvm/v21/resource/chartconfig/current.go
+++ b/service/controller/kvm/v21/resource/chartconfig/current.go
@@ -58,6 +58,13 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 
 		return nil, nil
+	} else if key.IsChartConfigNotInstalled(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "chartconfig CRD is not installed yet")
+
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+		return nil, nil
 	} else if err != nil {
 		return nil, microerror.Mask(err)
 	}


### PR DESCRIPTION
Solving the issue that TC is new but no `chartconfigs` CRD installed yet. 

See below logs; 
```
{"caller":"github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:372","controller":"cluster-operator","event":"update","level":"error","loop":"13","message":"stop reconciliation due to error","object":"/apis/core.giantswarm.io/v1alpha1/namespaces/default/kvmclusterconfigs/0eodk-kvm-cluster-config","resource":"chartconfigv21","stack":"[{/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:553: } {/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/metricsresource/crud_resource_wrapper.go:63: } {/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/crud_resource_wrapper.go:82: } {/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/controller/crud_resource.go:71: } {/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/metricsresource/crud_resource_ops_wrapper.go:53: } {/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/crud_resource_ops_wrapper.go:76: } {/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/backoff/retry.go:23: } {/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/crud_resource_ops_wrapper.go:64: } {/go/src/github.com/giantswarm/cluster-operator/service/controller/kvm/v21/resource/chartconfig/current.go:62: } {/go/src/github.com/giantswarm/cluster-operator/pkg/v21/chartconfig/current.go:37: } {the server could not find the requested resource (get chartconfigs.core.giantswarm.io)}]","time":"2019-10-09T10:54:11.965365+00:00","version":"160978513"}
```