### PR TITLE
Add user config to app CRs when configmap or secret exists

### DIFF
--- a/pkg/v21/key/key.go
+++ b/pkg/v21/key/key.go
@@ -34,6 +34,18 @@ func APIDomain(clusterGuestConfig v1alpha1.ClusterGuestConfig) (string, error) {
 	return serverDomain(clusterGuestConfig, certs.APICert)
 }
 
+// AppUserConfigMapName returns the name of the user values configmap for the
+// given app spec.
+func AppUserConfigMapName(appSpec AppSpec) string {
+	return fmt.Sprintf("%s-user-values", appSpec.App)
+}
+
+// AppUserSecretName returns the name of the user values secret for the
+// given app spec.
+func AppUserSecretName(appSpec AppSpec) string {
+	return fmt.Sprintf("%s-user-secrets", appSpec.App)
+}
+
 // CertConfigName constructs a name for CertConfig CR using ClusterID and Cert.
 func CertConfigName(clusterID string, cert certs.Cert) string {
 	return fmt.Sprintf("%s-%s", clusterID, cert)

--- a/pkg/v21/resource/app/desired.go
+++ b/pkg/v21/resource/app/desired.go
@@ -2,11 +2,13 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	g8sv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/microerror"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/cluster-operator/pkg/annotation"
@@ -24,16 +26,65 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*g8s
 		return nil, microerror.Mask(err)
 	}
 
+	configMaps, err := r.getConfigMaps(ctx, clusterConfig)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	secrets, err := r.getSecrets(ctx, clusterConfig)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
 	var apps []*g8sv1alpha1.App
 
 	for _, appSpec := range r.newAppSpecs() {
-		apps = append(apps, r.newApp(clusterConfig, appSpec))
+		userConfig := newUserConfig(clusterConfig, appSpec, configMaps, secrets)
+		apps = append(apps, r.newApp(clusterConfig, appSpec, userConfig))
 	}
 
 	return apps, nil
 }
 
-func (r *Resource) newApp(clusterConfig v1alpha1.ClusterGuestConfig, appSpec key.AppSpec) *g8sv1alpha1.App {
+func (r *Resource) getConfigMaps(ctx context.Context, clusterConfig v1alpha1.ClusterGuestConfig) (map[string]corev1.ConfigMap, error) {
+	configMaps := map[string]corev1.ConfigMap{}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding configMaps in namespace %#q", clusterConfig.ID))
+
+	list, err := r.k8sClient.CoreV1().ConfigMaps(clusterConfig.ID).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	for _, cm := range list.Items {
+		configMaps[cm.Name] = cm
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d configMaps in namespace %#q", len(configMaps), clusterConfig.ID))
+
+	return configMaps, nil
+}
+
+func (r *Resource) getSecrets(ctx context.Context, clusterConfig v1alpha1.ClusterGuestConfig) (map[string]corev1.Secret, error) {
+	secrets := map[string]corev1.Secret{}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding secrets in namespace %#q", clusterConfig.ID))
+
+	list, err := r.k8sClient.CoreV1().Secrets(clusterConfig.ID).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	for _, s := range list.Items {
+		secrets[s.Name] = s
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d secrets in namespace %#q", len(secrets), clusterConfig.ID))
+
+	return secrets, nil
+}
+
+func (r *Resource) newApp(clusterConfig v1alpha1.ClusterGuestConfig, appSpec key.AppSpec, userConfig g8sv1alpha1.AppSpecUserConfig) *g8sv1alpha1.App {
 	return &g8sv1alpha1.App{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "App",
@@ -77,6 +128,8 @@ func (r *Resource) newApp(clusterConfig v1alpha1.ClusterGuestConfig, appSpec key
 					Namespace: clusterConfig.ID,
 				},
 			},
+
+			UserConfig: userConfig,
 		},
 	}
 }
@@ -92,4 +145,30 @@ func (r *Resource) newAppSpecs() []key.AppSpec {
 	default:
 		return key.CommonAppSpecs()
 	}
+}
+
+func newUserConfig(clusterConfig v1alpha1.ClusterGuestConfig, appSpec key.AppSpec, configMaps map[string]corev1.ConfigMap, secrets map[string]corev1.Secret) g8sv1alpha1.AppSpecUserConfig {
+	userConfig := g8sv1alpha1.AppSpecUserConfig{}
+
+	_, ok := configMaps[key.AppUserConfigMapName(appSpec)]
+	if ok {
+		configMapSpec := g8sv1alpha1.AppSpecUserConfigConfigMap{
+			Name:      key.AppUserConfigMapName(appSpec),
+			Namespace: clusterConfig.ID,
+		}
+
+		userConfig.ConfigMap = configMapSpec
+	}
+
+	_, ok = secrets[key.AppUserSecretName(appSpec)]
+	if ok {
+		secretSpec := g8sv1alpha1.AppSpecUserConfigSecret{
+			Name:      key.AppUserSecretName(appSpec),
+			Namespace: clusterConfig.ID,
+		}
+
+		userConfig.Secret = secretSpec
+	}
+
+	return userConfig
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7181

Spec PR https://github.com/giantswarm/giantswarm/pull/7111. 

Sets the userConfig block when the user configmap or secret is present.

```
k get app metrics-server -o yaml

apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  name: metrics-server
  namespace: 8ivdw
spec:
...
  userConfig:
    configMap:
      name: metrics-server-user-values
      namespace: 8ivdw
    secret:
      name: metrics-server-user-secrets
      namespace: 8ivdw
...
```

