### PR TITLE
circleci: switch draughtsman deployments to thiccc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
         - ./cluster-operator
     - deploy:
         command: |
-          if [ "${CIRCLE_BRANCH}" == "master" ]; then
+          if [ "${CIRCLE_BRANCH}" == "thiccc" ]; then
             ./architect deploy
           fi
 
@@ -42,33 +42,33 @@ workflows:
           type: approval
           requires:
             - build
-          # Needed to prevent job from being triggered on master branch.
+          # Needed to prevent job from being triggered on thiccc branch.
           filters:
             branches:
-              ignore: master
+              ignore: thiccc
 
       - architect/push-to-docker:
           name: push-cluster-operator-to-aliyun-pr
           image: "registry-intl.cn-shanghai.aliyuncs.com/giantswarm/cluster-operator"
           username_envar: "ALIYUN_USERNAME"
           password_envar: "ALIYUN_PASSWORD"
-          # Push to Aliyun should execute for non-master branches only once manually approved.
+          # Push to Aliyun should execute for non-thiccc branches only once manually approved.
           requires:
             - hold-push-cluster-operator-to-aliyun-pr
-          # Needed to prevent job from being triggered on master branch.
+          # Needed to prevent job from being triggered on thiccc branch.
           filters:
             branches:
-              ignore: master
+              ignore: thiccc
 
-      # Push to Aliyun should execute without manual approval on master.
+      # Push to Aliyun should execute without manual approval on thiccc.
       - architect/push-to-docker:
-          name: push-cluster-operator-to-aliyun-master
+          name: push-cluster-operator-to-aliyun-thiccc
           image: "registry-intl.cn-shanghai.aliyuncs.com/giantswarm/cluster-operator"
           username_envar: "ALIYUN_USERNAME"
           password_envar: "ALIYUN_PASSWORD"
           requires:
             - build
-          # Needed to trigger job only on merge to master.
+          # Needed to trigger job only on merge to thiccc.
           filters:
             branches:
-              only: master
+              only: thiccc


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7720

⚠️ https://github.com/giantswarm/cluster-operator/pull/799 should be merged first.