### PR TITLE
update pod anti-affinity label selector

### DIFF
--- a/helm/cluster-operator/templates/deployment.yaml
+++ b/helm/cluster-operator/templates/deployment.yaml
@@ -27,11 +27,9 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
           - podAffinityTerm:
               labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - {{ tpl .Values.resource.default.name  . }}
+                matchLabels:
+                  app: {{ .Values.project.name }}
+                  version: {{ .Values.project.version }}
               topologyKey: kubernetes.io/hostname
             weight: 100
       volumes:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/7719

* fix the `app` label value in `podAntiAffinity`
* add version label in `podAntiAffinity`
* simplify the label selector by using `matchLabels` instead of `matchExpressions`