### PR TITLE
Delay creation of app CR when user values not migrated

### DIFF
--- a/pkg/v22/resource/app/desired.go
+++ b/pkg/v22/resource/app/desired.go
@@ -77,7 +77,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*g8s
 		return nil, microerror.Mask(err)
 	}
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "timeout getting chartconfig CRs")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "timeout getting tenant configmaps")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		resourcecanceledcontext.SetCanceled(ctx)
 		return nil, nil

--- a/pkg/v22/resource/app/desired.go
+++ b/pkg/v22/resource/app/desired.go
@@ -2,18 +2,23 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
+	"time"
 
 	g8sv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/errors/tenant"
 	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/cluster-operator/pkg/annotation"
 	"github.com/giantswarm/cluster-operator/pkg/label"
 	"github.com/giantswarm/cluster-operator/pkg/project"
+	"github.com/giantswarm/cluster-operator/pkg/v22/controllercontext"
 	"github.com/giantswarm/cluster-operator/pkg/v22/key"
 	awskey "github.com/giantswarm/cluster-operator/service/controller/aws/v22/key"
 	azurekey "github.com/giantswarm/cluster-operator/service/controller/azure/v22/key"
@@ -34,6 +39,54 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*g8s
 	secrets, err := r.getSecrets(ctx, clusterConfig)
 	if err != nil {
 		return nil, microerror.Mask(err)
+	}
+
+	// TODO: Remove connection to tenant cluster once all tenant clusters use
+	// app CRs instead of chartconfig CRs.
+	//
+	//	https://github.com/giantswarm/giantswarm/issues/7402
+	//
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	if cc.Client.TenantCluster.G8s == nil {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant clients not available")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+		return nil, nil
+	}
+
+	listOptions := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", label.ManagedBy, project.Name()),
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	// Get all configmaps in kube-system in the tenant cluster to ensure user
+	// configmaps have been migrated.
+	list, err := cc.Client.TenantCluster.K8s.CoreV1().ConfigMaps(metav1.NamespaceSystem).List(listOptions)
+	if tenant.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available yet")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+		return nil, nil
+	} else if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "timeout getting chartconfig CRs")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+		return nil, nil
+	}
+
+	tenantConfigMaps := map[string]corev1.ConfigMap{}
+
+	for _, cm := range list.Items {
+		tenantConfigMaps[cm.Name] = cm
 	}
 
 	var apps []*g8sv1alpha1.App

--- a/pkg/v22/resource/app/desired.go
+++ b/pkg/v22/resource/app/desired.go
@@ -94,7 +94,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*g8s
 	for _, appSpec := range r.newAppSpecs() {
 		userConfig, err := newUserConfig(clusterConfig, appSpec, configMaps, tenantConfigMaps, secrets)
 		if IsNotMigratedError(err) {
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("app %#q not migrated yet, continuing", appSpec.App))
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("app %#q user values not migrated yet, continuing", appSpec.App))
 			continue
 		} else if err != nil {
 			return nil, microerror.Mask(err)

--- a/pkg/v22/resource/app/desired.go
+++ b/pkg/v22/resource/app/desired.go
@@ -92,7 +92,14 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*g8s
 	var apps []*g8sv1alpha1.App
 
 	for _, appSpec := range r.newAppSpecs() {
-		userConfig := newUserConfig(clusterConfig, appSpec, configMaps, secrets)
+		userConfig, err := newUserConfig(clusterConfig, appSpec, configMaps, tenantConfigMaps, secrets)
+		if IsNotMigratedError(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("app %#q not migrated yet, continuing", appSpec.App))
+			continue
+		} else if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
 		apps = append(apps, r.newApp(clusterConfig, appSpec, userConfig))
 	}
 
@@ -200,11 +207,20 @@ func (r *Resource) newAppSpecs() []key.AppSpec {
 	}
 }
 
