### PR TITLE
Add configmap for ingress controller replicas

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,7 +1,7 @@
 package project
 
 var (
-	bundleVersion = "2.0.0-dev"
+	bundleVersion = "2.0.0-dev-rossf7"
 	description   = "The cluster-operator manages Kubernetes guest cluster resources."
 	gitSHA        = "n/a"
 	name          = "cluster-operator"

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,7 +1,7 @@
 package project
 
 var (
-	bundleVersion = "2.0.0-dev-rossf7"
+	bundleVersion = "2.0.0-rc1"
 	description   = "The cluster-operator manages Kubernetes guest cluster resources."
 	gitSHA        = "n/a"
 	name          = "cluster-operator"

--- a/pkg/project/version_bundle.go
+++ b/pkg/project/version_bundle.go
@@ -34,10 +34,6 @@ func VersionBundle(p string) versionbundle.Bundle {
 				Version: "1.8.0",
 			},
 			{
-				Name:    "nginx-ingress-controller",
-				Version: "0.26.1",
-			},
-			{
 				Name:    "node-exporter",
 				Version: "0.18.1",
 			},

--- a/service/controller/key/provider_appspecs.go
+++ b/service/controller/key/provider_appspecs.go
@@ -33,7 +33,7 @@ func AWSAppSpecs() []AppSpec {
 			ClusterAPIOnly:  true,
 			Namespace:       metav1.NamespaceSystem,
 			UseUpgradeForce: true,
-			Version:         "1.0.0",
+			Version:         "1.0.1",
 		},
 		{
 			App:             "cluster-autoscaler",

--- a/service/controller/resource/app/current.go
+++ b/service/controller/resource/app/current.go
@@ -32,6 +32,14 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) ([]*v1a
 		return nil, nil
 	}
 
+	// The app custom resources are deleted when the namespace is deleted.
+	if key.IsDeleted(&cr) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not deleting apps for tenant cluster %#q", key.ClusterID(&cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+		return nil, nil
+	}
+
 	var apps []*v1alpha1.App
 	{
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding apps for tenant cluster %#q", key.ClusterID(&cr)))

--- a/service/controller/resource/app/current.go
+++ b/service/controller/resource/app/current.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/cluster-operator/pkg/label"
@@ -18,15 +17,6 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) ([]*v1a
 	cr, err := key.ToCluster(obj)
 	if err != nil {
 		return nil, microerror.Mask(err)
-	}
-
-	// The app custom resource is deleted implicitly by the provider operator
-	// when it deletes the tenant cluster namespace in the control plane.
-	if key.IsDeleted(&cr) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not deleting apps for tenant cluster %#q", key.ClusterID(&cr)))
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-		resourcecanceledcontext.SetCanceled(ctx)
-		return nil, nil
 	}
 
 	var apps []*v1alpha1.App

--- a/service/controller/resource/app/current.go
+++ b/service/controller/resource/app/current.go
@@ -6,10 +6,12 @@ import (
 
 	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
 	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/cluster-operator/pkg/label"
 	"github.com/giantswarm/cluster-operator/pkg/project"
+	"github.com/giantswarm/cluster-operator/service/controller/controllercontext"
 	"github.com/giantswarm/cluster-operator/service/controller/key"
 )
 

--- a/service/controller/resource/app/current.go
+++ b/service/controller/resource/app/current.go
@@ -18,6 +18,17 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) ([]*v1a
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	if cc.Status.Endpoint.Base == "" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "no endpoint base in controller context yet")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+		return nil, nil
+	}
 
 	var apps []*v1alpha1.App
 	{

--- a/service/controller/resource/clusterconfigmap/current.go
+++ b/service/controller/resource/clusterconfigmap/current.go
@@ -32,6 +32,14 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) ([]*cor
 		return nil, nil
 	}
 
+	// The config maps are deleted when the namespace is deleted.
+	if key.IsDeleted(&cr) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not deleting config maps for tenant cluster %#q", key.ClusterID(&cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+		return nil, nil
+	}
+
 	var configMaps []*corev1.ConfigMap
 	{
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding cluster config maps in namespace %#q", key.ClusterID(&cr)))

--- a/service/controller/resource/clusterconfigmap/current.go
+++ b/service/controller/resource/clusterconfigmap/current.go
@@ -31,15 +31,6 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) ([]*cor
 		return nil, nil
 	}
 
-	// The cluster config map is deleted implicitly by the provider operator when
-	// it deletes the tenant cluster namespace in the control plane.
-	if key.IsDeleted(&cr) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not deleting config map %#q for tenant cluster %#q", key.ClusterConfigMapName(&cr), key.ClusterID(&cr)))
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-		resourcecanceledcontext.SetCanceled(ctx)
-		return nil, nil
-	}
-
 	var configMap *corev1.ConfigMap
 	{
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding config map %#q for tenant cluster %#q", key.ClusterConfigMapName(&cr), key.ClusterID(&cr)))

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -7,6 +7,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 
 	"github.com/giantswarm/cluster-operator/pkg/label"
 	"github.com/giantswarm/cluster-operator/pkg/project"
@@ -24,35 +25,85 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 		return nil, microerror.Mask(err)
 	}
 
