### PR TITLE
Work with infrastructurev1alpha2.AWSCluster on all providers

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"sync"
 	"time"
@@ -298,14 +297,9 @@ func newBaseClusterConfig(f *flag.Flag, v *viper.Viper) (*cluster.Config, error)
 }
 
 func newCommonClusterObjectFunc(provider string) func() infrastructurev1alpha2.CommonClusterObject {
-	switch provider {
-	case "aws":
-		return func() infrastructurev1alpha2.CommonClusterObject {
-			return new(infrastructurev1alpha2.AWSCluster)
-		}
-
-	default:
-		panic(fmt.Sprintf("No support for provider %s", provider))
+	// Deal with different providers in here once they reach Cluster API.
+	return func() infrastructurev1alpha2.CommonClusterObject {
+		return new(infrastructurev1alpha2.AWSCluster)
 	}
 }
 


### PR DESCRIPTION
The master branch of cluster-operator is only meant to be used with
Cluster API. Currently there's only AWS implementation and hence we
cannot distinguish different CRs based on provider.

Due to our deployment pipeline, this will nevertheless get deployed in
all installations and therefore it must not panic.