### PR TITLE
Add structure for configmapmigration resource

### DIFF
--- a/pkg/v21/resource/configmapmigration/create.go
+++ b/pkg/v21/resource/configmapmigration/create.go
@@ -1,0 +1,76 @@
+package configmapmigration
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/cluster-operator/pkg/v21/key"
+	awskey "github.com/giantswarm/cluster-operator/service/controller/aws/v21/key"
+	azurekey "github.com/giantswarm/cluster-operator/service/controller/azure/v21/key"
+	kvmkey "github.com/giantswarm/cluster-operator/service/controller/kvm/v21/key"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	objectMeta, err := r.getClusterObjectMetaFunc(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Cluster is being deleted. No migration is necessary.
+	if key.IsDeleted(objectMeta) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "cluster is being deleted")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+		return nil
+	}
+
+	chartSpecsToMigrate := r.newChartSpecsToMigrate()
+
+	if len(chartSpecsToMigrate) == 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "no charts to migrate")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+		return nil
+	}
+
+	clusterConfig, err := r.getClusterConfigFunc(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Get all configmaps in the cluster namespace.
+	_, err = r.k8sClient.CoreV1().ConfigMaps(clusterConfig.ID).List(metav1.ListOptions{})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *Resource) newChartSpecsToMigrate() []key.ChartSpec {
+	chartSpecs := []key.ChartSpec{}
+
+	switch r.provider {
+	case "aws":
+		chartSpecs = append(key.CommonChartSpecs(), awskey.ChartSpecs()...)
+	case "azure":
+		chartSpecs = append(key.CommonChartSpecs(), azurekey.ChartSpecs()...)
+	case "kvm":
+		chartSpecs = append(key.CommonChartSpecs(), kvmkey.ChartSpecs()...)
+	default:
+		chartSpecs = key.CommonChartSpecs()
+	}
+
+	chartSpecsToMigrate := []key.ChartSpec{}
+
+	for _, spec := range chartSpecs {
+		if spec.HasAppCR {
+			chartSpecsToMigrate = append(chartSpecsToMigrate, spec)
+		}
+	}
+
+	return chartSpecsToMigrate
+}

--- a/pkg/v21/resource/configmapmigration/delete.go
+++ b/pkg/v21/resource/configmapmigration/delete.go
@@ -1,0 +1,7 @@
+package configmapmigration
+
+import "context"
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/pkg/v21/resource/configmapmigration/error.go
+++ b/pkg/v21/resource/configmapmigration/error.go
@@ -12,12 +12,3 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfigError(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
-
-var notFoundError = &microerror.Error{
-	Kind: "notFoundError",
-}
-
-// IsNotFound asserts notFoundError.
-func IsNotFound(err error) bool {
-	return microerror.Cause(err) == notFoundError
-}

--- a/pkg/v21/resource/configmapmigration/error.go
+++ b/pkg/v21/resource/configmapmigration/error.go
@@ -1,0 +1,23 @@
+package configmapmigration
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfigError asserts invalidConfigError.
+func IsInvalidConfigError(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}

--- a/pkg/v21/resource/configmapmigration/resource.go
+++ b/pkg/v21/resource/configmapmigration/resource.go
@@ -1,0 +1,72 @@
+package configmapmigration
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/tenantcluster"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	Name = "configmapmigrationv21"
+)
+
+type Config struct {
+	GetClusterConfigFunc     func(obj interface{}) (v1alpha1.ClusterGuestConfig, error)
+	GetClusterObjectMetaFunc func(obj interface{}) (metav1.ObjectMeta, error)
+	K8sClient                kubernetes.Interface
+	Logger                   micrologger.Logger
+	Tenant                   tenantcluster.Interface
+
+	Provider string
+}
+
+type Resource struct {
+	getClusterConfigFunc     func(obj interface{}) (v1alpha1.ClusterGuestConfig, error)
+	getClusterObjectMetaFunc func(obj interface{}) (metav1.ObjectMeta, error)
+	k8sClient                kubernetes.Interface
+	logger                   micrologger.Logger
+	tenant                   tenantcluster.Interface
+
+	provider string
+}
+
+func New(config Config) (*Resource, error) {
+	if config.GetClusterConfigFunc == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.GetClusterConfigFunc must not be empty", config)
+	}
+	if config.GetClusterObjectMetaFunc == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.GetClusterObjectMetaFunc must not be empty", config)
+	}
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Tenant == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Tenant must not be empty", config)
+	}
+
+	if config.Provider == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Provider must not be empty", config)
+	}
+
+	r := &Resource{
+		getClusterConfigFunc:     config.GetClusterConfigFunc,
+		getClusterObjectMetaFunc: config.GetClusterObjectMetaFunc,
+		k8sClient:                config.K8sClient,
+		logger:                   config.Logger,
+		tenant:                   config.Tenant,
+
+		provider: config.Provider,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7181

- This adds the structure for the new `configmapmigration` resource.
- It copies user configmaps from the tenant cluster to the cluster namespace in the control plane.
- This is so we can migrate CoreDNS, cluster-autoscaler and nginx-ingress-controller to app CRs without losing user settings.


