### PR TITLE
Add list verb for configmaps

### DIFF
--- a/helm/cluster-operator-chart/templates/rbac.yaml
+++ b/helm/cluster-operator-chart/templates/rbac.yaml
@@ -24,6 +24,7 @@ rules:
       - update
       - delete
       - get
+      - list
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
Follow up to https://github.com/giantswarm/cluster-operator/pull/698. 

The list verb is now needed for configmaps to check if there are user configmaps.