### PR TITLE
clusterapi: Don't create old style configmap if there is an app CR

### DIFF
--- a/service/controller/clusterapi/v21/resource/configmap/desired.go
+++ b/service/controller/clusterapi/v21/resource/configmap/desired.go
@@ -52,6 +52,12 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	var configMaps []*corev1.ConfigMap
 
 	for _, spec := range newConfigMapSpecs(r.newChartSpecs()) {
+		// No configmap is added because the app has been migrated to use an
+		// App CR.
+		if spec.HasAppCR {
+			continue
+		}
+
 		spec.Labels = newConfigMapLabels(spec, configMapValues, project.Name())
 
 		// Values are only set for app configmaps.
@@ -286,6 +292,7 @@ func newConfigMapSpecs(chartSpecs []pkgkey.ChartSpec) []ConfigMapSpec {
 		if chartSpec.ConfigMapName != "" {
 			configMapSpec := ConfigMapSpec{
 				App:         chartSpec.AppName,
+				HasAppCR:    chartSpec.HasAppCR,
 				Name:        chartSpec.ConfigMapName,
 				Namespace:   chartSpec.Namespace,
 				ReleaseName: chartSpec.ReleaseName,

--- a/service/controller/clusterapi/v21/resource/configmap/spec.go
+++ b/service/controller/clusterapi/v21/resource/configmap/spec.go
@@ -11,6 +11,7 @@ type ClusterConfig struct {
 // ConfigMapSpec is used to generate the desired state.
 type ConfigMapSpec struct {
 	App         string
+	HasAppCR    bool
 	Labels      map[string]string
 	Name        string
 	Namespace   string


### PR DESCRIPTION
Towards giantswarm/giantswarm#7181

Same as https://github.com/giantswarm/cluster-operator/pull/712 but for the clusterapi controller.