### PR TITLE
vendor: update for versionbundle

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -49,12 +49,12 @@
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:d37f34e1e231ee4b8657d1b6153e2696b1d7341850f648f5d78151d3bc1f677b"
+  digest = "1:a5f0485ed2aad9b9c6a730815d1f2bc92b0acc126d7ee8e36c1a51882fc284f5"
   name = "github.com/Masterminds/semver"
   packages = ["."]
   pruneopts = "UT"
-  revision = "fe7c21038085e01e67044ec1efe3afb1eaa59f75"
-  version = "v3.0.1"
+  revision = "25911d36c978be5eb3e81847734874fd4e1dc6c7"
+  version = "v3.0.2"
 
 [[projects]]
   digest = "1:b565deb585c50ab8e94fe5d6c9903f1495970b97814803e4ab0e70c0a9c87a30"
@@ -420,11 +420,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:8c692f26876d709cd28e18f6b0c935b15539097d6dfd5e71af87f12d1f420874"
+  digest = "1:672e0eb4d4982ab6bb53c51a7d874f81267806557cd611149b88e22feaecd494"
   name = "github.com/giantswarm/versionbundle"
   packages = ["."]
   pruneopts = "UT"
-  revision = "da16c09beea209bff3aff94585f6b8d81eee95e6"
+  revision = "21f4b8d7441e7dc7de8b2db37f712a675cf83a70"
 
 [[projects]]
   digest = "1:83a37f3bd4ccd13469775ef771e943e6c7cfaba6926decff6c83135e56512f08"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -103,6 +103,10 @@ required = [
   name = "github.com/google/go-cmp"
   version = "0.2.0"
 
+[[override]]
+  name = "github.com/Masterminds/semver"
+  version = "=3.0.2"
+
 [[constraint]]
   name = "github.com/spf13/viper"
   version = "1.0.0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -103,10 +103,6 @@ required = [
   name = "github.com/google/go-cmp"
   version = "0.2.0"
 
-[[override]]
-  name = "github.com/Masterminds/semver"
-  version = "=3.0.2"
-
 [[constraint]]
   name = "github.com/spf13/viper"
   version = "1.0.0"

--- a/vendor/github.com/Masterminds/semver/CHANGELOG.md
+++ b/vendor/github.com/Masterminds/semver/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.0.2 (2019-11-14)
+
+### Fixed
+
+- #134: Fixed broken constraint checking with ^0.0 (thanks @krmichelos)
+
 ## 3.0.1 (2019-09-13)
 
 ### Fixed

--- a/vendor/github.com/Masterminds/semver/constraints.go
+++ b/vendor/github.com/Masterminds/semver/constraints.go
@@ -493,6 +493,9 @@ func constraintCaret(v *Version, c *constraint) bool {
 	}
 
 	// ^ when the major is 0 and minor > 0 is >=0.y.z < 0.y+1
+	if c.con.Major() == 0 && v.Major() > 0 {
+		return false
+	}
 	// If the con Minor is > 0 it is not dirty
 	if c.con.Minor() > 0 || c.patchDirty {
 		return v.Minor() == c.con.Minor()

--- a/vendor/github.com/giantswarm/versionbundle/bundle.go
+++ b/vendor/github.com/giantswarm/versionbundle/bundle.go
@@ -172,21 +172,9 @@ func (b Bundle) Validate() error {
 		return microerror.Maskf(invalidBundleError, "name must not be empty")
 	}
 
-	versionSplit := strings.Split(b.Version, ".")
-	if len(versionSplit) != 3 {
-		return microerror.Maskf(invalidBundleError, "version format must be '<major>.<minor>.<patch>'")
-	}
-
-	if !isPositiveNumber(versionSplit[0]) {
-		return microerror.Maskf(invalidBundleError, "major version must be positive number")
-	}
-
-	if !isPositiveNumber(versionSplit[1]) {
-		return microerror.Maskf(invalidBundleError, "minor version must be positive number")
-	}
-
-	if !isPositiveNumber(versionSplit[2]) {
-		return microerror.Maskf(invalidBundleError, "patch version must be positive number")
+	_, err := semver.NewVersion(b.Version)
+	if err != nil {
+		return microerror.Maskf(invalidBundleError, "version parsing failed with error %#q", err)
 	}
 
 	return nil

--- a/vendor/github.com/giantswarm/versionbundle/changelog.go
+++ b/vendor/github.com/giantswarm/versionbundle/changelog.go
@@ -55,6 +55,9 @@ type Changelog struct {
 	// Kind is a machine readable type describing what kind of changelog the
 	// changelog actually is. Also see the kind type.
 	Kind kind `json:"kind" yaml:"kind"`
+	// URLs is a list of links which contain additional information to the
+	// changelog entry such as upstream changelogs or pull requests.
+	URLs []string `json:"urls" yaml:"urls"`
 }
 
 func (c Changelog) String() string {

--- a/vendor/github.com/giantswarm/versionbundle/component.go
+++ b/vendor/github.com/giantswarm/versionbundle/component.go
@@ -2,8 +2,8 @@ package versionbundle
 
 import (
 	"encoding/json"
-	"strings"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/giantswarm/microerror"
 )
 
@@ -26,21 +26,9 @@ func (c Component) Validate() error {
 		return microerror.Maskf(invalidComponentError, "version must not be empty")
 	}
 
-	versionSplit := strings.Split(c.Version, ".")
-	if len(versionSplit) != 3 {
-		return microerror.Maskf(invalidComponentError, "version format must be '<major>.<minor>.<patch>'")
-	}
-
-	if !isPositiveNumber(versionSplit[0]) {
-		return microerror.Maskf(invalidComponentError, "major version must be positive number")
-	}
-
-	if !isPositiveNumber(versionSplit[1]) {
-		return microerror.Maskf(invalidComponentError, "minor version must be positive number")
-	}
-
-	if !isPositiveNumber(versionSplit[2]) {
-		return microerror.Maskf(invalidComponentError, "patch version must be positive number")
+	_, err := semver.NewVersion(c.Version)
+	if err != nil {
+		return microerror.Maskf(invalidComponentError, "version parsing failed with error %#q", err)
 	}
 
 	return nil

--- a/vendor/github.com/giantswarm/versionbundle/release.go
+++ b/vendor/github.com/giantswarm/versionbundle/release.go
@@ -1,6 +1,7 @@
 package versionbundle
 
 import (
+	"reflect"
 	"sort"
 	"time"
 
@@ -91,7 +92,7 @@ func (r Release) Version() string {
 
 func (r *Release) removeChangelogEntry(clog Changelog) {
 	for i := 0; i < len(r.changelogs); i++ {
-		if clog == r.changelogs[i] {
+		if reflect.DeepEqual(clog, r.changelogs[i]) {
 			r.changelogs = append(r.changelogs[:i], r.changelogs[i+1:]...)
 			break
 		}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6881

Without updating versionbundle this operator fails to start with bundle version in pre-release format.

I used command:

```
$ dep ensure -update github.com/Masterminds/semver github.com/giantswarm/versionbundle
```

This didn't work initially because versionbundle depends on 3.0.2 and helmclient depends on 3.0.1.

I didn't want to mess with update to 1.16 which is in progress https://github.com/giantswarm/helmclient/pull/134.

I also asked there to update this https://github.com/giantswarm/helmclient/pull/134#issuecomment-559831323.

To make that work I had temporarily following lines to `Gopkg.toml`:

```
[[constraint]]
  name = "github.com/Masterminds/semver"
  version = "=3.0.2"
```

And then reverted after running `dep ensure`. This is dirty but I think least disruptive long term.