### PR TITLE
Get tenant configmaps in app resource

### DIFF
--- a/pkg/v22/resource/app/desired.go
+++ b/pkg/v22/resource/app/desired.go
@@ -77,7 +77,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*g8s
 		return nil, microerror.Mask(err)
 	}
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "timeout getting chartconfig CRs")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "timeout getting tenant configmaps")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		resourcecanceledcontext.SetCanceled(ctx)
 		return nil, nil

--- a/pkg/v22/resource/app/desired.go
+++ b/pkg/v22/resource/app/desired.go
@@ -2,18 +2,23 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
+	"time"
 
 	g8sv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/errors/tenant"
 	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/cluster-operator/pkg/annotation"
 	"github.com/giantswarm/cluster-operator/pkg/label"
 	"github.com/giantswarm/cluster-operator/pkg/project"
+	"github.com/giantswarm/cluster-operator/pkg/v22/controllercontext"
 	"github.com/giantswarm/cluster-operator/pkg/v22/key"
 	awskey "github.com/giantswarm/cluster-operator/service/controller/aws/v22/key"
 	azurekey "github.com/giantswarm/cluster-operator/service/controller/azure/v22/key"
@@ -34,6 +39,54 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*g8s
 	secrets, err := r.getSecrets(ctx, clusterConfig)
 	if err != nil {
 		return nil, microerror.Mask(err)
+	}
+
+	// TODO: Remove connection to tenant cluster once all tenant clusters use
+	// app CRs instead of chartconfig CRs.
+	//
+	//	https://github.com/giantswarm/giantswarm/issues/7402
+	//
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	if cc.Client.TenantCluster.G8s == nil {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant clients not available")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+		return nil, nil
+	}
+
+	listOptions := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", label.ManagedBy, project.Name()),
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	// Get all configmaps in kube-system in the tenant cluster to ensure user
+	// configmaps have been migrated.
+	list, err := cc.Client.TenantCluster.K8s.CoreV1().ConfigMaps(metav1.NamespaceSystem).List(listOptions)
+	if tenant.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available yet")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+		return nil, nil
+	} else if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "timeout getting chartconfig CRs")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+		return nil, nil
+	}
+
+	tenantConfigMaps := map[string]corev1.ConfigMap{}
+
+	for _, cm := range list.Items {
+		tenantConfigMaps[cm.Name] = cm
 	}
 
 	var apps []*g8sv1alpha1.App


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7181

For the 3 apps with user settings (coredns, cluster-autoscale & nginx-ingress-controller). We need to copy these before creating app CRs for them.

This is prep for adding that check. So we get all tenant configmaps in `kube-system`.
