### PR TITLE
Fixes for configmap migration logic

### DIFF
--- a/pkg/v21/configmap/configmap.go
+++ b/pkg/v21/configmap/configmap.go
@@ -68,9 +68,9 @@ func (s *Service) newChartSpecs() []key.ChartSpec {
 	}
 }
 
-func (s *Service) getChartSpecByName(name string) key.ChartSpec {
+func (s *Service) getChartSpecByAppName(appName string) key.ChartSpec {
 	for _, spec := range s.newChartSpecs() {
-		if spec.ChartName == name {
+		if spec.AppName == appName {
 			return spec
 		}
 	}

--- a/pkg/v21/configmap/create.go
+++ b/pkg/v21/configmap/create.go
@@ -44,7 +44,7 @@ func (s *Service) newCreateChange(ctx context.Context, currentConfigMaps, desire
 
 	for _, desiredConfigMap := range desiredConfigMaps {
 		appName := desiredConfigMap.Labels[label.App]
-		chartSpec := s.getChartSpecByName(appName)
+		chartSpec := s.getChartSpecByAppName(appName)
 		if chartSpec.HasAppCR {
 			continue
 		}

--- a/pkg/v21/resource/appmigration/create.go
+++ b/pkg/v21/resource/appmigration/create.go
@@ -125,7 +125,8 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 		appCR, err := r.g8sClient.ApplicationV1alpha1().Apps(key.ClusterID(cr)).Get(chartSpec.AppName, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
-			return microerror.Maskf(notFoundError, "app CR %#q", chartSpec.AppName)
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("app CR %#q does not exist yet, continuing", chartSpec.AppName))
+			continue
 		}
 
 		if appCR.Status.Release.Status == "DEPLOYED" {

--- a/pkg/v21/resource/appmigration/create.go
+++ b/pkg/v21/resource/appmigration/create.go
@@ -121,7 +121,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("chartconfig CR %#q is already cordoned", chartSpec.ChartName))
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding out app CR %#q is deployed", chartSpec.AppName))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding out if app CR %#q is deployed", chartSpec.AppName))
 
 		appCR, err := r.g8sClient.ApplicationV1alpha1().Apps(key.ClusterID(cr)).Get(chartSpec.AppName, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {

--- a/pkg/v21/resource/configmapmigration/create.go
+++ b/pkg/v21/resource/configmapmigration/create.go
@@ -9,7 +9,6 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/errors/tenant"
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	yaml "gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
@@ -66,8 +65,8 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 	if cc.Client.TenantCluster.G8s == nil {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant clients not available")
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
-		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
 		return nil
 	}
 
@@ -83,21 +82,21 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	chartConfigs, err := cc.Client.TenantCluster.G8s.CoreV1alpha1().ChartConfigs("giantswarm").List(listOptions)
 	if tenant.IsAPINotAvailable(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available yet")
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
-		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
 		return nil
 	} else if isChartConfigNotInstalled(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "chartconfig CRD does not exist")
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
-		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
 		return nil
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "timeout getting chartconfig CRs")
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
-		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
 		return nil
 	}
 
@@ -106,16 +105,16 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	tenantConfigMaps, err := cc.Client.TenantCluster.K8s.CoreV1().ConfigMaps(metav1.NamespaceSystem).List(listOptions)
 	if tenant.IsAPINotAvailable(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available yet")
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
-		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
 		return nil
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "timeout getting chartconfig CRs")
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
-		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
 		return nil
 	}
 


### PR DESCRIPTION
Towards giantswarm/giantswarm#7181

Breaking down https://github.com/giantswarm/cluster-operator/pull/735 because the diff is a bit wild. 

These are all fixes to the migration process but the new configmapmigration resource is not wired yet.