### PR TITLE
Fix base domain in cluster configmap

### DIFF
--- a/pkg/v22/key/key.go
+++ b/pkg/v22/key/key.go
@@ -275,6 +275,10 @@ func serverDomain(clusterGuestConfig v1alpha1.ClusterGuestConfig, cert certs.Cer
 	return string(cert) + "." + strings.TrimLeft(commonDomain, "\t ."), nil
 }
 
+func TenantBaseDomain(clusterGuestConfig v1alpha1.ClusterGuestConfig) string {
+	return fmt.Sprintf("%s.k8s.%s", ClusterID(clusterGuestConfig), DNSZone(clusterGuestConfig))
+}
+
 // VersionBundles returns slice of versionbundle.Bundles for given guest
 // cluster config.
 func VersionBundles(clusterGuestConfig v1alpha1.ClusterGuestConfig) []versionbundle.Bundle {

--- a/pkg/v22/resource/clusterconfigmap/desired.go
+++ b/pkg/v22/resource/clusterconfigmap/desired.go
@@ -28,7 +28,7 @@ func (r *StateGetter) GetDesiredState(ctx context.Context, obj interface{}) ([]*
 	}
 
 	values := map[string]string{
-		"baseDomain":   key.DNSZone(clusterConfig),
+		"baseDomain":   key.TenantBaseDomain(clusterConfig),
 		"clusterDNSIP": clusterDNSIP,
 		"clusterID":    key.ClusterID(clusterConfig),
 	}

--- a/pkg/v22/resource/clusterconfigmap/desired_test.go
+++ b/pkg/v22/resource/clusterconfigmap/desired_test.go
@@ -27,7 +27,7 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 				Spec: v1alpha1.AWSClusterConfigSpec{
 					Guest: v1alpha1.AWSClusterConfigSpecGuest{
 						ClusterGuestConfig: v1alpha1.ClusterGuestConfig{
-							DNSZone: "giantswarm.io",
+							DNSZone: "gauss.eu-central-1.aws.gigantic.io",
 							ID:      "w7utg",
 							Name:    "My own snowflake cluster",
 							Owner:   "giantswarm",
@@ -47,7 +47,7 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 					},
 				},
 				Data: map[string]string{
-					"values": "baseDomain: giantswarm.io\nclusterDNSIP: 172.31.0.10\nclusterID: w7utg\n",
+					"values": "baseDomain: w7utg.k8s.gauss.eu-central-1.aws.gigantic.io\nclusterDNSIP: 172.31.0.10\nclusterID: w7utg\n",
 				},
 			},
 		},

--- a/service/controller/clusterapi/v22/key/cluster.go
+++ b/service/controller/clusterapi/v22/key/cluster.go
@@ -48,6 +48,10 @@ func IsProviderSpecForAWS(cluster v1alpha1.Cluster) bool {
 	return err == nil
 }
 
+func TenantBaseDomain(cluster v1alpha1.Cluster) string {
+	return fmt.Sprintf("%s.k8s.%s", ClusterID(&cluster), ClusterBaseDomain(cluster))
+}
+
 func ToCluster(v interface{}) (v1alpha1.Cluster, error) {
 	if v == nil {
 		return v1alpha1.Cluster{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &v1alpha1.Cluster{}, v)

--- a/service/controller/clusterapi/v22/resource/clusterconfigmap/desired.go
+++ b/service/controller/clusterapi/v22/resource/clusterconfigmap/desired.go
@@ -22,7 +22,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 	var configMap *corev1.ConfigMap
 	{
 		v := map[string]string{
-			"baseDomain":   key.ClusterBaseDomain(cr),
+			"baseDomain":   key.TenantBaseDomain(cr),
 			"clusterDNSIP": r.dnsIP,
 			"clusterID":    key.ClusterID(&cr),
 		}


### PR DESCRIPTION
We added the base domain to the cluster configmap we created. This is for use in apps when creating ingress resources.

But it should match the wildcard record we create for tenant clusters.

e.g. `w7utg.k8s.gauss.eu-central-1.aws.gigantic.io`