### PR TITLE
Set correct values for Ingress Controller configmap for legacy AWS and KVM

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,7 +1,7 @@
 package project
 
 var (
-	bundleVersion = "0.21.1-dev"
+	bundleVersion = "0.21.1-dev-rossf7"
 	description   = "The cluster-operator manages Kubernetes tenant cluster resources."
 	gitSHA        = "n/a"
 	name          = "cluster-operator"

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,7 +1,7 @@
 package project
 
 var (
-	bundleVersion = "0.21.1-dev-rossf7"
+	bundleVersion = "0.21.1-dev"
 	description   = "The cluster-operator manages Kubernetes tenant cluster resources."
 	gitSHA        = "n/a"
 	name          = "cluster-operator"

--- a/service/controller/aws/resource_set.go
+++ b/service/controller/aws/resource_set.go
@@ -200,6 +200,7 @@ func newResourceSet(config resourceSetConfig) (*controller.ResourceSet, error) {
 			Logger:                   config.Logger,
 
 			ClusterIPRange: config.ClusterIPRange,
+			Provider:       config.Provider,
 		}
 
 		stateGetter, err := clusterconfigmap.New(c)

--- a/service/controller/azure/resource_set.go
+++ b/service/controller/azure/resource_set.go
@@ -197,6 +197,7 @@ func newResourceSet(config resourceSetConfig) (*controller.ResourceSet, error) {
 			Logger:                   config.Logger,
 
 			ClusterIPRange: config.ClusterIPRange,
+			Provider:       config.Provider,
 		}
 
 		stateGetter, err := clusterconfigmap.New(c)

--- a/service/controller/kvm/resource_set.go
+++ b/service/controller/kvm/resource_set.go
@@ -196,6 +196,7 @@ func newResourceSet(config resourceSetConfig) (*controller.ResourceSet, error) {
 			Logger:                   config.Logger,
 
 			ClusterIPRange: config.ClusterIPRange,
+			Provider:       config.Provider,
 		}
 
 		stateGetter, err := clusterconfigmap.New(c)

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -70,7 +70,7 @@ func (r *StateGetter) GetDesiredState(ctx context.Context, obj interface{}) ([]*
 		}
 	}
 
-	// useProxyProtocol is only enabled for AWS clusters.
+	// useProxyProtocol is only enabled by default for AWS clusters.
 	var useProxyProtocol bool
 	{
 		if r.provider == "aws" {

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -70,6 +70,14 @@ func (r *StateGetter) GetDesiredState(ctx context.Context, obj interface{}) ([]*
 		}
 	}
 
+	// useProxyProtocol is only enabled for AWS clusters.
+	var useProxyProtocol bool
+	{
+		if r.provider == "aws" {
+			useProxyProtocol = true
+		}
+	}
+
 	configMapSpecs := []configMapSpec{
 		{
 			Name:      key.ClusterConfigMapName(clusterConfig),
@@ -89,6 +97,11 @@ func (r *StateGetter) GetDesiredState(ctx context.Context, obj interface{}) ([]*
 				"controller": map[string]interface{}{
 					"service": map[string]interface{}{
 						"enabled": controllerServiceEnabled,
+					},
+				},
+				"global": map[string]interface{}{
+					"controller": map[string]interface{}{
+						"useProxyProtocol": useProxyProtocol,
 					},
 				},
 				"ingressController": map[string]interface{}{

--- a/service/controller/resource/clusterconfigmap/error.go
+++ b/service/controller/resource/clusterconfigmap/error.go
@@ -2,6 +2,10 @@ package clusterconfigmap
 
 import "github.com/giantswarm/microerror"
 
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
 var invalidConfigError = &microerror.Error{
 	Kind: "invalidConfigError",
 }

--- a/service/controller/resource/clusterconfigmap/resource.go
+++ b/service/controller/resource/clusterconfigmap/resource.go
@@ -27,6 +27,7 @@ type Config struct {
 
 	// Settings.
 	ClusterIPRange string
+	Provider       string
 }
 
 // Resource implements the clusterConfigMap resource.
@@ -40,6 +41,7 @@ type StateGetter struct {
 
 	// Settings.
 	clusterIPRange string
+	provider       string
 }
 
 // New creates a new configured clusterConfigMap resource.
@@ -65,6 +67,9 @@ func New(config Config) (*StateGetter, error) {
 	if config.ClusterIPRange == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ClusterIPRange must not be empty", config)
 	}
+	if config.Provider == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Provider must not be empty", config)
+	}
 
 	r := &StateGetter{
 		// Dependencies.
@@ -76,6 +81,7 @@ func New(config Config) (*StateGetter, error) {
 
 		// Settings
 		clusterIPRange: config.ClusterIPRange,
+		provider:       config.Provider,
 	}
 
 	return r, nil


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7029

On AWS fix is to disable the controller service and enable proxy protocol. AWS is the only provider that has proxy protocol enabled by default.

On KVM just disables the controller service.