### PR TITLE
Don't create old style configmaps when there is an app CR

### DIFF
--- a/pkg/v21/chartconfig/create.go
+++ b/pkg/v21/chartconfig/create.go
@@ -48,7 +48,6 @@ func (c *ChartConfig) newCreateChange(ctx context.Context, currentChartConfigs, 
 	for _, desiredChartConfig := range desiredChartConfigs {
 		chartSpec := c.getChartSpecByName(desiredChartConfig.Name)
 		if chartSpec.HasAppCR {
-			c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not creating %#q it is migrated to app CR", desiredChartConfig.Name))
 			continue
 		}
 

--- a/pkg/v21/configmap/configmap.go
+++ b/pkg/v21/configmap/configmap.go
@@ -15,12 +15,16 @@ import (
 type Config struct {
 	Logger micrologger.Logger
 	Tenant tenantcluster.Interface
+
+	Provider string
 }
 
 // Service provides shared functionality for managing configmaps.
 type Service struct {
 	logger micrologger.Logger
 	tenant tenantcluster.Interface
+
+	provider string
 }
 
 // New creates a new configmap service.
@@ -32,9 +36,15 @@ func New(config Config) (*Service, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Tenant must not be empty", config)
 	}
 
+	if config.Provider == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Provider must not be empty", config)
+	}
+
 	s := &Service{
 		logger: config.Logger,
 		tenant: config.Tenant,
+
+		provider: config.Provider,
 	}
 
 	return s, nil

--- a/pkg/v21/configmap/create.go
+++ b/pkg/v21/configmap/create.go
@@ -7,6 +7,8 @@ import (
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/giantswarm/cluster-operator/pkg/label"
 )
 
 func (s *Service) ApplyCreateChange(ctx context.Context, clusterConfig ClusterConfig, configMapsToCreate []*corev1.ConfigMap) error {
@@ -41,6 +43,12 @@ func (s *Service) newCreateChange(ctx context.Context, currentConfigMaps, desire
 	configMapsToCreate := make([]*corev1.ConfigMap, 0)
 
 	for _, desiredConfigMap := range desiredConfigMaps {
+		appName := desiredConfigMap.Labels[label.App]
+		chartSpec := s.getChartSpecByName(appName)
+		if chartSpec.HasAppCR {
+			continue
+		}
+
 		if !containsConfigMap(currentConfigMaps, desiredConfigMap) {
 			configMapsToCreate = append(configMapsToCreate, desiredConfigMap)
 		}

--- a/pkg/v21/configmap/create_test.go
+++ b/pkg/v21/configmap/create_test.go
@@ -157,6 +157,8 @@ func Test_ConfigMap_newCreateChange(t *testing.T) {
 	c := Config{
 		Logger: microloggertest.New(),
 		Tenant: &tenantMock{},
+
+		Provider: "aws",
 	}
 	newService, err := New(c)
 	if err != nil {

--- a/pkg/v21/configmap/current_test.go
+++ b/pkg/v21/configmap/current_test.go
@@ -412,6 +412,8 @@ func Test_ConfigMap_GetCurrentState(t *testing.T) {
 			c := Config{
 				Logger: microloggertest.New(),
 				Tenant: tenantService,
+
+				Provider: "aws",
 			}
 			newService, err := New(c)
 			if err != nil {

--- a/pkg/v21/configmap/delete_test.go
+++ b/pkg/v21/configmap/delete_test.go
@@ -104,6 +104,8 @@ func Test_ConfigMap_newDeleteChangeForUpdatePatch(t *testing.T) {
 	c := Config{
 		Logger: microloggertest.New(),
 		Tenant: &tenantMock{},
+
+		Provider: "aws",
 	}
 	newService, err := New(c)
 	if err != nil {

--- a/pkg/v21/configmap/desired_test.go
+++ b/pkg/v21/configmap/desired_test.go
@@ -258,6 +258,8 @@ func Test_ConfigMap_GetDesiredState(t *testing.T) {
 				Tenant: &tenantMock{
 					fakeTenantK8sClient: fakeTenantK8sClient,
 				},
+
+				Provider: "aws",
 			}
 			newService, err := New(c)
 			if err != nil {

--- a/pkg/v21/configmap/update_test.go
+++ b/pkg/v21/configmap/update_test.go
@@ -303,6 +303,8 @@ func Test_ConfigMap_newUpdateChange(t *testing.T) {
 	c := Config{
 		Logger: microloggertest.New(),
 		Tenant: &tenantMock{},
+
+		Provider: "aws",
 	}
 	newService, err := New(c)
 	if err != nil {

--- a/pkg/v21/key/key.go
+++ b/pkg/v21/key/key.go
@@ -97,7 +97,7 @@ func CommonAppSpecs() []AppSpec {
 			Chart:           "kube-state-metrics-app",
 			Namespace:       metav1.NamespaceSystem,
 			UseUpgradeForce: true,
-			Version:         "0.5.0",
+			Version:         "0.6.0",
 		},
 		{
 			App:             "metrics-server",
@@ -125,7 +125,7 @@ func CommonChartSpecs() []ChartSpec {
 	return []ChartSpec{
 		{
 			AppName:       "coredns",
-			ChannelName:   "0-7-stable",
+			ChannelName:   "0-8-stable",
 			ChartName:     "kubernetes-coredns-chart",
 			ConfigMapName: "coredns-values",
 			HasAppCR:      false,
@@ -177,7 +177,7 @@ func CommonChartSpecs() []ChartSpec {
 		},
 		{
 			AppName:       "nginx-ingress-controller",
-			ChannelName:   "0-10-stable",
+			ChannelName:   "1-0-stable",
 			ChartName:     "kubernetes-nginx-ingress-controller-chart",
 			ConfigMapName: "nginx-ingress-controller-values",
 			HasAppCR:      false,

--- a/service/controller/aws/v21/key/key.go
+++ b/service/controller/aws/v21/key/key.go
@@ -20,7 +20,7 @@ func ChartSpecs() []key.ChartSpec {
 	return []key.ChartSpec{
 		{
 			AppName:           "cluster-autoscaler",
-			ChannelName:       "0-7-stable",
+			ChannelName:       "0-9-stable",
 			ChartName:         "kubernetes-cluster-autoscaler-chart",
 			ConfigMapName:     "cluster-autoscaler-values",
 			Namespace:         metav1.NamespaceSystem,

--- a/service/controller/aws/v21/resource_set.go
+++ b/service/controller/aws/v21/resource_set.go
@@ -181,6 +181,8 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		c := configmapservice.Config{
 			Logger: config.Logger,
 			Tenant: config.Tenant,
+
+			Provider: config.Provider,
 		}
 
 		configMapService, err = configmapservice.New(c)

--- a/service/controller/aws/v21/version_bundle.go
+++ b/service/controller/aws/v21/version_bundle.go
@@ -27,15 +27,40 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Extended to support multiple DNS servers when bootstrapping coredns.",
 				Kind:        versionbundle.KindAdded,
 			},
+			{
+				Component:   "kube-state-metrics",
+				Description: "Updated to v1.8.0. https://github.com/giantswarm/kube-state-metrics-app/blob/72d4d3804b9fd8c46e1f23013ed2d78efed5ecca/CHANGELOG.md#v060",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "nginx-ingress-controller",
+				Description: "Updated to v0.26.1. https://github.com/giantswarm/kubernetes-nginx-ingress-controller/blob/d0616c69eb224d49cdfd9a9b63e7cf61d59335ae/CHANGELOG.md#100",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "coredns",
+				Description: "Updated to v1.16.4. https://github.com/giantswarm/kubernetes-coredns/blob/eb9e6979e4bb35b03bd9b0c99e1c68b6a4f3b4c6/CHANGELOG.md#v080",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "cluster-autoscaler",
+				Description: "Updated to v1.15.2. ",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "metrics-server",
+				Description: "Updated to v0.4.1. https://github.com/giantswarm/metrics-server-app/blob/db61c5c13c4ba55c357ab098253b3f3fe8f4e2cd/CHANGELOG.md#v041",
+				Kind:        versionbundle.KindChanged,
+			},
 		},
 		Components: []versionbundle.Component{
 			{
 				Name:    "kube-state-metrics",
-				Version: "1.7.2",
+				Version: "1.8.0",
 			},
 			{
 				Name:    "nginx-ingress-controller",
-				Version: "0.25.1",
+				Version: "0.26.1",
 			},
 			{
 				Name:    "node-exporter",
@@ -43,15 +68,15 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Name:    "coredns",
-				Version: "1.6.2",
+				Version: "1.6.4",
 			},
 			{
 				Name:    "cluster-autoscaler",
-				Version: "1.14.0",
+				Version: "1.15.2",
 			},
 			{
 				Name:    "metrics-server",
-				Version: "0.3.1",
+				Version: "0.4.1",
 			},
 		},
 		Name:     "cluster-operator",

--- a/service/controller/azure/v21/resource_set.go
+++ b/service/controller/azure/v21/resource_set.go
@@ -178,6 +178,8 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		c := configmapservice.Config{
 			Logger: config.Logger,
 			Tenant: config.Tenant,
+
+			Provider: config.Provider,
 		}
 
 		configMapService, err = configmapservice.New(c)

--- a/service/controller/azure/v21/version_bundle.go
+++ b/service/controller/azure/v21/version_bundle.go
@@ -27,19 +27,35 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Extended to support multiple DNS servers when bootstrapping coredns.",
 				Kind:        versionbundle.KindAdded,
 			},
+			{
+				Component:   "kube-state-metrics",
+				Description: "Updated to v1.8.0. https://github.com/giantswarm/kube-state-metrics-app/blob/72d4d3804b9fd8c46e1f23013ed2d78efed5ecca/CHANGELOG.md#v060",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "nginx-ingress-controller",
+				Description: "Updated to v0.26.1. https://github.com/giantswarm/kubernetes-nginx-ingress-controller/blob/d0616c69eb224d49cdfd9a9b63e7cf61d59335ae/CHANGELOG.md#100",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "coredns",
+				Description: "Updated to v1.16.4. https://github.com/giantswarm/kubernetes-coredns/blob/eb9e6979e4bb35b03bd9b0c99e1c68b6a4f3b4c6/CHANGELOG.md#v080",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "metrics-server",
+				Description: "Updated to v0.4.1. https://github.com/giantswarm/metrics-server-app/blob/db61c5c13c4ba55c357ab098253b3f3fe8f4e2cd/CHANGELOG.md#v041",
+				Kind:        versionbundle.KindChanged,
+			},
 		},
 		Components: []versionbundle.Component{
 			{
-				Name:    "nginx-ingress-controller",
-				Version: "0.25.0",
-			},
-			{
-				Name:    "external-dns",
-				Version: "0.5.2",
-			},
-			{
 				Name:    "kube-state-metrics",
-				Version: "1.7.2",
+				Version: "1.8.0",
+			},
+			{
+				Name:    "nginx-ingress-controller",
+				Version: "0.26.1",
 			},
 			{
 				Name:    "node-exporter",
@@ -47,11 +63,11 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Name:    "coredns",
-				Version: "1.6.2",
+				Version: "1.6.4",
 			},
 			{
 				Name:    "metrics-server",
-				Version: "0.3.1",
+				Version: "0.4.1",
 			},
 		},
 		Name:     "cluster-operator",

--- a/service/controller/clusterapi/v21/version_bundle.go
+++ b/service/controller/clusterapi/v21/version_bundle.go
@@ -8,31 +8,75 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "TODO",
-				Description: "Add your changes here.",
+				Component:   "kube-state-metrics",
+				Description: "Migrated to use default app catalog.",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "metrics-server",
+				Description: "Migrated to use default app catalog.",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "node-exporter",
+				Description: "Migrated to use default app catalog.",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "chart-operator",
+				Description: "Extended to support multiple DNS servers when bootstrapping coredns.",
+				Kind:        versionbundle.KindAdded,
+			},
+			{
+				Component:   "kube-state-metrics",
+				Description: "Updated to v1.8.0. https://github.com/giantswarm/kube-state-metrics-app/blob/72d4d3804b9fd8c46e1f23013ed2d78efed5ecca/CHANGELOG.md#v060",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "nginx-ingress-controller",
+				Description: "Updated to v0.26.1. https://github.com/giantswarm/kubernetes-nginx-ingress-controller/blob/d0616c69eb224d49cdfd9a9b63e7cf61d59335ae/CHANGELOG.md#100",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "coredns",
+				Description: "Updated to v1.16.4. https://github.com/giantswarm/kubernetes-coredns/blob/eb9e6979e4bb35b03bd9b0c99e1c68b6a4f3b4c6/CHANGELOG.md#v080",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "cluster-autoscaler",
+				Description: "Updated to v1.15.2. ",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "metrics-server",
+				Description: "Updated to v0.4.1. https://github.com/giantswarm/metrics-server-app/blob/db61c5c13c4ba55c357ab098253b3f3fe8f4e2cd/CHANGELOG.md#v041",
 				Kind:        versionbundle.KindChanged,
 			},
 		},
 		Components: []versionbundle.Component{
 			{
-				Name:    "coredns",
-				Version: "1.6.2",
-			},
-			{
 				Name:    "kube-state-metrics",
-				Version: "1.7.2",
+				Version: "1.8.0",
 			},
 			{
 				Name:    "nginx-ingress-controller",
-				Version: "0.25.1",
+				Version: "0.26.1",
 			},
 			{
 				Name:    "node-exporter",
 				Version: "0.18.0",
 			},
 			{
+				Name:    "coredns",
+				Version: "1.6.4",
+			},
+			{
+				Name:    "cluster-autoscaler",
+				Version: "1.15.2",
+			},
+			{
 				Name:    "metrics-server",
-				Version: "0.3.1",
+				Version: "0.4.1",
 			},
 		},
 		Name:    "cluster-operator",

--- a/service/controller/kvm/v21/resource_set.go
+++ b/service/controller/kvm/v21/resource_set.go
@@ -177,6 +177,8 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		c := configmapservice.Config{
 			Logger: config.Logger,
 			Tenant: config.Tenant,
+
+			Provider: config.Provider,
 		}
 
 		configMapService, err = configmapservice.New(c)

--- a/service/controller/kvm/v21/version_bundle.go
+++ b/service/controller/kvm/v21/version_bundle.go
@@ -27,27 +27,47 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Extended to support multiple DNS servers when bootstrapping coredns.",
 				Kind:        versionbundle.KindAdded,
 			},
+			{
+				Component:   "kube-state-metrics",
+				Description: "Updated to v1.8.0. https://github.com/giantswarm/kube-state-metrics-app/blob/72d4d3804b9fd8c46e1f23013ed2d78efed5ecca/CHANGELOG.md#v060",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "nginx-ingress-controller",
+				Description: "Updated to v0.26.1. https://github.com/giantswarm/kubernetes-nginx-ingress-controller/blob/d0616c69eb224d49cdfd9a9b63e7cf61d59335ae/CHANGELOG.md#100",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "coredns",
+				Description: "Updated to v1.16.4. https://github.com/giantswarm/kubernetes-coredns/blob/eb9e6979e4bb35b03bd9b0c99e1c68b6a4f3b4c6/CHANGELOG.md#v080",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "metrics-server",
+				Description: "Updated to v0.4.1. https://github.com/giantswarm/metrics-server-app/blob/db61c5c13c4ba55c357ab098253b3f3fe8f4e2cd/CHANGELOG.md#v041",
+				Kind:        versionbundle.KindChanged,
+			},
 		},
 		Components: []versionbundle.Component{
 			{
-				Name:    "coredns",
-				Version: "1.6.2",
-			},
-			{
 				Name:    "kube-state-metrics",
-				Version: "1.7.2",
+				Version: "1.8.0",
 			},
 			{
 				Name:    "nginx-ingress-controller",
-				Version: "0.25.1",
+				Version: "0.26.1",
 			},
 			{
 				Name:    "node-exporter",
 				Version: "0.18.0",
 			},
 			{
+				Name:    "coredns",
+				Version: "1.6.4",
+			},
+			{
 				Name:    "metrics-server",
-				Version: "0.3.1",
+				Version: "0.4.1",
 			},
 		},
 		Name:     "cluster-operator",


### PR DESCRIPTION
Towards giantswarm/giantswarm#7181

Previously we created a configmap per managed app for chartconfig CRs. With app CRs we now create a single cluster configmap.

These changes are for new clusters. If a managed app has an app CR we don't need to create these configmaps. I'll do a separate PR for the clusterapi controller.