### PR TITLE
Add metrics for number of nodepools per cluster

### DIFF
--- a/service/collector/cluster.go
+++ b/service/collector/cluster.go
@@ -7,15 +7,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 
-	"github.com/giantswarm/cluster-operator/pkg/label"
 	"github.com/giantswarm/cluster-operator/service/controller/clusterapi/v21/key"
-)
-
-const (
-	subsystemCluster = "cluster"
 )
 
 var (
@@ -25,15 +19,6 @@ var (
 		[]string{
 			"cluster_id",
 			"status",
-		},
-		nil,
-	)
-
-	clusterNodePools *prometheus.Desc = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, subsystemCluster, "nodepools"),
-		"Number of Node Pools in a cluster as provided by the MachineDeployment CRs with given cluster ID.",
-		[]string{
-			"cluster_id",
 		},
 		nil,
 	)
@@ -111,29 +96,6 @@ func (c *Cluster) Collect(ch chan<- prometheus.Metric) error {
 				v1alpha1.ClusterStatusConditionDeleting,
 			)
 		}
-
-		{
-			clusterID := cluster.GetLabels()[label.Cluster]
-			l := metav1.AddLabelToSelector(
-				&metav1.LabelSelector{},
-				label.Cluster,
-				clusterID,
-			)
-			o := metav1.ListOptions{
-				LabelSelector: labels.Set(l.MatchLabels).String(),
-			}
-			machineDeployments, err := c.cmaClient.ClusterV1alpha1().MachineDeployments(cluster.Namespace).List(o)
-			if err != nil {
-				return microerror.Mask(err)
-			}
-
-			ch <- prometheus.MustNewConstMetric(
-				clusterNodePools,
-				prometheus.GaugeValue,
-				float64(len(machineDeployments.Items)),
-				clusterID,
-			)
-		}
 	}
 
 	return nil
@@ -141,7 +103,6 @@ func (c *Cluster) Collect(ch chan<- prometheus.Metric) error {
 
 func (c *Cluster) Describe(ch chan<- *prometheus.Desc) error {
 	ch <- clusterStatus
-	ch <- clusterNodePools
 	return nil
 }
 

--- a/service/collector/collector.go
+++ b/service/collector/collector.go
@@ -1,6 +1,7 @@
 package collector
 
 const (
-	GaugeValue float64 = 1
-	namespace          = "cluster_operator"
+	GaugeValue       float64 = 1
+	namespace                = "cluster_operator"
+	subsystemCluster         = "cluster"
 )

--- a/service/collector/nodepool.go
+++ b/service/collector/nodepool.go
@@ -1,0 +1,89 @@
+package collector
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
+
+	"github.com/giantswarm/cluster-operator/pkg/label"
+)
+
+var (
+	clusterNodePools *prometheus.Desc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, subsystemCluster, "nodepools"),
+		"Number of Node Pools in a cluster as provided by the MachineDeployment CRs with given cluster ID.",
+		[]string{
+			"cluster_id",
+		},
+		nil,
+	)
+)
+
+type NodePoolConfig struct {
+	CMAClient clientset.Interface
+	Logger    micrologger.Logger
+}
+
+type NodePool struct {
+	cmaClient clientset.Interface
+	logger    micrologger.Logger
+}
+
+func NewNodePool(config NodePoolConfig) (*NodePool, error) {
+	if config.CMAClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CMAClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	np := &NodePool{
+		cmaClient: config.CMAClient,
+		logger:    config.Logger,
+	}
+
+	return np, nil
+}
+
+func (np *NodePool) Collect(ch chan<- prometheus.Metric) error {
+	list, err := np.cmaClient.ClusterV1alpha1().Clusters(corev1.NamespaceAll).List(metav1.ListOptions{})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	for _, cluster := range list.Items {
+		{
+			clusterID := cluster.GetLabels()[label.Cluster]
+			l := metav1.AddLabelToSelector(
+				&metav1.LabelSelector{},
+				label.Cluster,
+				clusterID,
+			)
+			o := metav1.ListOptions{
+				LabelSelector: labels.Set(l.MatchLabels).String(),
+			}
+			machineDeployments, err := np.cmaClient.ClusterV1alpha1().MachineDeployments(cluster.Namespace).List(o)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			ch <- prometheus.MustNewConstMetric(
+				clusterNodePools,
+				prometheus.GaugeValue,
+				float64(len(machineDeployments.Items)),
+				clusterID,
+			)
+		}
+	}
+
+	return nil
+}
+
+func (np *NodePool) Describe(ch chan<- *prometheus.Desc) error {
+	ch <- clusterNodePools
+	return nil
+}

--- a/service/collector/nodepool.go
+++ b/service/collector/nodepool.go
@@ -14,7 +14,7 @@ import (
 var (
 	nodePools *prometheus.Desc = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, subsystemCluster, "nodepools"),
-		"Number of Node Pools in a cluster as provided by the MachineDeployment CRs with given cluster ID.",
+		"Number of Node Pools in a cluster as provided by the MachineDeployment CRs associated with a given cluster ID.",
 		[]string{
 			"cluster_id",
 		},

--- a/service/collector/set.go
+++ b/service/collector/set.go
@@ -39,11 +39,25 @@ func NewSet(config SetConfig) (*Set, error) {
 		}
 	}
 
+	var nodePoolCollector *NodePool
+	{
+		c := NodePoolConfig{
+			CMAClient: config.CMAClient,
+			Logger:    config.Logger,
+		}
+
+		nodePoolCollector, err = NewNodePool(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var collectorSet *collector.Set
 	{
 		c := collector.SetConfig{
 			Collectors: []collector.Interface{
 				clusterCollector,
+				nodePoolCollector,
 			},
 			Logger: config.Logger,
 		}


### PR DESCRIPTION
Track number of nodepools per cluster so that it can be used for alerts.

Towards https://github.com/giantswarm/giantswarm/issues/7082