### PR TITLE
Migrate Ingress Controller to app CR for legacy

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,8 +1,8 @@
 package project
 
 var (
-	bundleVersion = "0.21.1-dev"
-	description   = "The cluster-operator manages Kubernetes guest cluster resources."
+	bundleVersion = "0.21.1-dev-rossf7"
+	description   = "The cluster-operator manages Kubernetes tenant cluster resources."
 	gitSHA        = "n/a"
 	name          = "cluster-operator"
 	source        = "https://github.com/giantswarm/cluster-operator"

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,7 +1,7 @@
 package project
 
 var (
-	bundleVersion = "0.21.1-dev-rossf7"
+	bundleVersion = "0.21.1-dev"
 	description   = "The cluster-operator manages Kubernetes tenant cluster resources."
 	gitSHA        = "n/a"
 	name          = "cluster-operator"

--- a/pkg/project/version_bundle_aws.go
+++ b/pkg/project/version_bundle_aws.go
@@ -26,6 +26,11 @@ var versionBundleAWS = versionbundle.Bundle{
 			Description: "Updated to version 0.18.1.",
 			Kind:        versionbundle.KindChanged,
 		},
+		{
+			Component:   "nginx-ingress-controller",
+			Description: "Migrated to use default app catalog.",
+			Kind:        versionbundle.KindChanged,
+		},
 	},
 	Components: []versionbundle.Component{
 		{

--- a/pkg/project/version_bundle_azure.go
+++ b/pkg/project/version_bundle_azure.go
@@ -26,6 +26,11 @@ var versionBundleAzure = versionbundle.Bundle{
 			Description: "Migrated to use default app catalog.",
 			Kind:        versionbundle.KindChanged,
 		},
+		{
+			Component:   "nginx-ingress-controller",
+			Description: "Migrated to use default app catalog.",
+			Kind:        versionbundle.KindChanged,
+		},
 	},
 	Components: []versionbundle.Component{
 		{

--- a/pkg/project/version_bundle_kvm.go
+++ b/pkg/project/version_bundle_kvm.go
@@ -21,6 +21,11 @@ var versionBundleKVM = versionbundle.Bundle{
 			Description: "Updated to version 0.18.1.",
 			Kind:        versionbundle.KindChanged,
 		},
+		{
+			Component:   "nginx-ingress-controller",
+			Description: "Migrated to use default app catalog.",
+			Kind:        versionbundle.KindChanged,
+		},
 	},
 	Components: []versionbundle.Component{
 		{

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -135,6 +135,17 @@ func CommonAppSpecs() []AppSpec {
 			Version:         "1.4.0",
 		},
 		{
+			App:           "nginx-ingress-controller",
+			Catalog:       "default",
+			Chart:         "nginx-ingress-controller-app",
+			ConfigMapName: IngressControllerConfigMapName,
+			Namespace:     metav1.NamespaceSystem,
+			// Upgrade force is disabled to avoid dropping customer traffic
+			// that is using the Ingress Controller.
+			UseUpgradeForce: false,
+			Version:         "1.1.0",
+		},
+		{
 			App:             "node-exporter",
 			Catalog:         "default",
 			Chart:           "node-exporter-app",
@@ -207,7 +218,7 @@ func CommonChartSpecs() []ChartSpec {
 			ChannelName:   "1-0-stable",
 			ChartName:     "kubernetes-nginx-ingress-controller-chart",
 			ConfigMapName: "nginx-ingress-controller-values",
-			HasAppCR:      false,
+			HasAppCR:      true,
 			Namespace:     metav1.NamespaceSystem,
 			ReleaseName:   "nginx-ingress-controller",
 			// Upgrade force is disabled to avoid dropping customer traffic

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -45,6 +45,17 @@ func (r *StateGetter) GetDesiredState(ctx context.Context, obj interface{}) ([]*
 		}
 	}
 
+	// We limit the number of replicas to 20 as running more than this does
+	// not make sense.
+	//
+	// TODO: Remove Ingress Controller configmap once HPA is enabled by default.
+	//
+	//	https://github.com/giantswarm/giantswarm/issues/8080
+	//
+	if ingressControllerReplicas > 20 {
+		ingressControllerReplicas = 20
+	}
+
 	configMapSpecs := []configMapSpec{
 		{
 			Name:      key.ClusterConfigMapName(clusterConfig),


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7029

Migrates the last default app from a chartconfig CR to an app CR for the legacy controllers.