### PR TITLE
helm/cluster-operator: add version to resource names

### DIFF
--- a/helm/cluster-operator/Chart.yaml
+++ b/helm/cluster-operator/Chart.yaml
@@ -1,2 +1,3 @@
+apiVersion: v1
 name: cluster-operator
 version: [[ .Version ]]

--- a/helm/cluster-operator/Chart.yaml
+++ b/helm/cluster-operator/Chart.yaml
@@ -1,2 +1,2 @@
-name: cluster-operator-chart
-version: 1.0.0-[[ .SHA ]]
+name: cluster-operator
+version: [[ .Version ]]

--- a/helm/cluster-operator/templates/configmap.yaml
+++ b/helm/cluster-operator/templates/configmap.yaml
@@ -30,7 +30,7 @@ data:
           domain: '{{ .Values.Installation.V1.Registry.Domain }}'
       kubeconfig:
         resource:
-          namespace: 'giantswarm'  // TODO replace this too?
+          namespace: 'giantswarm'
       kubernetes:
         address: ''
         inCluster: true

--- a/helm/cluster-operator/templates/configmap.yaml
+++ b/helm/cluster-operator/templates/configmap.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cluster-operator-configmap
-  namespace: {{ .Values.namespace }}
+  name: {{ tpl .Values.resource.default.name  . }}
+  namespace: {{ tpl .Values.resource.default.namespace  . }}
 data:
   config.yml: |
     server:
@@ -30,7 +30,7 @@ data:
           domain: '{{ .Values.Installation.V1.Registry.Domain }}'
       kubeconfig:
         resource:
-          namespace: 'giantswarm'
+          namespace: 'giantswarm'  // TODO replace this too?
       kubernetes:
         address: ''
         inCluster: true

--- a/helm/cluster-operator/templates/deployment.yaml
+++ b/helm/cluster-operator/templates/deployment.yaml
@@ -4,7 +4,8 @@ metadata:
   name: {{ tpl .Values.resource.default.name  . }}
   namespace: {{ tpl .Values.resource.default.namespace  . }}
   labels:
-    app: {{ tpl .Values.resource.default.name  . }}
+    app: {{ .Values.project.name }}
+    version: {{ .Values.project.version }}
 spec:
   replicas: 1
   strategy:
@@ -12,7 +13,8 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ tpl .Values.resource.default.name  . }}
+        app: {{ .Values.project.name }}
+        version: {{ .Values.project.version }}
       annotations:
         releasetime: {{ $.Release.Time }}
     spec:
@@ -41,7 +43,7 @@ spec:
         runAsGroup: {{ .Values.pod.group.id }}
       containers:
       - name: {{ .Values.project.name }}
-        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         args:
         - daemon
         - --config.dirs=/var/run/{{ .Values.project.name }}/configmap/

--- a/helm/cluster-operator/templates/deployment.yaml
+++ b/helm/cluster-operator/templates/deployment.yaml
@@ -1,10 +1,10 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: cluster-operator
-  namespace: {{ .Values.namespace }}
+  name: {{ tpl .Values.resource.default.name  . }}
+  namespace: {{ tpl .Values.resource.default.namespace  . }}
   labels:
-    app: cluster-operator
+    app: {{ tpl .Values.resource.default.name  . }}
 spec:
   replicas: 1
   strategy:
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       labels:
-        app: cluster-operator
+        app: {{ tpl .Values.resource.default.name  . }}
       annotations:
         releasetime: {{ $.Release.Time }}
     spec:
@@ -25,30 +25,30 @@ spec:
                 - key: app
                   operator: In
                   values:
-                  - cluster-operator
+                  - {{ tpl .Values.resource.default.name  . }}
               topologyKey: kubernetes.io/hostname
             weight: 100
       volumes:
-      - name: cluster-operator-configmap
+      - name: {{ .Values.project.name }}-configmap
         configMap:
-          name: cluster-operator-configmap
+          name: {{ tpl .Values.resource.default.name  . }}
           items:
           - key: config.yml
             path: config.yml
-      serviceAccountName: cluster-operator
+      serviceAccountName: {{ tpl .Values.resource.default.name  . }}
       securityContext:
-        runAsUser: {{ .Values.userID }}
-        runAsGroup: {{ .Values.groupID }}
+        runAsUser: {{ .Values.pod.user.id }}
+        runAsGroup: {{ .Values.pod.group.id }}
       containers:
-      - name: cluster-operator
-        image: quay.io/giantswarm/cluster-operator:[[ .SHA ]]
+      - name: {{ .Values.project.name }}
+        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         args:
         - daemon
-        - --config.dirs=/var/run/cluster-operator/configmap/
+        - --config.dirs=/var/run/{{ .Values.project.name }}/configmap/
         - --config.files=config
         volumeMounts:
-        - name: cluster-operator-configmap
-          mountPath: /var/run/cluster-operator/configmap/
+        - name: {{ .Values.project.name }}-configmap
+          mountPath: /var/run/{{ .Values.project.name }}/configmap/
         livenessProbe:
           httpGet:
             path: /healthz
@@ -63,4 +63,4 @@ spec:
             cpu: 100m
             memory: 220Mi
       imagePullSecrets:
-      - name: cluster-operator-pull-secret
+      - name: {{ tpl .Values.resource.pullSecret.name . }}

--- a/helm/cluster-operator/templates/psp.yaml
+++ b/helm/cluster-operator/templates/psp.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: cluster-operator-psp
+  name: {{ tpl .Values.resource.psp.name . }}
 spec:
   privileged: false
   fsGroup:

