### PR TITLE
update chart labels selector

### DIFF
--- a/helm/cluster-operator-chart/templates/deployment.yaml
+++ b/helm/cluster-operator-chart/templates/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Values.namespace }}
   labels:
     app: cluster-operator
+    version: {{ .Chart.Version }}
 spec:
   replicas: 1
   strategy:
@@ -13,6 +14,7 @@ spec:
     metadata:
       labels:
         app: cluster-operator
+        version: {{ .Chart.Version }}
       annotations:
         releasetime: {{ $.Release.Time }}
     spec:

--- a/helm/cluster-operator-chart/templates/deployment.yaml
+++ b/helm/cluster-operator-chart/templates/deployment.yaml
@@ -23,11 +23,9 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
           - podAffinityTerm:
               labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - cluster-operator
+                matchLabels:
+                  app: cluster-operator
+                  version: {{ .Chart.Version }}
               topologyKey: kubernetes.io/hostname
             weight: 100
       volumes:

--- a/helm/cluster-operator-chart/templates/service.yaml
+++ b/helm/cluster-operator-chart/templates/service.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Values.namespace }}
   labels:
     app: cluster-operator
+    version: {{ .Chart.Version }}
   annotations:
     prometheus.io/scrape: "true"
 spec:

--- a/helm/cluster-operator-chart/templates/service.yaml
+++ b/helm/cluster-operator-chart/templates/service.yaml
@@ -13,3 +13,4 @@ spec:
   - port: 8000
   selector:
     app: cluster-operator
+    version: {{ .Chart.Version }}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/7719

* add the `version` label in pod, this is important so `deployment` and `service` target the right pod version.
* add version label in `podAntiAffinity`
* simplify the label selector by using `matchLabels` instead of `matchExpressions`