### PR TITLE
Add ingress controller replicas to clusterconfigmap for legacy

### DIFF
--- a/pkg/v22/controllercontext/status.go
+++ b/pkg/v22/controllercontext/status.go
@@ -5,5 +5,5 @@ type ContextStatus struct {
 }
 
 type ContextStatusWorker struct {
-	Nodes int32
+	Nodes int
 }

--- a/pkg/v22/resource/clusterconfigmap/resource.go
+++ b/pkg/v22/resource/clusterconfigmap/resource.go
@@ -21,6 +21,7 @@ type Config struct {
 	// Dependencies.
 	GetClusterConfigFunc     func(obj interface{}) (v1alpha1.ClusterGuestConfig, error)
 	GetClusterObjectMetaFunc func(obj interface{}) (metav1.ObjectMeta, error)
+	GetWorkerCountFunc       func(obj interface{}) (int, error)
 	K8sClient                kubernetes.Interface
 	Logger                   micrologger.Logger
 
@@ -33,6 +34,7 @@ type StateGetter struct {
 	// Dependencies.
 	getClusterConfigFunc     func(obj interface{}) (v1alpha1.ClusterGuestConfig, error)
 	getClusterObjectMetaFunc func(obj interface{}) (metav1.ObjectMeta, error)
+	getWorkerCountFunc       func(obj interface{}) (int, error)
 	k8sClient                kubernetes.Interface
 	logger                   micrologger.Logger
 
@@ -48,6 +50,9 @@ func New(config Config) (*StateGetter, error) {
 	}
 	if config.GetClusterObjectMetaFunc == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.GetClusterObjectMetaFunc must not be empty", config)
+	}
+	if config.GetWorkerCountFunc == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.GetWorkerCountFunc must not be empty", config)
 	}
 	if config.K8sClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
@@ -65,6 +70,7 @@ func New(config Config) (*StateGetter, error) {
 		// Dependencies.
 		getClusterConfigFunc:     config.GetClusterConfigFunc,
 		getClusterObjectMetaFunc: config.GetClusterObjectMetaFunc,
+		getWorkerCountFunc:       config.GetWorkerCountFunc,
 		k8sClient:                config.K8sClient,
 		logger:                   config.Logger,
 

--- a/pkg/v22/resource/workercount/create.go
+++ b/pkg/v22/resource/workercount/create.go
@@ -55,11 +55,11 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 		workerCount = len(l.Items)
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d nodes of tenant cluster %#q", len(l.Items), key.ClusterID(cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d nodes of tenant cluster %#q", workerCount, key.ClusterID(cr)))
 	}
 
 	{
-		cc.Status.Worker.Nodes = int32(workerCount)
+		cc.Status.Worker.Nodes = workerCount
 	}
 
 	return nil

--- a/service/controller/aws/v22/resource_set.go
+++ b/service/controller/aws/v22/resource_set.go
@@ -275,6 +275,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		c := clusterconfigmap.Config{
 			GetClusterConfigFunc:     getClusterConfig,
 			GetClusterObjectMetaFunc: getClusterObjectMeta,
+			GetWorkerCountFunc:       getWorkerCount,
 			K8sClient:                config.K8sClient,
 			Logger:                   config.Logger,
 
@@ -466,6 +467,15 @@ func getClusterObjectMeta(obj interface{}) (metav1.ObjectMeta, error) {
 	}
 
 	return cr.ObjectMeta, nil
+}
+
+func getWorkerCount(obj interface{}) (int, error) {
+	cr, err := key.ToCustomObject(obj)
+	if err != nil {
+		return 0, microerror.Mask(err)
+	}
+
+	return key.WorkerCount(cr), nil
 }
 
 func toClusterGuestConfig(obj interface{}) (v1alpha1.ClusterGuestConfig, error) {

--- a/service/controller/azure/v22/resource_set.go
+++ b/service/controller/azure/v22/resource_set.go
@@ -272,6 +272,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		c := clusterconfigmap.Config{
 			GetClusterConfigFunc:     getClusterConfig,
 			GetClusterObjectMetaFunc: getClusterObjectMeta,
+			GetWorkerCountFunc:       getWorkerCount,
 			K8sClient:                config.K8sClient,
 			Logger:                   config.Logger,
 
@@ -459,6 +460,15 @@ func getClusterObjectMeta(obj interface{}) (metav1.ObjectMeta, error) {
 	}
 
 	return cr.ObjectMeta, nil
+}
+
+func getWorkerCount(obj interface{}) (int, error) {
+	cr, err := key.ToCustomObject(obj)
+	if err != nil {
+		return 0, microerror.Mask(err)
+	}
+
+	return key.WorkerCount(cr), nil
 }
 
 func toClusterGuestConfig(obj interface{}) (v1alpha1.ClusterGuestConfig, error) {

--- a/service/controller/kvm/v22/resource_set.go
+++ b/service/controller/kvm/v22/resource_set.go
@@ -271,6 +271,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		c := clusterconfigmap.Config{
 			GetClusterConfigFunc:     getClusterConfig,
 			GetClusterObjectMetaFunc: getClusterObjectMeta,
+			GetWorkerCountFunc:       getWorkerCount,
 			K8sClient:                config.K8sClient,
 			Logger:                   config.Logger,
 
@@ -458,6 +459,15 @@ func getClusterObjectMeta(obj interface{}) (metav1.ObjectMeta, error) {
 	}
 
 	return cr.ObjectMeta, nil
+}
+
+func getWorkerCount(obj interface{}) (int, error) {
+	cr, err := key.ToCustomObject(obj)
+	if err != nil {
+		return 0, microerror.Mask(err)
+	}
+
+	return key.WorkerCount(cr), nil
 }
 
 func toClusterGuestConfig(obj interface{}) (v1alpha1.ClusterGuestConfig, error) {


### PR DESCRIPTION
Towards giantswarm/giantswarm#4795

Adds the replicas setting to the configmap. Next PR will migrate IC to an app CR and use this.