-	var configMap *corev1.ConfigMap
+	var ingressControllerReplicas int32
 	{
-		v := map[string]string{
-			"baseDomain":   key.TenantEndpoint(cr, cc.Status.Endpoint.Base),
-			"clusterDNSIP": r.dnsIP,
-			"clusterID":    key.ClusterID(&cr),
+		// We set the number of replicas to the number of worker nodes. This is
+		// set by the workercount resource which returns a map with each node
+		// pool and its current number of nodes.
+		for _, v := range cc.Status.Worker {
+			ingressControllerReplicas += v.Nodes
 		}
+	}
 
-		b, err := yaml.Marshal(v)
+	// We limit the number of replicas to 20 as running more than this does
+	// not make sense.
+	//
+	// TODO: Remove Ingress Controller configmap once HPA is enabled by default.
+	//
+	//	https://github.com/giantswarm/giantswarm/issues/8080
+	//
+	if ingressControllerReplicas > 20 {
+		ingressControllerReplicas = 20
+	}
+
+	configMapSpecs := []configMapSpec{
+		{
+			Name:      key.ClusterConfigMapName(&cr),
+			Namespace: key.ClusterID(&cr),
+			Values: map[string]interface{}{
+				"baseDomain":   key.TenantEndpoint(cr, cc.Status.Endpoint.Base),
+				"clusterDNSIP": r.dnsIP,
+				"clusterID":    key.ClusterID(&cr),
+			},
+		},
+		{
+			Name:      "ingress-controller-values",
+			Namespace: key.ClusterID(&cr),
+			Values: map[string]interface{}{
+				"baseDomain": key.TenantEndpoint(cr, cc.Status.Endpoint.Base),
+				"clusterID":  key.ClusterID(&cr),
+				"ingressController": map[string]interface{}{
+					"replicas": ingressControllerReplicas,
+				},
+			},
+		},
+	}
+
+	var configMaps []*corev1.ConfigMap
+
+	for _, spec := range configMapSpecs {
+		configMap, err := newConfigMap(cr, spec)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 
-		configMap = &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      key.ClusterConfigMapName(&cr),
-				Namespace: key.ClusterID(&cr),
-				Labels: map[string]string{
-					label.Cluster:      key.ClusterID(&cr),
-					label.ManagedBy:    project.Name(),
-					label.Organization: key.OrganizationID(&cr),
-					label.ServiceType:  label.ServiceTypeManaged,
-				},
-			},
-			Data: map[string]string{
-				"values": string(b),
-			},
-		}
+		configMaps = append(configMaps, configMap)
 	}
 
-	return []*corev1.ConfigMap{configMap}, nil
+	return configMaps, nil
+}
+
+func newConfigMap(cr apiv1alpha2.Cluster, configMapSpec configMapSpec) (*corev1.ConfigMap, error) {
+	yamlValues, err := yaml.Marshal(configMapSpec.Values)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapSpec.Name,
+			Namespace: configMapSpec.Namespace,
+			Labels: map[string]string{
+				label.Cluster:      key.ClusterID(&cr),
+				label.ManagedBy:    project.Name(),
+				label.Organization: key.OrganizationID(&cr),
+				label.ServiceType:  label.ServiceTypeManaged,
+			},
+		},
+		Data: map[string]string{
+			"values": string(yamlValues),
+		},
+	}
+
+	return cm, nil
 }

--- a/service/controller/resource/clusterconfigmap/types.go
+++ b/service/controller/resource/clusterconfigmap/types.go
@@ -1,0 +1,7 @@
+package clusterconfigmap
+
+type configMapSpec struct {
+	Name      string
+	Namespace string
+	Values    map[string]interface{}
+}

--- a/service/controller/resource/kubeconfig/current.go
+++ b/service/controller/resource/kubeconfig/current.go
@@ -31,6 +31,14 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) ([]*cor
 		return nil, nil
 	}
 
+	// The secrets are deleted when the namespace is deleted.
+	if key.IsDeleted(&cr) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not deleting kubeconfig secret for tenant cluster %#q", key.ClusterID(&cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+		return nil, nil
+	}
+
 	var secret *corev1.Secret
 	{
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding secret %#q for tenant cluster %#q", key.KubeConfigSecretName(&cr), key.ClusterID(&cr)))

--- a/service/controller/resource/kubeconfig/current.go
+++ b/service/controller/resource/kubeconfig/current.go
@@ -31,15 +31,6 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) ([]*cor
 		return nil, nil
 	}
 
-	// The kube config secret is deleted implicitely by the provider operator when
-	// it deletes the tenant cluster namespace in the control plane.
-	if key.IsDeleted(&cr) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not deleting secret %#q for tenant cluster %#q", key.KubeConfigSecretName(&cr), key.ClusterID(&cr)))
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-		resourcecanceledcontext.SetCanceled(ctx)
-		return nil, nil
-	}
-
 	var secret *corev1.Secret
 	{
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding secret %#q for tenant cluster %#q", key.KubeConfigSecretName(&cr), key.ClusterID(&cr)))


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/23

Until we enable HPA for Nginx Ingress Controller by default we need a way to set the replicas based on the number of nodes.

- A second `ingress-controller-values` configmap has been added to do this.
- The cluster configmap must only contain values that are static for the lifetime of the cluster.
- Otherwise scaling the cluster will update all apps using this configmap.

This PR needs to be tested with https://github.com/giantswarm/nginx-ingress-controller-app which will be an optional component for Node Pools clusters.
