### PR TITLE
Add logic for getting tenant cluster resources

### DIFF
--- a/pkg/v21/resource/configmapmigration/create.go
+++ b/pkg/v21/resource/configmapmigration/create.go
@@ -2,11 +2,17 @@ package configmapmigration
 
 import (
 	"context"
+	"fmt"
+	"time"
 
+	"github.com/giantswarm/errors/tenant"
 	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/giantswarm/cluster-operator/pkg/label"
+	"github.com/giantswarm/cluster-operator/pkg/project"
 	"github.com/giantswarm/cluster-operator/pkg/v21/key"
 	awskey "github.com/giantswarm/cluster-operator/service/controller/aws/v21/key"
 	azurekey "github.com/giantswarm/cluster-operator/service/controller/azure/v21/key"
@@ -44,6 +50,67 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	// Get all configmaps in the cluster namespace.
 	_, err = r.k8sClient.CoreV1().ConfigMaps(clusterConfig.ID).List(metav1.ListOptions{})
 	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	tenantAPIDomain, err := key.APIDomain(clusterConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	tenantG8sClient, err := r.tenant.NewG8sClient(ctx, clusterConfig.ID, tenantAPIDomain)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	tenantK8sClient, err := r.tenant.NewK8sClient(ctx, clusterConfig.ID, tenantAPIDomain)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	listOptions := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", label.ManagedBy, project.Name()),
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	// Get all chartconfig CRs in the tenant cluster. The migration needs to
+	// complete before we create app CRs. So we cancel the entire loop on error.
+	_, err = tenantG8sClient.CoreV1alpha1().ChartConfigs("giantswarm").List(listOptions)
+	if tenant.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available yet")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		return nil
+	} else if isChartConfigNotInstalled(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "chartconfig CRD does not exist")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		return nil
+	} else if ctx.Err() == context.DeadlineExceeded {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "timeout getting chartconfig CRs")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Get all configmaps in kube-system in the tenant cluster. The migration needs to
+	// complete before we create app CRs. So we cancel the entire loop on error.
+	_, err = tenantK8sClient.CoreV1().ConfigMaps(metav1.NamespaceSystem).List(listOptions)
+	if tenant.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available yet")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		return nil
+	} else if ctx.Err() == context.DeadlineExceeded {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "timeout getting chartconfig CRs")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		return nil
+	} else if err != nil {
 		return microerror.Mask(err)
 	}
 

--- a/pkg/v21/resource/configmapmigration/error_internal.go
+++ b/pkg/v21/resource/configmapmigration/error_internal.go
@@ -1,0 +1,21 @@
+package configmapmigration
+
+import (
+	"strings"
+
+	"github.com/giantswarm/microerror"
+)
+
+const (
+	errorText = "the server could not find the requested resource (get chartconfigs.core.giantswarm.io)"
+)
+
+func isChartConfigNotInstalled(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	c := microerror.Cause(err)
+
+	return strings.Contains(c.Error(), errorText)
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7181

For the migration logic we need to get the chartconfig CRs from the tenant cluster and the configmaps from the kube-system namespace.

This is so we can copy the user values configmap from the tenant cluster to the cluster namespace. The error handling is tricky because we want to copy any user settings before we create app CRs.
