### PR TITLE
Use clients from controller context in chartconfig service

### DIFF
--- a/pkg/v21/chartconfig/create_test.go
+++ b/pkg/v21/chartconfig/create_test.go
@@ -148,7 +148,6 @@ func Test_ChartConfig_newCreateChange(t *testing.T) {
 
 	c := Config{
 		Logger: microloggertest.New(),
-		Tenant: &tenantMock{},
 
 		Provider: "aws",
 	}

--- a/pkg/v21/chartconfig/current.go
+++ b/pkg/v21/chartconfig/current.go
@@ -21,6 +21,15 @@ func (c *ChartConfig) GetCurrentState(ctx context.Context, clusterConfig Cluster
 		return nil, microerror.Mask(err)
 	}
 
+	{
+		if cc.Client.TenantCluster.G8s == nil {
+			c.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster clients not available")
+			c.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+			resourcecanceledcontext.SetCanceled(ctx)
+			return nil, nil
+		}
+	}
+
 	c.logger.LogCtx(ctx, "level", "debug", "message", "looking for chartconfigs in the tenant cluster")
 
 	listOptions := metav1.ListOptions{

--- a/pkg/v21/chartconfig/delete.go
+++ b/pkg/v21/chartconfig/delete.go
@@ -9,19 +9,21 @@ import (
 	"github.com/giantswarm/operatorkit/controller"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/cluster-operator/pkg/v21/controllercontext"
 )
 
 func (c *ChartConfig) ApplyDeleteChange(ctx context.Context, clusterConfig ClusterConfig, chartConfigsToDelete []*v1alpha1.ChartConfig) error {
 	if len(chartConfigsToDelete) > 0 {
-		c.logger.LogCtx(ctx, "level", "debug", "message", "deleting chartconfigs")
-
-		tenantG8sClient, err := c.newTenantG8sClient(ctx, clusterConfig)
+		cc, err := controllercontext.FromContext(ctx)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
+		c.logger.LogCtx(ctx, "level", "debug", "message", "deleting chartconfigs")
+
 		for _, chartConfig := range chartConfigsToDelete {
-			err := tenantG8sClient.CoreV1alpha1().ChartConfigs(resourceNamespace).Delete(chartConfig.Name, &metav1.DeleteOptions{})
+			err := cc.Client.TenantCluster.G8s.CoreV1alpha1().ChartConfigs(resourceNamespace).Delete(chartConfig.Name, &metav1.DeleteOptions{})
 			if apierrors.IsNotFound(err) {
 				// fall through
 			} else if err != nil {

--- a/pkg/v21/chartconfig/delete_test.go
+++ b/pkg/v21/chartconfig/delete_test.go
@@ -103,7 +103,6 @@ func Test_ChartConfig_newDeleteChangeForUpdatePatch(t *testing.T) {
 
 	c := Config{
 		Logger: microloggertest.New(),
-		Tenant: &tenantMock{},
 
 		Provider: "aws",
 	}

--- a/pkg/v21/chartconfig/desired.go
+++ b/pkg/v21/chartconfig/desired.go
@@ -13,6 +13,7 @@ import (
 	"github.com/giantswarm/cluster-operator/pkg/annotation"
 	"github.com/giantswarm/cluster-operator/pkg/label"
 	"github.com/giantswarm/cluster-operator/pkg/project"
+	"github.com/giantswarm/cluster-operator/pkg/v21/controllercontext"
 	"github.com/giantswarm/cluster-operator/pkg/v21/key"
 )
 
@@ -95,12 +96,12 @@ func (c *ChartConfig) newConfigMapSpec(ctx context.Context, clusterConfig Cluste
 		return &v1alpha1.ChartConfigSpecConfigMap{}, nil
 	}
 
-	tenantK8sClient, err := c.newTenantK8sClient(ctx, clusterConfig)
+	cc, err := controllercontext.FromContext(ctx)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	configMap, err := tenantK8sClient.CoreV1().ConfigMaps(configMapNamespace).Get(configMapName, metav1.GetOptions{})
+	configMap, err := cc.Client.TenantCluster.K8s.CoreV1().ConfigMaps(configMapNamespace).Get(configMapName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) || tenant.IsAPINotAvailable(err) {
 		// Cannot get configmap resource version so leave it unset. We will
 		// check again after the next resync period.

--- a/pkg/v21/chartconfig/desired_test.go
+++ b/pkg/v21/chartconfig/desired_test.go
@@ -13,6 +13,7 @@ import (
 	clientgofake "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/giantswarm/cluster-operator/pkg/label"
+	"github.com/giantswarm/cluster-operator/pkg/v21/controllercontext"
 	"github.com/giantswarm/cluster-operator/pkg/v21/key"
 )
 
@@ -96,13 +97,8 @@ func Test_ChartConfig_GetDesiredState(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			fakeTenantK8sClient := clientgofake.NewSimpleClientset()
-
 			c := Config{
 				Logger: microloggertest.New(),
-				Tenant: &tenantMock{
-					fakeTenantK8sClient: fakeTenantK8sClient,
-				},
 
 				Provider: "aws",
 			}
@@ -111,7 +107,19 @@ func Test_ChartConfig_GetDesiredState(t *testing.T) {
 				t.Fatal("expected", nil, "got", err)
 			}
 
-			chartConfigs, err := cc.GetDesiredState(context.TODO(), tc.clusterConfig, tc.providerChartSpecs)
+			var ctx context.Context
+			{
+				c := controllercontext.Context{
+					Client: controllercontext.ContextClient{
+						TenantCluster: controllercontext.ContextClientTenantCluster{
+							K8s: clientgofake.NewSimpleClientset(),
+						},
+					},
+				}
+				ctx = controllercontext.NewContext(context.Background(), c)
+			}
+
+			chartConfigs, err := cc.GetDesiredState(ctx, tc.clusterConfig, tc.providerChartSpecs)
 			if err != nil {
 				t.Fatal("expected", nil, "got", err)
 			}
@@ -253,13 +261,8 @@ func Test_ChartConfig_newChartConfig(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			fakeTenantK8sClient := clientgofake.NewSimpleClientset()
-
 			c := Config{
 				Logger: microloggertest.New(),
-				Tenant: &tenantMock{
-					fakeTenantK8sClient: fakeTenantK8sClient,
-				},
 
 				Provider: "aws",
 			}
@@ -268,7 +271,19 @@ func Test_ChartConfig_newChartConfig(t *testing.T) {
 				t.Fatal("expected", nil, "got", err)
 			}
 
-			result, err := cc.newChartConfig(context.TODO(), tc.clusterConfig, tc.chartSpec)
+			var ctx context.Context
+			{
+				c := controllercontext.Context{
+					Client: controllercontext.ContextClient{
+						TenantCluster: controllercontext.ContextClientTenantCluster{
+							K8s: clientgofake.NewSimpleClientset(),
+						},
+					},
+				}
+				ctx = controllercontext.NewContext(context.Background(), c)
+			}
+
+			result, err := cc.newChartConfig(ctx, tc.clusterConfig, tc.chartSpec)
 			if err != nil {
 				t.Fatalf("expected nil, got %#v", err)
 			}
@@ -426,13 +441,8 @@ func Test_ChartConfig_newConfigMapSpec(t *testing.T) {
 				objs = append(objs, cm)
 			}
 
-			fakeTenantK8sClient := clientgofake.NewSimpleClientset(objs...)
-
 			c := Config{
 				Logger: microloggertest.New(),
-				Tenant: &tenantMock{
-					fakeTenantK8sClient: fakeTenantK8sClient,
-				},
 
 				Provider: "aws",
 			}
@@ -441,7 +451,19 @@ func Test_ChartConfig_newConfigMapSpec(t *testing.T) {
 				t.Fatal("expected", nil, "got", err)
 			}
 
-			result, err := cc.newConfigMapSpec(context.TODO(), tc.clusterConfig, tc.configMapName, tc.namespace)
+			var ctx context.Context
+			{
+				c := controllercontext.Context{
+					Client: controllercontext.ContextClient{
+						TenantCluster: controllercontext.ContextClientTenantCluster{
+							K8s: clientgofake.NewSimpleClientset(objs...),
+						},
+					},
+				}
+				ctx = controllercontext.NewContext(context.Background(), c)
+			}
+
+			result, err := cc.newConfigMapSpec(ctx, tc.clusterConfig, tc.configMapName, tc.namespace)
 			if err != nil {
 				t.Fatalf("expected nil, got %#v", err)
 			}

--- a/pkg/v21/chartconfig/update.go
+++ b/pkg/v21/chartconfig/update.go
@@ -7,19 +7,21 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller"
+
+	"github.com/giantswarm/cluster-operator/pkg/v21/controllercontext"
 )
 
 func (c *ChartConfig) ApplyUpdateChange(ctx context.Context, clusterConfig ClusterConfig, chartConfigsToUpdate []*v1alpha1.ChartConfig) error {
 	if len(chartConfigsToUpdate) > 0 {
-		c.logger.LogCtx(ctx, "level", "debug", "message", "updating chartconfigs")
-
-		tenantG8sClient, err := c.newTenantG8sClient(ctx, clusterConfig)
+		cc, err := controllercontext.FromContext(ctx)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
+		c.logger.LogCtx(ctx, "level", "debug", "message", "updating chartconfigs")
+
 		for _, chartConfigToUpdate := range chartConfigsToUpdate {
-			_, err := tenantG8sClient.CoreV1alpha1().ChartConfigs(resourceNamespace).Update(chartConfigToUpdate)
+			_, err := cc.Client.TenantCluster.G8s.CoreV1alpha1().ChartConfigs(resourceNamespace).Update(chartConfigToUpdate)
 			if err != nil {
 				return microerror.Mask(err)
 			}

--- a/pkg/v21/chartconfig/update_test.go
+++ b/pkg/v21/chartconfig/update_test.go
@@ -251,7 +251,6 @@ func Test_ChartConfig_newUpdateChange(t *testing.T) {
 
 	c := Config{
 		Logger: microloggertest.New(),
-		Tenant: &tenantMock{},
 
 		Provider: "aws",
 	}

--- a/service/controller/aws/v21/resource_set.go
+++ b/service/controller/aws/v21/resource_set.go
@@ -221,7 +221,6 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	{
 		c := chartconfigservice.Config{
 			Logger: config.Logger,
-			Tenant: config.Tenant,
 
 			Provider: config.Provider,
 		}

--- a/service/controller/azure/v21/resource_set.go
+++ b/service/controller/azure/v21/resource_set.go
@@ -218,7 +218,6 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	{
 		c := chartconfigservice.Config{
 			Logger: config.Logger,
-			Tenant: config.Tenant,
 
 			Provider: config.Provider,
 		}

--- a/service/controller/kvm/v21/resource_set.go
+++ b/service/controller/kvm/v21/resource_set.go
@@ -217,7 +217,6 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	{
 		c := chartconfigservice.Config{
 			Logger: config.Logger,
-			Tenant: config.Tenant,
 
 			Provider: config.Provider,
 		}


### PR DESCRIPTION
Using the clients from the controller context in the chartconfig service. I'll do another PR for the configmap service which is the last package affected.