### PR TITLE
Delete configmaps once migration to app CRs is complete

### DIFF
--- a/pkg/v21/resource/configmapmigration/resource.go
+++ b/pkg/v21/resource/configmapmigration/resource.go
@@ -65,6 +65,16 @@ func (r *Resource) Name() string {
 	return Name
 }
 
+func getChartConfigByName(list []v1alpha1.ChartConfig, name string) (v1alpha1.ChartConfig, error) {
+	for _, l := range list {
+		if l.Name == name {
+			return l, nil
+		}
+	}
+
+	return v1alpha1.ChartConfig{}, microerror.Mask(notFoundError)
+}
+
 func getConfigMapByName(list []corev1.ConfigMap, name string) (corev1.ConfigMap, error) {
 	for _, l := range list {
 		if l.Name == name {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7181

Spec PR: https://github.com/giantswarm/giantswarm/pull/7204/files

Last part of the migration resource logic to delete the old configmaps once the migration is complete. Next PR will wire the resource and add the new apps.