### PR TITLE
Exposes reconciled_version in build_info metric for master

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -382,7 +382,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:a2122f2c0fae0df1c4225df3c18e624d712566cb43eabc38c6f0914231cae2bb"
+  digest = "1:568716a2e87ca3f4fb9bce7f65b8491a2ab92c97adee4b2b750b1d76c709b183"
   name = "github.com/giantswarm/microendpoint"
   packages = [
     "endpoint/healthz",
@@ -391,7 +391,7 @@
     "service/version",
   ]
   pruneopts = "UT"
-  revision = "2c0b54e888d682445c698d2b2b3544b2001e84ac"
+  revision = "e991deac265373d9347b96ecc56b13f228be144f"
 
 [[projects]]
   branch = "master"

--- a/vendor/github.com/giantswarm/microendpoint/service/version/metric.go
+++ b/vendor/github.com/giantswarm/microendpoint/service/version/metric.go
@@ -12,7 +12,7 @@ var buildInfo = prometheus.NewGaugeVec(
 		Name:      "build_info",
 		Help:      "A metric with a constant '1' value labeled by commit, golang version, golang os, and golang arch.",
 	},
-	[]string{"commit", "golang_version", "golang_goos", "golang_goarch"},
+	[]string{"commit", "golang_version", "golang_goos", "golang_goarch", "reconciled_version"},
 )
 
 func init() {
@@ -20,5 +20,7 @@ func init() {
 }
 
 func (s *Service) updateBuildInfoMetric() {
-	buildInfo.WithLabelValues(s.gitCommit, runtime.Version(), runtime.GOOS, runtime.GOARCH).Set(1)
+	for _, bundle := range s.versionBundles {
+		buildInfo.WithLabelValues(s.gitCommit, runtime.Version(), runtime.GOOS, runtime.GOARCH, bundle.Version).Set(1)
+	}
 }


### PR DESCRIPTION
Update microendpoint to add reconciled_version metric

Towards: https://github.com/giantswarm/giantswarm/issues/7723