### PR TITLE
helm/cluster-operator-chart: restore from 81bbd353

### DIFF
--- a/helm/cluster-operator-chart/Chart.yaml
+++ b/helm/cluster-operator-chart/Chart.yaml
@@ -1,0 +1,2 @@
+name: cluster-operator-chart
+version: 1.0.0-[[ .SHA ]]

--- a/helm/cluster-operator-chart/templates/configmap.yaml
+++ b/helm/cluster-operator-chart/templates/configmap.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-operator-configmap
+  namespace: {{ .Values.namespace }}
+data:
+  config.yml: |
+    server:
+      enable:
+        debug:
+          server: true
+      listen:
+        address: 'http://0.0.0.0:8000'
+    guest:
+      cluster:
+        calico:
+          subnet: '{{ .Values.Installation.V1.Guest.Calico.Subnet }}'
+          cidr: '{{ .Values.Installation.V1.Guest.Calico.CIDR }}'
+        kubernetes:
+          api:
+            clusterIPRange: '{{ .Values.Installation.V1.Guest.Kubernetes.API.ClusterIPRange }}'
+        vault:
+          certificate:
+            ttl: '{{ .Values.Installation.V1.Auth.Vault.Certificate.TTL }}'
+    service:
+      clusterService:
+        address: 'http://cluster-service:8000'
+      image:
+        registry:
+          domain: '{{ .Values.Installation.V1.Registry.Domain }}'
+      kubeconfig:
+        resource:
+          namespace: 'giantswarm'
+      kubernetes:
+        address: ''
+        inCluster: true
+        tls:
+          caFile: ''
+          crtFile: ''
+          keyFile: ''
+      provider:
+        kind: '{{ .Values.Installation.V1.Provider.Kind }}'

--- a/helm/cluster-operator-chart/templates/deployment.yaml
+++ b/helm/cluster-operator-chart/templates/deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cluster-operator
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: cluster-operator
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: cluster-operator
+      annotations:
+        releasetime: {{ $.Release.Time }}
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - cluster-operator
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      volumes:
+      - name: cluster-operator-configmap
+        configMap:
+          name: cluster-operator-configmap
+          items:
+          - key: config.yml
+            path: config.yml
+      serviceAccountName: cluster-operator
+      securityContext:
+        runAsUser: {{ .Values.userID }}
+        runAsGroup: {{ .Values.groupID }}
+      containers:
+      - name: cluster-operator
+        image: quay.io/giantswarm/cluster-operator:[[ .SHA ]]
+        args:
+        - daemon
+        - --config.dirs=/var/run/cluster-operator/configmap/
+        - --config.files=config
+        volumeMounts:
+        - name: cluster-operator-configmap
+          mountPath: /var/run/cluster-operator/configmap/
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
+          initialDelaySeconds: 30
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 220Mi
+          limits:
+            cpu: 100m
+            memory: 220Mi
+      imagePullSecrets:
+      - name: cluster-operator-pull-secret

--- a/helm/cluster-operator-chart/templates/psp.yaml
+++ b/helm/cluster-operator-chart/templates/psp.yaml
@@ -1,0 +1,29 @@
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: cluster-operator-psp
+spec:
+  privileged: false
+  fsGroup:
+    rule: MustRunAs
+    ranges:
+      - min: 1
+        max: 65535 
+  runAsUser:
+    rule: MustRunAsNonRoot
+  runAsGroup:
+    rule: MustRunAs
+    ranges:
+      - min: 1
+        max: 65535
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+    - 'secret'
+    - 'configMap'
+  allowPrivilegeEscalation: false
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false

--- a/helm/cluster-operator-chart/templates/pull-secret.yaml
+++ b/helm/cluster-operator-chart/templates/pull-secret.yaml
@@ -1,0 +1,9 @@
+
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/dockerconfigjson
+metadata:
+  name: cluster-operator-pull-secret
+  namespace: {{ .Values.namespace }}
+data:
+  .dockerconfigjson: {{ .Values.Installation.V1.Secret.Registry.PullSecret.DockerConfigJSON | b64enc | quote }}

--- a/helm/cluster-operator-chart/templates/rbac.yaml
+++ b/helm/cluster-operator-chart/templates/rbac.yaml
@@ -1,0 +1,115 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-operator
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - "*"
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - namespaces
+    verbs:
+      - create
+      - update
+      - delete
+      - get
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - create
+  - apiGroups:
+      - "application.giantswarm.io"
+    resources:
+      - apps
+    verbs:
+      - "*"
+  - apiGroups:
+      - "networking.k8s.io"
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      - clusterrolebindings
+    verbs:
+      - create
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - "*"
+  - apiGroups:
+      - cluster.k8s.io
+    resources:
+      - clusters
+      - clusters/status
+      - machinedeployments
+      - machinedeployments/status
+    verbs:
+      - "*"
+  - apiGroups:
+      - core.giantswarm.io
+    resources:
+      - awsclusterconfigs
+      - azureclusterconfigs
+      - certconfigs
+      - kvmclusterconfigs
+    verbs:
+      - "*"
+  - nonResourceURLs:
+      - "/"
+      - "/healthz"
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-operator
+subjects:
+  - kind: ServiceAccount
+    name: cluster-operator
+    namespace: {{ .Values.namespace }}
+roleRef:
+  kind: ClusterRole
+  name: cluster-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-operator-psp
+rules:
+  - apiGroups:
+      - extensions
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+    resourceNames:
+      - cluster-operator-psp
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-operator-psp
+subjects:
+  - kind: ServiceAccount
+    name: cluster-operator
+    namespace: {{ .Values.namespace }}
+roleRef:
+  kind: ClusterRole
+  name: cluster-operator-psp
+  apiGroup: rbac.authorization.k8s.io

--- a/helm/cluster-operator-chart/templates/service-account.yaml
+++ b/helm/cluster-operator-chart/templates/service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-operator
+  namespace: {{ .Values.namespace }}

--- a/helm/cluster-operator-chart/templates/service.yaml
+++ b/helm/cluster-operator-chart/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cluster-operator
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: cluster-operator
+  annotations:
+    prometheus.io/scrape: "true"
+spec:
+  ports:
+  - port: 8000
+  selector:
+    app: cluster-operator

--- a/helm/cluster-operator-chart/values.yaml
+++ b/helm/cluster-operator-chart/values.yaml
@@ -1,0 +1,4 @@
+namespace: giantswarm
+
+userID: 1000
+groupID: 1000


### PR DESCRIPTION
Towards giantswarm/giantswarm#7719.

Contents restored from commit 81bbd353 using: `git restore --source master^ helm/cluster-operator-chart`

This is needed on master for now to be able to test things.