-func newUserConfig(clusterConfig v1alpha1.ClusterGuestConfig, appSpec key.AppSpec, configMaps map[string]corev1.ConfigMap, secrets map[string]corev1.Secret) g8sv1alpha1.AppSpecUserConfig {
+func newUserConfig(clusterConfig v1alpha1.ClusterGuestConfig, appSpec key.AppSpec, configMaps, tenantConfigMaps map[string]corev1.ConfigMap, secrets map[string]corev1.Secret) (g8sv1alpha1.AppSpecUserConfig, error) {
 	userConfig := g8sv1alpha1.AppSpecUserConfig{}
 
-	_, ok := configMaps[key.AppUserConfigMapName(appSpec)]
-	if ok {
+	_, cmExists := configMaps[key.AppUserConfigMapName(appSpec)]
+	tenantCM, tenantExists := tenantConfigMaps[key.AppUserConfigMapName(appSpec)]
+
+	// A tenant configmap exists with user settings but the user configmap for
+	// this app CR does not exist yet. We delay creating the app CR until it
+	// does so the app is installed with the correct settings.
+	if tenantExists && len(tenantCM.Data) > 0 && !cmExists {
+		return g8sv1alpha1.AppSpecUserConfig{}, microerror.Maskf(notMigratedError, "%#q not migrated yet", appSpec.App)
+	}
+
+	if cmExists {
 		configMapSpec := g8sv1alpha1.AppSpecUserConfigConfigMap{
 			Name:      key.AppUserConfigMapName(appSpec),
 			Namespace: clusterConfig.ID,
@@ -213,8 +229,8 @@ func newUserConfig(clusterConfig v1alpha1.ClusterGuestConfig, appSpec key.AppSpe
 		userConfig.ConfigMap = configMapSpec
 	}
 
-	_, ok = secrets[key.AppUserSecretName(appSpec)]
-	if ok {
+	_, secretExists := secrets[key.AppUserSecretName(appSpec)]
+	if secretExists {
 		secretSpec := g8sv1alpha1.AppSpecUserConfigSecret{
 			Name:      key.AppUserSecretName(appSpec),
 			Namespace: clusterConfig.ID,
@@ -223,5 +239,5 @@ func newUserConfig(clusterConfig v1alpha1.ClusterGuestConfig, appSpec key.AppSpe
 		userConfig.Secret = secretSpec
 	}
 
-	return userConfig
+	return userConfig, nil
 }

--- a/pkg/v22/resource/app/error.go
+++ b/pkg/v22/resource/app/error.go
@@ -12,3 +12,12 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfigError(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
+
+var notMigratedError = &microerror.Error{
+	Kind: "notMigrateError",
+}
+
+// IsNotMigratedError asserts notMigratedError.
+func IsNotMigratedError(err error) bool {
+	return microerror.Cause(err) == notMigratedError
+}

--- a/pkg/v22/resource/appmigration/create.go
+++ b/pkg/v22/resource/appmigration/create.go
@@ -125,7 +125,8 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 		appCR, err := r.g8sClient.ApplicationV1alpha1().Apps(key.ClusterID(cr)).Get(chartSpec.AppName, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
-			return microerror.Maskf(notFoundError, "app CR %#q", chartSpec.AppName)
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("app CR %#q does not exist yet, continuing", chartSpec.AppName))
+			continue
 		}
 
 		if appCR.Status.Release.Status == "DEPLOYED" {

--- a/pkg/v22/resource/configmapmigration/create.go
+++ b/pkg/v22/resource/configmapmigration/create.go
@@ -9,7 +9,6 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/errors/tenant"
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	yaml "gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,7 +33,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	if key.IsDeleted(objectMeta) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "cluster is being deleted")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-		resourcecanceledcontext.SetCanceled(ctx)
 		return nil
 	}
 
@@ -43,7 +41,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	if len(chartSpecsToMigrate) == 0 {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "no charts to migrate")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-		resourcecanceledcontext.SetCanceled(ctx)
 		return nil
 	}
 
@@ -66,7 +63,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	if cc.Client.TenantCluster.G8s == nil {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant clients not available")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
-		resourcecanceledcontext.SetCanceled(ctx)
 		return nil
 	}
 
@@ -83,12 +79,10 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	if tenant.IsAPINotAvailable(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available yet")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
-		resourcecanceledcontext.SetCanceled(ctx)
 		return nil
 	} else if isChartConfigNotInstalled(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "chartconfig CRD does not exist")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
-		resourcecanceledcontext.SetCanceled(ctx)
 		return nil
 	} else if err != nil {
 		return microerror.Mask(err)
@@ -96,7 +90,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "timeout getting chartconfig CRs")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
-		resourcecanceledcontext.SetCanceled(ctx)
 		return nil
 	}
 
@@ -106,7 +99,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	if tenant.IsAPINotAvailable(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available yet")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
-		resourcecanceledcontext.SetCanceled(ctx)
 		return nil
 	} else if err != nil {
 		return microerror.Mask(err)
@@ -114,7 +106,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "timeout getting chartconfig CRs")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
-		resourcecanceledcontext.SetCanceled(ctx)
 		return nil
 	}
 

--- a/pkg/v22/resource/configmapmigration/create.go
+++ b/pkg/v22/resource/configmapmigration/create.go
@@ -9,7 +9,6 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/errors/tenant"
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	yaml "gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
@@ -67,7 +66,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	if cc.Client.TenantCluster.G8s == nil {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant clients not available")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
-		reconciliationcanceledcontext.SetCanceled(ctx)
+		resourcecanceledcontext.SetCanceled(ctx)
 		return nil
 	}
 
@@ -84,12 +83,12 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	if tenant.IsAPINotAvailable(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available yet")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
-		reconciliationcanceledcontext.SetCanceled(ctx)
+		resourcecanceledcontext.SetCanceled(ctx)
 		return nil
 	} else if isChartConfigNotInstalled(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "chartconfig CRD does not exist")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
-		reconciliationcanceledcontext.SetCanceled(ctx)
+		resourcecanceledcontext.SetCanceled(ctx)
 		return nil
 	} else if err != nil {
 		return microerror.Mask(err)
@@ -97,7 +96,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "timeout getting chartconfig CRs")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
-		reconciliationcanceledcontext.SetCanceled(ctx)
+		resourcecanceledcontext.SetCanceled(ctx)
 		return nil
 	}
 
@@ -107,7 +106,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	if tenant.IsAPINotAvailable(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available yet")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
-		reconciliationcanceledcontext.SetCanceled(ctx)
+		resourcecanceledcontext.SetCanceled(ctx)
 		return nil
 	} else if err != nil {
 		return microerror.Mask(err)
@@ -115,7 +114,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "timeout getting chartconfig CRs")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
-		reconciliationcanceledcontext.SetCanceled(ctx)
+		resourcecanceledcontext.SetCanceled(ctx)
 		return nil
 	}
 

