### PR TITLE
legacy: Use node label instead of node-role

### DIFF
--- a/pkg/label/k8s.go
+++ b/pkg/label/k8s.go
@@ -1,6 +1,6 @@
 package label
 
 const (
-	// MasterNodeRole label denotes K8s cluster master node role.
-	MasterNodeRole = "node-role.kubernetes.io/master"
+	// MasterNode label denotes a K8s cluster master node.
+	MasterNode = "node.kubernetes.io/master"
 )

--- a/service/controller/resource/workercount/create.go
+++ b/service/controller/resource/workercount/create.go
@@ -40,7 +40,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			//
 			// Constructing this LabelSelector is not currently possible with
 			// k8s types and functions. Therefore it's hardcoded here.
-			LabelSelector: fmt.Sprintf("!%s", label.MasterNodeRole),
+			LabelSelector: fmt.Sprintf("!%s", label.MasterNode),
 		}
 
 		l, err := cc.Client.TenantCluster.K8s.CoreV1().Nodes().List(o)


### PR DESCRIPTION
With kubernetes 1.16 the `node-role` label is deprecated and we switch to the `node` label instead

towards https://github.com/giantswarm/giantswarm/issues/7428 and https://github.com/giantswarm/giantswarm/issues/7824

Legacy port of https://github.com/giantswarm/cluster-operator/pull/810