### PR TITLE
Copy user configmap from tenant cluster to control plane

### DIFF
--- a/pkg/v21/resource/appmigration/create.go
+++ b/pkg/v21/resource/appmigration/create.go
@@ -59,6 +59,13 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	if cc.Client.TenantCluster.G8s == nil {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant clients not available")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+		return nil
+	}
+
 	listOptions := metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s", label.ManagedBy, project.Name()),
 	}

--- a/pkg/v21/resource/configmapmigration/create.go
+++ b/pkg/v21/resource/configmapmigration/create.go
@@ -59,6 +59,13 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	if cc.Client.TenantCluster.G8s == nil {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant clients not available")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		return nil
+	}
+
 	listOptions := metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s", label.ManagedBy, project.Name()),
 	}

--- a/pkg/v21/resource/configmapmigration/create.go
+++ b/pkg/v21/resource/configmapmigration/create.go
@@ -53,11 +53,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	// Get all configmaps in the cluster namespace.
-<<<<<<< HEAD
 	clusterConfigMaps, err := r.k8sClient.CoreV1().ConfigMaps(key.ClusterID(cr)).List(metav1.ListOptions{})
-=======
-	_, err = r.k8sClient.CoreV1().ConfigMaps(key.ClusterID(cr)).List(metav1.ListOptions{})
->>>>>>> master
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/v21/resource/configmapmigration/create.go
+++ b/pkg/v21/resource/configmapmigration/create.go
@@ -43,13 +43,13 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return nil
 	}
 
-	clusterConfig, err := r.getClusterConfigFunc(obj)
+	cr, err := r.getClusterConfigFunc(obj)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
 	// Get all configmaps in the cluster namespace.
-	_, err = r.k8sClient.CoreV1().ConfigMaps(clusterConfig.ID).List(metav1.ListOptions{})
+	clusterConfigMaps, err := r.k8sClient.CoreV1().ConfigMaps(key.ClusterID(cr)).List(metav1.ListOptions{})
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/v21/resource/configmapmigration/error.go
+++ b/pkg/v21/resource/configmapmigration/error.go
@@ -12,3 +12,12 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfigError(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}

--- a/pkg/v21/resource/configmapmigration/resource.go
+++ b/pkg/v21/resource/configmapmigration/resource.go
@@ -4,6 +4,7 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -62,4 +63,14 @@ func New(config Config) (*Resource, error) {
 
 func (r *Resource) Name() string {
 	return Name
+}
+
+func getConfigMapByName(list []corev1.ConfigMap, name string) (corev1.ConfigMap, error) {
+	for _, l := range list {
+		if l.Name == name {
+			return l, nil
+		}
+	}
+
+	return corev1.ConfigMap{}, microerror.Mask(notFoundError)
 }

--- a/pkg/v21/resource/configmapmigration/resource.go
+++ b/pkg/v21/resource/configmapmigration/resource.go
@@ -4,7 +4,6 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"github.com/giantswarm/tenantcluster"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -18,7 +17,6 @@ type Config struct {
 	GetClusterObjectMetaFunc func(obj interface{}) (metav1.ObjectMeta, error)
 	K8sClient                kubernetes.Interface
 	Logger                   micrologger.Logger
-	Tenant                   tenantcluster.Interface
 
 	Provider string
 }
@@ -28,7 +26,6 @@ type Resource struct {
 	getClusterObjectMetaFunc func(obj interface{}) (metav1.ObjectMeta, error)
 	k8sClient                kubernetes.Interface
 	logger                   micrologger.Logger
-	tenant                   tenantcluster.Interface
 
 	provider string
 }
@@ -46,9 +43,6 @@ func New(config Config) (*Resource, error) {
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
-	if config.Tenant == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Tenant must not be empty", config)
-	}
 
 	if config.Provider == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Provider must not be empty", config)
@@ -59,7 +53,6 @@ func New(config Config) (*Resource, error) {
 		getClusterObjectMetaFunc: config.GetClusterObjectMetaFunc,
 		k8sClient:                config.K8sClient,
 		logger:                   config.Logger,
-		tenant:                   config.Tenant,
 
 		provider: config.Provider,
 	}

--- a/pkg/v21/resource/configmapmigration/resource.go
+++ b/pkg/v21/resource/configmapmigration/resource.go
@@ -4,10 +4,7 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-<<<<<<< HEAD
 	corev1 "k8s.io/api/core/v1"
-=======
->>>>>>> master
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7181

Next part of the migration process that copies the user settings from the tenant cluster to the control plane.