### PR TITLE
Add cluster's node pool metrics (num of desired & ready workers)

### DIFF
--- a/service/collector/collector.go
+++ b/service/collector/collector.go
@@ -1,7 +1,8 @@
 package collector
 
 const (
-	GaugeValue       float64 = 1
-	namespace                = "cluster_operator"
-	subsystemCluster         = "cluster"
+	GaugeValue        float64 = 1
+	namespace                 = "cluster_operator"
+	subsystemCluster          = "cluster"
+	subsystemNodePool         = "node_pool"
 )

--- a/service/collector/nodepool.go
+++ b/service/collector/nodepool.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	nodePools *prometheus.Desc = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, subsystemCluster, "nodepools"),
+		prometheus.BuildFQName(namespace, subsystemNodePool, "count"),
 		"Number of Node Pools in a cluster as provided by the MachineDeployment CRs associated with a given cluster ID.",
 		[]string{
 			"cluster_id",

--- a/service/collector/nodepool.go
+++ b/service/collector/nodepool.go
@@ -20,6 +20,26 @@ var (
 		},
 		nil,
 	)
+
+	nodePoolDesiredWorkers *prometheus.Desc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, subsystemNodePool, "desired_workers"),
+		"Number of desired workers in all node pools for a specific cluster as provided by the MachineDeployment CRs associated with a given cluster ID.",
+		[]string{
+			"cluster_id",
+			"node_pool_id",
+		},
+		nil,
+	)
+
+	nodePoolReadyWorkers *prometheus.Desc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, subsystemNodePool, "ready_workers"),
+		"Number of ready workers in all node pools for a specific cluster as provided by the MachineDeployment CRs associated with a given cluster ID.",
+		[]string{
+			"cluster_id",
+			"node_pool_id",
+		},
+		nil,
+	)
 )
 
 type NodePoolConfig struct {
@@ -54,22 +74,54 @@ func (np *NodePool) Collect(ch chan<- prometheus.Metric) error {
 		return microerror.Mask(err)
 	}
 
-	clusterNodePools := make(map[string]int)
+	type nodes struct {
+		nodePoolID string
+		desired    int
+		ready      int
+	}
+
+	clusterNodePools := make(map[string][]nodes)
 
 	for _, md := range list.Items {
 		clusterID := md.GetLabels()[label.Cluster]
 
-		clusterNodePools[clusterID] = clusterNodePools[clusterID] + 1
+		n := nodes{
+			nodePoolID: md.GetLabels()[label.MachineDeployment],
+			desired:    int(md.Status.Replicas),
+			ready:      int(md.Status.ReadyReplicas),
+		}
+
+		clusterNodePools[clusterID] = append(clusterNodePools[clusterID], n)
 	}
 
-	for clusterID, nodePoolCount := range clusterNodePools {
+	for clusterID, nps := range clusterNodePools {
 		{
 			ch <- prometheus.MustNewConstMetric(
 				nodePools,
 				prometheus.GaugeValue,
-				float64(nodePoolCount),
+				float64(len(nps)),
 				clusterID,
 			)
+		}
+
+		for _, n := range nps {
+			{
+				ch <- prometheus.MustNewConstMetric(
+					nodePoolDesiredWorkers,
+					prometheus.GaugeValue,
+					float64(n.desired),
+					clusterID,
+					n.nodePoolID,
+				)
+
+				ch <- prometheus.MustNewConstMetric(
+					nodePoolReadyWorkers,
+					prometheus.GaugeValue,
+					float64(n.ready),
+					clusterID,
+					n.nodePoolID,
+				)
+			}
 		}
 	}
 
@@ -78,5 +130,8 @@ func (np *NodePool) Collect(ch chan<- prometheus.Metric) error {
 
 func (np *NodePool) Describe(ch chan<- *prometheus.Desc) error {
 	ch <- nodePools
+	ch <- nodePoolDesiredWorkers
+	ch <- nodePoolReadyWorkers
+
 	return nil
 }


### PR DESCRIPTION
In order to observe cluster's scaling behavior and number of workers in
different node pools, add metrics for desired and ready workers.

Towards https://github.com/giantswarm/giantswarm/issues/7082

With these metrics, we can have inhibition for specific alerts when cluster is scaling (i.e. `desired != ready`).