### PR TITLE
service/controller/resource: drop v22 suffix from resource names

### DIFF
--- a/service/controller/resource/app/resource.go
+++ b/service/controller/resource/app/resource.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	Name = "appv22"
+	Name = "app"
 )
 
 // Config represents the configuration used to create a new chartconfig service.

--- a/service/controller/resource/certconfig/resource.go
+++ b/service/controller/resource/certconfig/resource.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "certconfigv22"
+	Name = "certconfig"
 )
 
 const (

--- a/service/controller/resource/cleanupmachinedeployments/resource.go
+++ b/service/controller/resource/cleanupmachinedeployments/resource.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	Name = "cleanupmachinedeploymentsv22"
+	Name = "cleanupmachinedeployments"
 )
 
 type Config struct {

--- a/service/controller/resource/clusterconfigmap/resource.go
+++ b/service/controller/resource/clusterconfigmap/resource.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "clusterconfigmapv22"
+	Name = "clusterconfigmap"
 )
 
 // Config represents the configuration used to create a new clusterConfigMap

--- a/service/controller/resource/clusterid/resource.go
+++ b/service/controller/resource/clusterid/resource.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	Name = "clusteridv22"
+	Name = "clusterid"
 )
 
 type Config struct {

--- a/service/controller/resource/clusterstatus/resource.go
+++ b/service/controller/resource/clusterstatus/resource.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	Name = "clusterstatusv22"
+	Name = "clusterstatus"
 )
 
 type Config struct {

--- a/service/controller/resource/cpnamespace/resource.go
+++ b/service/controller/resource/cpnamespace/resource.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "cpnamespacev22"
+	Name = "cpnamespace"
 )
 
 // Config represents the configuration used to create a new namespace resource.

--- a/service/controller/resource/encryptionkey/resource.go
+++ b/service/controller/resource/encryptionkey/resource.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "encryptionkeyv22"
+	Name = "encryptionkey"
 )
 
 // Config represents the configuration used to create a new cloud config resource.

--- a/service/controller/resource/kubeconfig/resource.go
+++ b/service/controller/resource/kubeconfig/resource.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "kubeconfigv22"
+	Name = "kubeconfig"
 )
 
 // Config represents the configuration used to create a new kubeconfig resource.

--- a/service/controller/resource/machinedeploymentstatus/resource.go
+++ b/service/controller/resource/machinedeploymentstatus/resource.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	Name = "machinedeploymentstatusv22"
+	Name = "machinedeploymentstatus"
 )
 
 type Config struct {

--- a/service/controller/resource/operatorversions/resource.go
+++ b/service/controller/resource/operatorversions/resource.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	Name = "operatorversionsv22"
+	Name = "operatorversions"
 )
 
 type Config struct {

--- a/service/controller/resource/tenantclients/resource.go
+++ b/service/controller/resource/tenantclients/resource.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	Name = "tenantclientsv22"
+	Name = "tenantclients"
 )
 
 type Config struct {

--- a/service/controller/resource/updatemachinedeployments/resource.go
+++ b/service/controller/resource/updatemachinedeployments/resource.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	Name = "updatemachinedeploymentsv22"
+	Name = "updatemachinedeployments"
 )
 
 type Config struct {

--- a/service/controller/resource/workercount/resource.go
+++ b/service/controller/resource/workercount/resource.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	Name = "workercountv22"
+	Name = "workercount"
 )
 
 type Config struct {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7722.
