### PR TITLE
Add clusterID to cluster configmap

### DIFF
--- a/pkg/v21/resource/clusterconfigmap/desired.go
+++ b/pkg/v21/resource/clusterconfigmap/desired.go
@@ -30,6 +30,7 @@ func (r *StateGetter) GetDesiredState(ctx context.Context, obj interface{}) ([]*
 	values := map[string]string{
 		"baseDomain":   key.DNSZone(clusterConfig),
 		"clusterDNSIP": clusterDNSIP,
+		"clusterID":    key.ClusterID(clusterConfig),
 	}
 
 	yamlValues, err := yaml.Marshal(values)

--- a/pkg/v21/resource/clusterconfigmap/desired_test.go
+++ b/pkg/v21/resource/clusterconfigmap/desired_test.go
@@ -47,7 +47,7 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 					},
 				},
 				Data: map[string]string{
-					"values": "baseDomain: giantswarm.io\nclusterDNSIP: 172.31.0.10\n",
+					"values": "baseDomain: giantswarm.io\nclusterDNSIP: 172.31.0.10\nclusterID: w7utg\n",
 				},
 			},
 		},

--- a/service/controller/clusterapi/v21/resource/clusterconfigmap/desired.go
+++ b/service/controller/clusterapi/v21/resource/clusterconfigmap/desired.go
@@ -24,6 +24,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 		v := map[string]string{
 			"baseDomain":   key.ClusterBaseDomain(cr),
 			"clusterDNSIP": r.dnsIP,
+			"clusterID":    key.ClusterID(&cr),
 		}
 
 		b, err := yaml.Marshal(v)


### PR DESCRIPTION
Adds clusterID to the configmap we generate for each tenant cluster. First usage of this is for IAM roles with KIAM.

I do have a worry about naming collisions with values from community changes. Maybe we need more structure here? Uncertain.