### PR TITLE
Do not install clusterapi apps in legacy

### DIFF
--- a/pkg/v22/key/types.go
+++ b/pkg/v22/key/types.go
@@ -2,9 +2,10 @@ package key
 
 // AppSpec is used to define app custom resources.
 type AppSpec struct {
-	App             string
-	Catalog         string
-	Chart           string
+	App     string
+	Catalog string
+	Chart   string
+	// Whether app is installed for clusterapi clusters only
 	ClusterAPI      bool
 	Namespace       string
 	UseUpgradeForce bool

--- a/pkg/v22/key/types.go
+++ b/pkg/v22/key/types.go
@@ -5,6 +5,7 @@ type AppSpec struct {
 	App             string
 	Catalog         string
 	Chart           string
+	ClusterAPI      bool
 	Namespace       string
 	UseUpgradeForce bool
 	Version         string

--- a/pkg/v22/resource/app/desired.go
+++ b/pkg/v22/resource/app/desired.go
@@ -100,7 +100,9 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*g8s
 			return nil, microerror.Mask(err)
 		}
 
-		apps = append(apps, r.newApp(clusterConfig, appSpec, userConfig))
+		if !appSpec.ClusterAPI {
+			apps = append(apps, r.newApp(clusterConfig, appSpec, userConfig))
+		}
 	}
 
 	return apps, nil


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4795

Add flag for clusterapi clusters so that we will install cert-manager/kiam/external-dns only for new clusters which have required IAM roles to work