### PR TITLE
drop tenant clients from controller context on delete events

### DIFF
--- a/service/controller/clusterapi/v22/resource/tenantclients/delete.go
+++ b/service/controller/clusterapi/v22/resource/tenantclients/delete.go
@@ -2,15 +2,13 @@ package tenantclients
 
 import (
 	"context"
-
-	"github.com/giantswarm/microerror"
 )
 
+// EnsureDeleted is not putting the tenant clients into the controller context
+// because we do not want to interact with the Tenant Cluster API on delete
+// events. This is to reduce eventual friction. Cluster deletion should not be
+// affected only because the Tenant Cluster API is not available for some
+// reason. Other resources must not rely on tenant clients on delete events.
 func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
-	err := r.ensure(ctx, obj)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
 	return nil
 }


### PR DESCRIPTION
Discussed this with @rossf7. Team Batman should merge this when they sorted the `clusterapi` controller. Precondition here is that `chartconfig` and `configmap` resource implementations are removed. This is part of the App CR migration process. It would be awesome if we could get this done before releasing Node Pools. Not a blocker though. 