### PR TITLE
Fixes for appmigration resource

### DIFF
--- a/pkg/v21/resource/appmigration/error_internal.go
+++ b/pkg/v21/resource/appmigration/error_internal.go
@@ -1,0 +1,21 @@
+package appmigration
+
+import (
+	"strings"
+
+	"github.com/giantswarm/microerror"
+)
+
+const (
+	errorText = "the server could not find the requested resource (get chartconfigs.core.giantswarm.io)"
+)
+
+func isChartConfigNotInstalled(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	c := microerror.Cause(err)
+
+	return strings.Contains(c.Error(), errorText)
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7181

While testing the new configmapmigration resource on geckon I've been getting a lot of timeouts accessing the tenant cluster to get the chartconfig CRs.

```
W 10/15 17:34:49 /apis/core.giantswarm.io/v1alpha1/namespaces/default/kvmclusterconfigs/t8u4x-kvm-cluster-config configmapmigrationv21 retrying due to error | operatorkit/resource/wrapper/retryresource/resource_wrapper.go:54 | controller=cluster-operator | event=update | loop=6 | version=161007198
	/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/resource_wrapper.go:47:
	/go/src/github.com/giantswarm/cluster-operator/pkg/v21/resource/configmapmigration/create.go:85:
	Get https://api.t8u4x.k8s.geckon.gridscale.kvm.gigantic.io/apis/core.giantswarm.io/v1alpha1/namespaces/giantswarm/chartconfigs?labelSelector=giantswarm.io%2Fmanaged-by%3Dcluster-operator: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
```

The appmigration resource has the same problem so fixing it first.