--- a/pkg/v22/resource/configmapmigration/create.go
+++ b/pkg/v22/resource/configmapmigration/create.go
@@ -62,7 +62,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 	if cc.Client.TenantCluster.G8s == nil {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant clients not available")
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		return nil
 	}
 
@@ -78,18 +78,18 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	chartConfigs, err := cc.Client.TenantCluster.G8s.CoreV1alpha1().ChartConfigs("giantswarm").List(listOptions)
 	if tenant.IsAPINotAvailable(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available yet")
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		return nil
 	} else if isChartConfigNotInstalled(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "chartconfig CRD does not exist")
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		return nil
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "timeout getting chartconfig CRs")
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		return nil
 	}
 
@@ -98,14 +98,14 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	tenantConfigMaps, err := cc.Client.TenantCluster.K8s.CoreV1().ConfigMaps(metav1.NamespaceSystem).List(listOptions)
 	if tenant.IsAPINotAvailable(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available yet")
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		return nil
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "timeout getting chartconfig CRs")
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		return nil
 	}
 

--- a/service/controller/aws/v22/resource_set.go
+++ b/service/controller/aws/v22/resource_set.go
@@ -343,8 +343,12 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		certConfigResource,
 		clusterConfigMapResource,
 		kubeConfigResource,
-		appResource,
+
+		// Migration resources are for migrating from chartconfig to app CRs.
 		appMigrationResource,
+
+		// appResource is executed after migration resources.
+		appResource,
 
 		// Following resources manage resources in tenant clusters so they
 		// should be executed last.

--- a/service/controller/azure/v22/resource_set.go
+++ b/service/controller/azure/v22/resource_set.go
@@ -340,8 +340,12 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		certConfigResource,
 		clusterConfigMapResource,
 		kubeConfigResource,
-		appResource,
+
+		// Migration resources are for migrating from chartconfig to app CRs.
 		appMigrationResource,
+
+		// appResource is executed after migration resources.
+		appResource,
 
 		// Following resources manage resources in tenant clusters so they
 		// should be executed last

--- a/service/controller/kvm/v22/resource_set.go
+++ b/service/controller/kvm/v22/resource_set.go
@@ -339,8 +339,12 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		certConfigResource,
 		clusterConfigMapResource,
 		kubeConfigResource,
-		appResource,
+
+		// Migration resources are for migrating from chartconfig to app CRs.
 		appMigrationResource,
+
+		// appResource is executed after migration resources.
+		appResource,
 
 		// Following resources manage resources in tenant clusters so they
 		// should be executed last


### PR DESCRIPTION
Towards giantswarm/giantswarm#7181

Spec PR: https://github.com/giantswarm/giantswarm/pull/7204/files

- Implements a delay on creating app CRs until any user values have been migrated.
- This is preparation for adding the configmapmigration resource and migrating CoreDNS to an app CR.