### PR TITLE
fix machine deployment status

### DIFF
--- a/service/controller/clusterapi/v21/controllercontext/status.go
+++ b/service/controller/clusterapi/v21/controllercontext/status.go
@@ -1,8 +1,14 @@
 package controllercontext
 
 type ContextStatus struct {
+	// Versions is a map of key value pairs where the map key is a version label
+	// of a given operator. The map value is the version of the corresponding
+	// operator.
 	Versions map[string]string
-	Worker   ContextStatusWorker
+	// Worker is a map of key value pairs where the key is the machine deployment
+	// ID. The map value is a structure holding node information for the
+	// corresponding machine deployment.
+	Worker map[string]ContextStatusWorker
 }
 
 type ContextStatusWorker struct {

--- a/service/controller/clusterapi/v21/controllercontext/status.go
+++ b/service/controller/clusterapi/v21/controllercontext/status.go
@@ -3,7 +3,10 @@ package controllercontext
 type ContextStatus struct {
 	// Versions is a map of key value pairs where the map key is a version label
 	// of a given operator. The map value is the version of the corresponding
-	// operator.
+	// operator. See also the operatorversions resource.
+	//
+	//     aws-operator.giantswarm.io/version: 6.5.0
+	//
 	Versions map[string]string
 	// Worker is a map of key value pairs where the key is the machine deployment
 	// ID. The map value is a structure holding node information for the

--- a/service/controller/clusterapi/v21/resource/configmap/desired.go
+++ b/service/controller/clusterapi/v21/resource/configmap/desired.go
@@ -144,16 +144,6 @@ func (r *Resource) newIngressControllerValues() (IngressControllerValues, error)
 	}
 }
 
-func workerCount(m map[string]controllercontext.ContextStatusWorker) int {
-	var n int
-
-	for _, w := range m {
-		n += w.Nodes
-	}
-
-	return n
-}
-
 func cidrBlock(address, prefix string) string {
 	if address == "" && prefix == "" {
 		return ""
@@ -319,4 +309,14 @@ func newConfigMapSpecs(chartSpecs []pkgkey.ChartSpec) []ConfigMapSpec {
 	}
 
 	return configMapSpecs
+}
+
+func workerCount(m map[string]controllercontext.ContextStatusWorker) int {
+	var n int
+
+	for _, w := range m {
+		n += w.Nodes
+	}
+
+	return n
 }

--- a/service/controller/clusterapi/v21/resource/configmap/desired.go
+++ b/service/controller/clusterapi/v21/resource/configmap/desired.go
@@ -46,7 +46,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		IngressController: providerValues,
 		Organization:      key.OrganizationID(&cr),
 		RegistryDomain:    r.registryDomain,
-		WorkerCount:       allWorkerNodes(cc.Status.Worker),
+		WorkerCount:       workerCount(cc.Status.Worker),
 	}
 
 	var configMaps []*corev1.ConfigMap
@@ -144,7 +144,7 @@ func (r *Resource) newIngressControllerValues() (IngressControllerValues, error)
 	}
 }
 
-func allWorkerNodes(m map[string]controllercontext.ContextStatusWorker) int {
+func workerCount(m map[string]controllercontext.ContextStatusWorker) int {
 	var n int
 
 	for _, w := range m {

--- a/service/controller/clusterapi/v21/resource/configmap/desired.go
+++ b/service/controller/clusterapi/v21/resource/configmap/desired.go
@@ -46,7 +46,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		IngressController: providerValues,
 		Organization:      key.OrganizationID(&cr),
 		RegistryDomain:    r.registryDomain,
-		WorkerCount:       cc.Status.Worker.Nodes,
+		WorkerCount:       allWorkerNodes(cc.Status.Worker),
 	}
 
 	var configMaps []*corev1.ConfigMap
@@ -142,6 +142,16 @@ func (r *Resource) newIngressControllerValues() (IngressControllerValues, error)
 	default:
 		return IngressControllerValues{}, microerror.Maskf(executionFailedError, "provider %#q not supported")
 	}
+}
+
+func allWorkerNodes(m map[string]controllercontext.ContextStatusWorker) int {
+	var n int
+
+	for _, w := range m {
+		n += w.Nodes
+	}
+
+	return n
 }
 
 func cidrBlock(address, prefix string) string {

--- a/service/controller/clusterapi/v21/resource/machinedeploymentstatus/resource.go
+++ b/service/controller/clusterapi/v21/resource/machinedeploymentstatus/resource.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 
+	"github.com/giantswarm/cluster-operator/pkg/label"
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v21/controllercontext"
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v21/key"
 )
