### PR TITLE
helm/cluster-operator: make deployment compatible with K8s 1.16

### DIFF
--- a/helm/cluster-operator/templates/deployment.yaml
+++ b/helm/cluster-operator/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ tpl .Values.resource.default.name  . }}
@@ -8,6 +8,10 @@ metadata:
     version: {{ .Values.project.version }}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Values.project.name }}
+      version: {{ .Values.project.version }}
   strategy:
     type: Recreate
   template:


### PR DESCRIPTION
Use apps/v1 for Deployment and add a selector to match by app and
version. `extensions/v1beta1` is no longer available in 1.16.

Towards giantswarm/giantswarm#7675.