### PR TITLE
Push PR branches to Aliyun on manual approval

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,31 @@ workflows:
           requires:
             - build
 
+      - hold-push-cluster-operator-to-aliyun-pr:
+          type: approval
+          requires:
+            - build
+          # Needed to prevent job from being triggered on master branch.
+          filters:
+            branches:
+              ignore: master
+
       - architect/push-to-docker:
-          name: push-cluster-operator-to-aliyun
+          name: push-cluster-operator-to-aliyun-pr
+          image: "registry-intl.cn-shanghai.aliyuncs.com/giantswarm/cluster-operator"
+          username_envar: "ALIYUN_USERNAME"
+          password_envar: "ALIYUN_PASSWORD"
+          # Push to Aliyun should execute for non-master branches only once manually approved.
+          requires:
+            - hold-push-cluster-operator-to-aliyun-pr
+          # Needed to prevent job from being triggered on master branch.
+          filters:
+            branches:
+              ignore: master
+
+      # Push to Aliyun should execute without manual approval on master.
+      - architect/push-to-docker:
+          name: push-cluster-operator-to-aliyun-master
           image: "registry-intl.cn-shanghai.aliyuncs.com/giantswarm/cluster-operator"
           username_envar: "ALIYUN_USERNAME"
           password_envar: "ALIYUN_PASSWORD"


### PR DESCRIPTION
Towards giantswarm/giantswarm#7029

This PR as followup to https://github.com/giantswarm/cluster-operator/pull/733 adds support for publishing cluster-operator images to Aliyun for non-master branches too to support testing cluster-operator in China more easily with improved image pull times compared to Quay, and only upon manual approval.