@@ -65,11 +66,19 @@ func (r *Resource) ensure(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	var md *v1alpha1.MachineDeployment
+	{
+		md, err = r.cmaClient.ClusterV1alpha1().MachineDeployments(cr.Namespace).Get(cr.Name, metav1.GetOptions{})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
 	{
 		r.logger.LogCtx(ctx, "level", "debug", "message", "checking if status of machine deployment needs to be updated")
 
-		replicasChanged := cr.Status.Replicas != int32(cc.Status.Worker.Nodes)
-		readyReplicasChanged := cr.Status.ReadyReplicas != int32(cc.Status.Worker.Ready)
+		replicasChanged := cr.Status.Replicas != int32(cc.Status.Worker[md.Labels[label.MachineDeployment]].Nodes)
+		readyReplicasChanged := cr.Status.ReadyReplicas != int32(cc.Status.Worker[md.Labels[label.MachineDeployment]].Ready)
 
 		if !replicasChanged && !readyReplicasChanged {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "status of machine deployment does not need to be updated")
@@ -79,15 +88,9 @@ func (r *Resource) ensure(ctx context.Context, obj interface{}) error {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "status of machine deployment needs to be updated")
 	}
 
-	var md *v1alpha1.MachineDeployment
 	{
-		md, err = r.cmaClient.ClusterV1alpha1().MachineDeployments(cr.Namespace).Get(cr.Name, metav1.GetOptions{})
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		md.Status.Replicas = int32(cc.Status.Worker.Nodes)
-		md.Status.ReadyReplicas = int32(cc.Status.Worker.Ready)
+		md.Status.Replicas = int32(cc.Status.Worker[md.Labels[label.MachineDeployment]].Nodes)
+		md.Status.ReadyReplicas = int32(cc.Status.Worker[md.Labels[label.MachineDeployment]].Ready)
 	}
 
 	{

--- a/service/controller/clusterapi/v22/controllercontext/status.go
+++ b/service/controller/clusterapi/v22/controllercontext/status.go
@@ -1,8 +1,17 @@
 package controllercontext
 
 type ContextStatus struct {
+	// Versions is a map of key value pairs where the map key is a version label
+	// of a given operator. The map value is the version of the corresponding
+	// operator. See also the operatorversions resource.
+	//
+	//     aws-operator.giantswarm.io/version: 6.5.0
+	//
 	Versions map[string]string
-	Worker   ContextStatusWorker
+	// Worker is a map of key value pairs where the key is the machine deployment
+	// ID. The map value is a structure holding node information for the
+	// corresponding machine deployment.
+	Worker map[string]ContextStatusWorker
 }
 
 type ContextStatusWorker struct {

--- a/service/controller/clusterapi/v22/resource/configmap/desired.go
+++ b/service/controller/clusterapi/v22/resource/configmap/desired.go
@@ -46,7 +46,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		IngressController: providerValues,
 		Organization:      key.OrganizationID(&cr),
 		RegistryDomain:    r.registryDomain,
-		WorkerCount:       cc.Status.Worker.Nodes,
+		WorkerCount:       workerCount(cc.Status.Worker),
 	}
 
 	var configMaps []*corev1.ConfigMap
@@ -309,4 +309,14 @@ func newConfigMapSpecs(chartSpecs []pkgkey.ChartSpec) []ConfigMapSpec {
 	}
 
 	return configMapSpecs
+}
+
+func workerCount(m map[string]controllercontext.ContextStatusWorker) int {
+	var n int
+
+	for _, w := range m {
+		n += w.Nodes
+	}
+
+	return n
 }


### PR DESCRIPTION
We need to track and assign the node counts per machine deployment. Below you see before and after. 

```
$ gsctl list nodepools 3scb2
ID     NAME   AZ   INSTANCE TYPE  NODES MIN/MAX  NODES DESIRED  NODES READY  CPUS  RAM (GB)
5npkn  aamnp  A    m4.xlarge      3/10                       7            7    28     112.0
bwk6a  aamnp  B,C  m4.xlarge      4/9                        7            7    28     112.0

```

```
$ gsctl list nodepools 3scb2
ID     NAME   AZ   INSTANCE TYPE  NODES MIN/MAX  NODES DESIRED  NODES READY  CPUS  RAM (GB)
5npkn  aamnp  A    m4.xlarge      3/10                       3            3    12      48.0
bwk6a  aamnp  B,C  m4.xlarge      4/9                        4            4    16      64.0
```