--- a/helm/cluster-operator/templates/pull-secret.yaml
+++ b/helm/cluster-operator/templates/pull-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 type: kubernetes.io/dockerconfigjson
 metadata:
-  name: cluster-operator-pull-secret
-  namespace: {{ .Values.namespace }}
+  name: {{ tpl .Values.resource.pullSecret.name . }}
+  namespace: {{ tpl .Values.resource.pullSecret.namespace . }}
 data:
   .dockerconfigjson: {{ .Values.Installation.V1.Secret.Registry.PullSecret.DockerConfigJSON | b64enc | quote }}

--- a/helm/cluster-operator/templates/rbac.yaml
+++ b/helm/cluster-operator/templates/rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: cluster-operator
+  name: {{ tpl .Values.resource.default.name  . }}
 rules:
   - apiGroups:
       - ""
@@ -77,20 +77,20 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: cluster-operator
+  name: {{ tpl .Values.resource.default.name  . }}
 subjects:
   - kind: ServiceAccount
-    name: cluster-operator
-    namespace: {{ .Values.namespace }}
+    name: {{ tpl .Values.resource.default.name  . }}
+    namespace: {{ tpl .Values.resource.default.namespace  . }}
 roleRef:
   kind: ClusterRole
-  name: cluster-operator
+  name: {{ tpl .Values.resource.default.name  . }}
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: cluster-operator-psp
+  name: {{ tpl .Values.resource.psp.name . }}
 rules:
   - apiGroups:
       - extensions
@@ -99,17 +99,17 @@ rules:
     verbs:
       - use
     resourceNames:
-      - cluster-operator-psp
+      - {{ tpl .Values.resource.psp.name . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: cluster-operator-psp
+  name: {{ tpl .Values.resource.psp.name . }}
 subjects:
   - kind: ServiceAccount
-    name: cluster-operator
-    namespace: {{ .Values.namespace }}
+    name: {{ tpl .Values.resource.default.name  . }}
+    namespace: {{ tpl .Values.resource.default.namespace  . }}
 roleRef:
   kind: ClusterRole
-  name: cluster-operator-psp
+  name: {{ tpl .Values.resource.psp.name . }}
   apiGroup: rbac.authorization.k8s.io

--- a/helm/cluster-operator/templates/service-account.yaml
+++ b/helm/cluster-operator/templates/service-account.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: cluster-operator
-  namespace: {{ .Values.namespace }}
+  name: {{ tpl .Values.resource.default.name  . }}
+  namespace: {{ tpl .Values.resource.default.namespace  . }}

--- a/helm/cluster-operator/templates/service.yaml
+++ b/helm/cluster-operator/templates/service.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: cluster-operator
-  namespace: {{ .Values.namespace }}
+  name: {{ tpl .Values.resource.default.name  . }}
+  namespace: {{ tpl .Values.resource.default.namespace  . }}
   labels:
-    app: cluster-operator
+    app: {{ tpl .Values.resource.default.name  . }}
   annotations:
     prometheus.io/scrape: "true"
 spec:
   ports:
   - port: 8000
   selector:
-    app: cluster-operator
+    app: {{ tpl .Values.resource.default.name  . }}

--- a/helm/cluster-operator/values.yaml
+++ b/helm/cluster-operator/values.yaml
@@ -1,4 +1,32 @@
-namespace: giantswarm
-
-userID: 1000
-groupID: 1000
+image:
+  registry: "quay.io"
+  repository: "giantswarm/cluster-operator"
+  tag: "[[ .Version ]]"
+pod:
+  user:
+    id: 1000
+  group:
+    id: 1000
+project:
+  name: "cluster-operator"
+# Resource names are truncated to 47 characters.
+#
+# Kubernetes allows 63 characters limit for resource names. When pods for
+# deployments are created they have additional 16 characters suffix, e.g.
+# "-957c9d6ff-pkzgw" and we want to have room for those suffixes.
+#
+# NOTE: All values under resource key need to be used with `tpl` to render them
+# correctly in the templates. This is because helm doesn't template values.yaml
+# file and it has to be a valid json. Example usage:
+#
+#     {{ tpl .Values.resource.default.name . }}.
+#
+resource:
+  default:
+    name: '{{ .Release.Name | replace "." "-" | trunc 47 }}'
+    namespace: "giantswarm"
+  psp:
+    name: '{{ .Release.Name | replace "." "-" | trunc 47 }}-psp'
+  pullSecret:
+    name: '{{ .Release.Name | replace "." "-" | trunc 47 }}-pull-secret'
+    namespace: "giantswarm"

--- a/helm/cluster-operator/values.yaml
+++ b/helm/cluster-operator/values.yaml
@@ -1,6 +1,6 @@
 image:
   registry: "quay.io"
-  repository: "giantswarm/cluster-operator"
+  name: "giantswarm/cluster-operator"
   tag: "[[ .Version ]]"
 pod:
   user:
@@ -9,6 +9,7 @@ pod:
     id: 1000
 project:
   name: "cluster-operator"
+  version: "[[ .Version ]]"
 # Resource names are truncated to 47 characters.
 #
 # Kubernetes allows 63 characters limit for resource names. When pods for


### PR DESCRIPTION
Towards giantswarm/giantswarm#7719.

Second part, this depends on #796 and replaces resource values in templates with references to variables defined in `values.yaml` which define versioned names.
