### PR TITLE
legacy: Increment app versions to include chart changes for K8s 1.16

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,7 +1,7 @@
 package project
 
 var (
-	bundleVersion = "0.21.1-dev"
+	bundleVersion = "0.21.1-dev-rossf7"
 	description   = "The cluster-operator manages Kubernetes tenant cluster resources."
 	gitSHA        = "n/a"
 	name          = "cluster-operator"

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,7 +1,7 @@
 package project
 
 var (
-	bundleVersion = "0.21.1-dev-rossf7"
+	bundleVersion = "0.21.1-dev"
 	description   = "The cluster-operator manages Kubernetes tenant cluster resources."
 	gitSHA        = "n/a"
 	name          = "cluster-operator"

--- a/pkg/project/version_bundle_aws.go
+++ b/pkg/project/version_bundle_aws.go
@@ -17,6 +17,11 @@ var versionBundleAWS = versionbundle.Bundle{
 			Kind:        versionbundle.KindChanged,
 		},
 		{
+			Component:   "kube-state-metrics",
+			Description: "Updated to version 1.9.0.",
+			Kind:        versionbundle.KindChanged,
+		},
+		{
 			Component:   "net-exporter",
 			Description: "Updated to version 1.4.3.",
 			Kind:        versionbundle.KindChanged,
@@ -35,7 +40,7 @@ var versionBundleAWS = versionbundle.Bundle{
 	Components: []versionbundle.Component{
 		{
 			Name:    "kube-state-metrics",
-			Version: "1.8.0",
+			Version: "1.9.0",
 		},
 		{
 			Name:    "nginx-ingress-controller",

--- a/pkg/project/version_bundle_azure.go
+++ b/pkg/project/version_bundle_azure.go
@@ -12,6 +12,11 @@ var versionBundleAzure = versionbundle.Bundle{
 			Kind:        versionbundle.KindChanged,
 		},
 		{
+			Component:   "kube-state-metrics",
+			Description: "Updated to version 1.9.0.",
+			Kind:        versionbundle.KindChanged,
+		},
+		{
 			Component:   "net-exporter",
 			Description: "Updated to version 1.4.3.",
 			Kind:        versionbundle.KindChanged,
@@ -35,7 +40,7 @@ var versionBundleAzure = versionbundle.Bundle{
 	Components: []versionbundle.Component{
 		{
 			Name:    "kube-state-metrics",
-			Version: "1.8.0",
+			Version: "1.9.0",
 		},
 		{
 			Name:    "nginx-ingress-controller",

--- a/pkg/project/version_bundle_kvm.go
+++ b/pkg/project/version_bundle_kvm.go
@@ -12,6 +12,11 @@ var versionBundleKVM = versionbundle.Bundle{
 			Kind:        versionbundle.KindChanged,
 		},
 		{
+			Component:   "kube-state-metrics",
+			Description: "Updated to version 1.9.0.",
+			Kind:        versionbundle.KindChanged,
+		},
+		{
 			Component:   "net-exporter",
 			Description: "Updated to version 1.4.3.",
 			Kind:        versionbundle.KindChanged,
@@ -30,7 +35,7 @@ var versionBundleKVM = versionbundle.Bundle{
 	Components: []versionbundle.Component{
 		{
 			Name:    "kube-state-metrics",
-			Version: "1.8.0",
+			Version: "1.9.0",
 		},
 		{
 			Name:    "nginx-ingress-controller",

--- a/service/controller/aws/key/key.go
+++ b/service/controller/aws/key/key.go
@@ -13,24 +13,6 @@ func AppSpecs() []key.AppSpec {
 	// Add any provider specific charts here.
 	return []key.AppSpec{
 		{
-			App:             "external-dns",
-			Catalog:         "default",
-			Chart:           "external-dns-app",
-			ClusterAPIOnly:  true,
-			Namespace:       metav1.NamespaceSystem,
-			UseUpgradeForce: true,
-			Version:         "1.1.0",
-		},
-		{
-			App:             "kiam",
-			Catalog:         "default",
-			Chart:           "kiam-app",
-			ClusterAPIOnly:  true,
-			Namespace:       metav1.NamespaceSystem,
-			UseUpgradeForce: true,
-			Version:         "1.0.1",
-		},
-		{
 			App:             "cert-manager",
 			Catalog:         "default",
 			Chart:           "cert-manager-app",
@@ -46,6 +28,24 @@ func AppSpecs() []key.AppSpec {
 			Namespace:       metav1.NamespaceSystem,
 			UseUpgradeForce: true,
 			Version:         "1.1.2",
+		},
+		{
+			App:             "external-dns",
+			Catalog:         "default",
+			Chart:           "external-dns-app",
+			ClusterAPIOnly:  true,
+			Namespace:       metav1.NamespaceSystem,
+			UseUpgradeForce: true,
+			Version:         "1.1.0",
+		},
+		{
+			App:             "kiam",
+			Catalog:         "default",
+			Chart:           "kiam-app",
+			ClusterAPIOnly:  true,
+			Namespace:       metav1.NamespaceSystem,
+			UseUpgradeForce: true,
+			Version:         "1.0.2",
 		},
 	}
 }

--- a/service/controller/aws/key/key.go
+++ b/service/controller/aws/key/key.go
@@ -19,7 +19,7 @@ func AppSpecs() []key.AppSpec {
 			ClusterAPIOnly:  true,
 			Namespace:       metav1.NamespaceSystem,
 			UseUpgradeForce: true,
-			Version:         "1.0.1",
+			Version:         "1.1.0",
 		},
 		{
 			App:             "kiam",
@@ -37,7 +37,7 @@ func AppSpecs() []key.AppSpec {
 			ClusterAPIOnly:  true,
 			Namespace:       metav1.NamespaceSystem,
 			UseUpgradeForce: true,
-			Version:         "1.0.2",
+			Version:         "1.0.3",
 		},
 		{
 			App:             "cluster-autoscaler",
@@ -45,7 +45,7 @@ func AppSpecs() []key.AppSpec {
 			Chart:           "cluster-autoscaler-app",
 			Namespace:       metav1.NamespaceSystem,
 			UseUpgradeForce: true,
-			Version:         "1.1.1",
+			Version:         "1.1.2",
 		},
 	}
 }

--- a/service/controller/azure/key/key.go
+++ b/service/controller/azure/key/key.go
@@ -18,7 +18,7 @@ func AppSpecs() []key.AppSpec {
 			Chart:           "external-dns-app",
 			Namespace:       metav1.NamespaceSystem,
 			UseUpgradeForce: true,
-			Version:         "1.0.1",
+			Version:         "1.1.0",
 		},
 	}
 }

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -143,7 +143,7 @@ func CommonAppSpecs() []AppSpec {
 			// Upgrade force is disabled to avoid dropping customer traffic
 			// that is using the Ingress Controller.
 			UseUpgradeForce: false,
-			Version:         "1.1.0",
+			Version:         "1.1.1",
 		},
 		{
 			App:             "node-exporter",

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -100,7 +100,7 @@ func CommonAppSpecs() []AppSpec {
 			Namespace: metav1.NamespaceSystem,
 			// Upgrade force is disabled to avoid affecting customer workloads.
 			UseUpgradeForce: false,
-			Version:         "1.1.1",
+			Version:         "1.1.2",
 		},
 		{
 			App:             "chart-operator",
@@ -124,7 +124,7 @@ func CommonAppSpecs() []AppSpec {
 			Chart:           "metrics-server-app",
 			Namespace:       metav1.NamespaceSystem,
 			UseUpgradeForce: true,
-			Version:         "0.4.1",
+			Version:         "1.0.0",
 		},
 		{
 			App:             "net-exporter",

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -86,14 +86,18 @@ func ClusterOrganization(clusterGuestConfig v1alpha1.ClusterGuestConfig) string 
 func CommonAppSpecs() []AppSpec {
 	return []AppSpec{
 		{
-			App:             "cert-exporter",
+			// chart-operator must be installed first so the chart CRD is
+			// created in the tenant cluster.
+			App:             "chart-operator",
 			Catalog:         "default",
-			Chart:           "cert-exporter",
-			Namespace:       metav1.NamespaceSystem,
+			Chart:           "chart-operator",
+			Namespace:       "giantswarm",
 			UseUpgradeForce: true,
-			Version:         "1.2.1",
+			Version:         "0.11.2",
 		},
 		{
+			// coredns must be installed second as its a requirement for other
+			// apps.
 			App:       "coredns",
 			Catalog:   "default",
 			Chart:     "coredns-app",
@@ -103,12 +107,12 @@ func CommonAppSpecs() []AppSpec {
 			Version:         "1.1.2",
 		},
 		{
-			App:             "chart-operator",
+			App:             "cert-exporter",
 			Catalog:         "default",
-			Chart:           "chart-operator",
-			Namespace:       "giantswarm",
+			Chart:           "cert-exporter",
+			Namespace:       metav1.NamespaceSystem,
 			UseUpgradeForce: true,
-			Version:         "0.11.2",
+			Version:         "1.2.1",
 		},
 		{
 			App:             "kube-state-metrics",


### PR DESCRIPTION
Towards giantswarm/giantswarm#7675

I haven't included changelogs because the helm chart changes are minor. But changes are described in the app repo changelogs.