### PR TITLE
Cluster conditions evaluate against  operator instead of release version

### DIFF
--- a/service/controller/clusterapi/v22/cluster_resource_set.go
+++ b/service/controller/clusterapi/v22/cluster_resource_set.go
@@ -196,6 +196,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 			CMAClient: config.CMAClient,
 			G8sClient: config.G8sClient,
 			Logger:    config.Logger,
+			Provider:  config.Provider,
 		}
 
 		clusterStatusResource, err = clusterstatus.New(c)

--- a/service/controller/clusterapi/v22/resource/clusterstatus/resource.go
+++ b/service/controller/clusterapi/v22/resource/clusterstatus/resource.go
@@ -16,6 +16,8 @@ type Config struct {
 	CMAClient clientset.Interface
 	G8sClient versioned.Interface
 	Logger    micrologger.Logger
+
+	Provider string
 }
 
 type Resource struct {
@@ -23,6 +25,8 @@ type Resource struct {
 	cmaClient clientset.Interface
 	g8sClient versioned.Interface
 	logger    micrologger.Logger
+
+	provider string
 }
 
 func New(config Config) (*Resource, error) {
@@ -38,12 +42,16 @@ func New(config Config) (*Resource, error) {
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
+	if config.Provider == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Provider must not be empty", config)
+	}
 
 	r := &Resource{
 		accessor:  config.Accessor,
 		cmaClient: config.CMAClient,
 		g8sClient: config.G8sClient,
 		logger:    config.Logger,
+		provider:  config.Provider,
 	}
 
 	return r, nil


### PR DESCRIPTION
Towards fixing giantswarm/giantswarm#7465

This is cluster-operator part of the fix. For aws-operator part of the fix see https://github.com/giantswarm/aws-operator/pull/2064