### PR TITLE
Push cluster-operator image to aliyun on merge to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
-version: 2
+version: 2.1
+orbs:
+  architect: giantswarm/architect@0.4.3
+
 jobs:
   build:
     machine: true
@@ -12,8 +15,37 @@ jobs:
     - run: ./architect build
     - store_test_results:
         path: /tmp/results
+    - persist_to_workspace:
+        root: .
+        paths:
+        - ./cluster-operator
     - deploy:
         command: |
           if [ "${CIRCLE_BRANCH}" == "master" ]; then
             ./architect deploy
           fi
+
+workflows:
+  build_and_push:
+    jobs:
+      - build
+
+      - architect/push-to-docker:
+          name: push-cluster-operator-to-quay
+          image: "quay.io/giantswarm/cluster-operator"
+          username_envar: "QUAY_USERNAME"
+          password_envar: "QUAY_PASSWORD"
+          requires:
+            - build
+
+      - architect/push-to-docker:
+          name: push-cluster-operator-to-aliyun
+          image: "registry-intl.cn-shanghai.aliyuncs.com/giantswarm/cluster-operator"
+          username_envar: "ALIYUN_USERNAME"
+          password_envar: "ALIYUN_PASSWORD"
+          requires:
+            - build
+          # Needed to trigger job only on merge to master.
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
Towards giantswarm/giantswarm#7029

This PR enables one to manually deploy (pull) same image from alibaba cloud image registry instead of quay. Flattening, appifying, automating the operator deployment to make use of "local" image registry will be done separately.