### PR TITLE
fix cluster status condition to be reconciled upon cluster creation

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,7 +1,7 @@
 package project
 
 var (
-	bundleVersion = "2.0.1-dev"
+	bundleVersion = "2.0.1-xh3b4sd"
 	description   = "The cluster-operator manages Kubernetes guest cluster resources."
 	gitSHA        = "n/a"
 	name          = "cluster-operator"

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,7 +1,7 @@
 package project
 
 var (
-	bundleVersion = "2.0.1-xh3b4sd"
+	bundleVersion = "2.0.1-dev"
 	description   = "The cluster-operator manages Kubernetes guest cluster resources."
 	gitSHA        = "n/a"
 	name          = "cluster-operator"

--- a/pkg/project/version_bundle.go
+++ b/pkg/project/version_bundle.go
@@ -8,9 +8,12 @@ func VersionBundle(p string) versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "todo",
-				Description: "TODO",
+				Component:   "cluster-operator",
+				Description: "Fix cluster status conditions to be reconciled upon cluster creation.",
 				Kind:        versionbundle.KindFixed,
+				URLs: []string{
+					"TODO",
+				},
 			},
 		},
 		Components: []versionbundle.Component{

--- a/pkg/project/version_bundle.go
+++ b/pkg/project/version_bundle.go
@@ -12,7 +12,7 @@ func VersionBundle(p string) versionbundle.Bundle {
 				Description: "Fix cluster status conditions to be reconciled upon cluster creation.",
 				Kind:        versionbundle.KindFixed,
 				URLs: []string{
-					"TODO",
+					"https://github.com/giantswarm/cluster-operator/pull/866",
 				},
 			},
 		},

--- a/service/controller/resource/clusterstatus/create.go
+++ b/service/controller/resource/clusterstatus/create.go
@@ -25,13 +25,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	if cc.Client.TenantCluster.K8s == nil {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster clients not available in controller context")
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-
-		return nil
-	}
-
 	cr := r.newCommonClusterObjectFunc()
 	var uc infrastructurev1alpha2.CommonClusterObject
 	{
@@ -53,7 +46,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	var nodes []corev1.Node
-	{
+	if cc.Client.TenantCluster.K8s != nil {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "finding nodes of tenant cluster")
 
 		l, err := cc.Client.TenantCluster.K8s.CoreV1().Nodes().List(metav1.ListOptions{})


### PR DESCRIPTION
```
$ kubectl get awsclusters.infrastructure.giantswarm.io kpp3p -o yaml
...
status:
  cluster:
    conditions:
    - condition: Creating
      lastTransitionTime: "2020-01-06T09:15:14.93086131Z"
    id: kpp3p
...
```


```
$ kubectl -n giantswarm logs --tail 10000 -f cluster-operator-fix-status-condition-78b8754d56-hvv62
...
{"caller":"github.com/giantswarm/cluster-operator/service/controller/resource/clusterstatus/create.go:150","event":"update","level":"info","message":"setting `Creating` status condition","object":"/apis/cluster.x-k8s.io/v1alpha2/namespaces/default/clusters/kpp3p","resource":"clusterstatus","time":"2020-01-06T09:15:14.930887+00:00","version":"36603568"}
{"caller":"github.com/giantswarm/cluster-operator/service/controller/resource/clusterstatus/create.go:90","event":"update","level":"debug","message":"updating cluster status","object":"/apis/cluster.x-k8s.io/v1alpha2/namespaces/default/clusters/kpp3p","resource":"clusterstatus","time":"2020-01-06T09:15:14.930919+00:00","version":"36603568"}
{"caller":"github.com/giantswarm/cluster-operator/service/controller/resource/clusterstatus/create.go:97","event":"update","level":"debug","message":"updated cluster status","object":"/apis/cluster.x-k8s.io/v1alpha2/namespaces/default/clusters/kpp3p","resource":"clusterstatus","time":"2020-01-06T09:15:14.937823+00:00","version":"36603568"}
...
```