### PR TITLE
Add workercount resource to legacy controllers

### DIFF
--- a/pkg/v22/controllercontext/context.go
+++ b/pkg/v22/controllercontext/context.go
@@ -12,6 +12,7 @@ const contextKey key = "controller"
 
 type Context struct {
 	Client ContextClient
+	Status ContextStatus
 }
 
 func NewContext(ctx context.Context, c Context) context.Context {

--- a/pkg/v22/controllercontext/status.go
+++ b/pkg/v22/controllercontext/status.go
@@ -1,0 +1,9 @@
+package controllercontext
+
+type ContextStatus struct {
+	Worker ContextStatusWorker
+}
+
+type ContextStatusWorker struct {
+	Nodes int32
+}

--- a/pkg/v22/resource/workercount/create.go
+++ b/pkg/v22/resource/workercount/create.go
@@ -1,0 +1,66 @@
+package workercount
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/errors/tenant"
+	"github.com/giantswarm/microerror"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/cluster-operator/pkg/label"
+	"github.com/giantswarm/cluster-operator/pkg/v22/controllercontext"
+	"github.com/giantswarm/cluster-operator/pkg/v22/key"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	cr, err := r.toClusterConfigFunc(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	{
+		if cc.Client.TenantCluster.K8s == nil {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster clients not available yet")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+			return nil
+		}
+	}
+
+	var workerCount int
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding nodes of tenant cluster %#q", key.ClusterID(cr)))
+
+		o := metav1.ListOptions{
+			// This label selector excludes the master nodes from node list.
+			//
+			// Constructing this LabelSelector is not currently possible with
+			// k8s types and functions. Therefore it's hardcoded here.
+			LabelSelector: fmt.Sprintf("!%s", label.MasterNodeRole),
+		}
+
+		l, err := cc.Client.TenantCluster.K8s.CoreV1().Nodes().List(o)
+		if tenant.IsAPINotAvailable(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant API not available yet")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+			return nil
+
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		workerCount = len(l.Items)
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d nodes of tenant cluster %#q", len(l.Items), key.ClusterID(cr)))
+	}
+
+	{
+		cc.Status.Worker.Nodes = int32(workerCount)
+	}
+
+	return nil
+}

--- a/pkg/v22/resource/workercount/delete.go
+++ b/pkg/v22/resource/workercount/delete.go
@@ -1,0 +1,9 @@
+package workercount
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/pkg/v22/resource/workercount/error.go
+++ b/pkg/v22/resource/workercount/error.go
@@ -1,0 +1,14 @@
+package workercount
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/pkg/v22/resource/workercount/resource.go
+++ b/pkg/v22/resource/workercount/resource.go
@@ -1,0 +1,41 @@
+package workercount
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+const (
+	Name = "workercountv22"
+)
+
+type Config struct {
+	Logger              micrologger.Logger
+	ToClusterConfigFunc func(v interface{}) (v1alpha1.ClusterGuestConfig, error)
+}
+
+type Resource struct {
+	logger              micrologger.Logger
+	toClusterConfigFunc func(v interface{}) (v1alpha1.ClusterGuestConfig, error)
+}
+
+func New(config Config) (*Resource, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.ToClusterConfigFunc == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ToClusterConfigFunc must not be empty", config)
+	}
+
+	r := &Resource{
+		logger:              config.Logger,
+		toClusterConfigFunc: config.ToClusterConfigFunc,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/aws/v22/resource_set.go
+++ b/service/controller/aws/v22/resource_set.go
@@ -34,6 +34,7 @@ import (
 	"github.com/giantswarm/cluster-operator/pkg/v22/resource/encryptionkey"
 	"github.com/giantswarm/cluster-operator/pkg/v22/resource/kubeconfig"
 	"github.com/giantswarm/cluster-operator/pkg/v22/resource/tenantclients"
+	"github.com/giantswarm/cluster-operator/pkg/v22/resource/workercount"
 	"github.com/giantswarm/cluster-operator/service/controller/aws/v22/key"
 	"github.com/giantswarm/cluster-operator/service/controller/aws/v22/resource/chartconfig"
 	"github.com/giantswarm/cluster-operator/service/controller/aws/v22/resource/configmap"
@@ -352,9 +353,23 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		}
 	}
 
+	var workerCountResource resource.Interface
+	{
+		c := workercount.Config{
+			Logger:              config.Logger,
+			ToClusterConfigFunc: getClusterConfig,
+		}
+
+		workerCountResource, err = workercount.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	resources := []resource.Interface{
 		// Following resources manage resources controller context information.
 		tenantClientsResource,
+		workerCountResource,
 
 		// Following resources manage resources in the control plane.
 		encryptionKeyResource,

--- a/service/controller/azure/v22/resource_set.go
+++ b/service/controller/azure/v22/resource_set.go
@@ -34,6 +34,7 @@ import (
 	"github.com/giantswarm/cluster-operator/pkg/v22/resource/encryptionkey"
 	"github.com/giantswarm/cluster-operator/pkg/v22/resource/kubeconfig"
 	"github.com/giantswarm/cluster-operator/pkg/v22/resource/tenantclients"
+	"github.com/giantswarm/cluster-operator/pkg/v22/resource/workercount"
 	"github.com/giantswarm/cluster-operator/service/controller/azure/v22/key"
 	"github.com/giantswarm/cluster-operator/service/controller/azure/v22/resource/chartconfig"
 	"github.com/giantswarm/cluster-operator/service/controller/azure/v22/resource/configmap"
@@ -349,9 +350,23 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		}
 	}
 
+	var workerCountResource resource.Interface
+	{
+		c := workercount.Config{
+			Logger:              config.Logger,
+			ToClusterConfigFunc: getClusterConfig,
+		}
+
+		workerCountResource, err = workercount.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	resources := []resource.Interface{
 		// Following resources manage resources controller context information.
 		tenantClientsResource,
+		workerCountResource,
 
 		// Following resources manage resources in the control plane.
 		encryptionKeyResource,

--- a/service/controller/kvm/v22/resource_set.go
+++ b/service/controller/kvm/v22/resource_set.go
@@ -34,6 +34,7 @@ import (
 	"github.com/giantswarm/cluster-operator/pkg/v22/resource/encryptionkey"
 	"github.com/giantswarm/cluster-operator/pkg/v22/resource/kubeconfig"
 	"github.com/giantswarm/cluster-operator/pkg/v22/resource/tenantclients"
+	"github.com/giantswarm/cluster-operator/pkg/v22/resource/workercount"
 	"github.com/giantswarm/cluster-operator/service/controller/kvm/v22/key"
 	"github.com/giantswarm/cluster-operator/service/controller/kvm/v22/resource/chartconfig"
 	"github.com/giantswarm/cluster-operator/service/controller/kvm/v22/resource/configmap"
@@ -348,9 +349,23 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		}
 	}
 
+	var workerCountResource resource.Interface
+	{
+		c := workercount.Config{
+			Logger:              config.Logger,
+			ToClusterConfigFunc: getClusterConfig,
+		}
+
+		workerCountResource, err = workercount.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	resources := []resource.Interface{
 		// Following resources manage resources controller context information.
 		tenantClientsResource,
+		workerCountResource,
 
 		// Following resources manage resources in the control plane.
 		encryptionKeyResource,


### PR DESCRIPTION
Towards giantswarm/giantswarm#4795

Backporting this resource to legacy from the clusterapi controller. So we can use it to set the replica count for ingress controller.