### PR TITLE
fix rbac rules for machine deployments

### DIFF
--- a/helm/cluster-operator-chart/templates/rbac.yaml
+++ b/helm/cluster-operator-chart/templates/rbac.yaml
@@ -8,12 +8,7 @@ rules:
     resources:
       - secrets
     verbs:
-      - create
-      - update
-      - delete
-      - get
-      - list
-      - watch
+      - "*"
   - apiGroups:
       - ""
     resources:
@@ -62,11 +57,7 @@ rules:
       - machinedeployments
       - machinedeployments/status
     verbs:
-      - get
-      - list
-      - patch
-      - update
-      - watch
+      - "*"
   - apiGroups:
       - core.giantswarm.io
     resources:


### PR DESCRIPTION
Since the `cluster-operator` does now also cleanup `MachineDeployment` CRs we need to align the RBAC rules. 