### PR TITLE
Migrate coredns and cluster-autoscaler to app CRs

### DIFF
--- a/pkg/v21/key/key.go
+++ b/pkg/v21/key/key.go
@@ -92,6 +92,15 @@ func CommonAppSpecs() []AppSpec {
 			Version:         "0.10.8",
 		},
 		{
+			App:       "coredns",
+			Catalog:   "default",
+			Chart:     "coredns-app",
+			Namespace: metav1.NamespaceSystem,
+			// Upgrade force is disabled to avoid affecting customer workloads.
+			UseUpgradeForce: false,
+			Version:         "0.8.0",
+		},
+		{
 			App:             "kube-state-metrics",
 			Catalog:         "default",
 			Chart:           "kube-state-metrics-app",
@@ -128,7 +137,7 @@ func CommonChartSpecs() []ChartSpec {
 			ChannelName:   "0-8-stable",
 			ChartName:     "kubernetes-coredns-chart",
 			ConfigMapName: "coredns-values",
-			HasAppCR:      false,
+			HasAppCR:      true,
 			Namespace:     metav1.NamespaceSystem,
 			ReleaseName:   "coredns",
 			// Upgrade force is disabled to avoid affecting customer workloads.

--- a/service/controller/aws/v21/key/key.go
+++ b/service/controller/aws/v21/key/key.go
@@ -11,7 +11,16 @@ import (
 // AppSpecs returns apps installed only for AWS.
 func AppSpecs() []key.AppSpec {
 	// Add any provider specific charts here.
-	return []key.AppSpec{}
+	return []key.AppSpec{
+		{
+			App:             "cluster-autoscaler",
+			Catalog:         "default",
+			Chart:           "cluster-autoscaler-app",
+			Namespace:       metav1.NamespaceSystem,
+			UseUpgradeForce: true,
+			Version:         "0.10.0",
+		},
+	}
 }
 
 // ChartSpecs returns charts installed only for AWS.
@@ -23,6 +32,7 @@ func ChartSpecs() []key.ChartSpec {
 			ChannelName:       "0-9-stable",
 			ChartName:         "kubernetes-cluster-autoscaler-chart",
 			ConfigMapName:     "cluster-autoscaler-values",
+			HasAppCR:          true,
 			Namespace:         metav1.NamespaceSystem,
 			ReleaseName:       "cluster-autoscaler",
 			UseUpgradeForce:   true,

--- a/service/controller/aws/v21/version_bundle.go
+++ b/service/controller/aws/v21/version_bundle.go
@@ -8,6 +8,16 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
+				Component:   "cluster-autoscaler",
+				Description: "Migrated to use default app catalog.",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "coredns",
+				Description: "Migrated to use default app catalog.",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
 				Component:   "kube-state-metrics",
 				Description: "Migrated to use default app catalog.",
 				Kind:        versionbundle.KindChanged,

--- a/service/controller/azure/v21/version_bundle.go
+++ b/service/controller/azure/v21/version_bundle.go
@@ -8,6 +8,11 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
+				Component:   "coredns",
+				Description: "Migrated to use default app catalog.",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
 				Component:   "kube-state-metrics",
 				Description: "Migrated to use default app catalog.",
 				Kind:        versionbundle.KindChanged,

--- a/service/controller/kvm/v21/version_bundle.go
+++ b/service/controller/kvm/v21/version_bundle.go
@@ -8,6 +8,11 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
+				Component:   "coredns",
+				Description: "Migrated to use default app catalog.",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
 				Component:   "kube-state-metrics",
 				Description: "Migrated to use default app catalog.",
 				Kind:        versionbundle.KindChanged,


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7181

Migrates coredns and cluster-autoscaler to app CRs installed from the default catalog.

To be merged after https://github.com/giantswarm/cluster-operator/pull/735