### PR TITLE
Add changelogs for 2.0.1 release

### DIFF
--- a/pkg/project/version_bundle.go
+++ b/pkg/project/version_bundle.go
@@ -23,6 +23,70 @@ func VersionBundle(p string) versionbundle.Bundle {
 					"https://github.com/giantswarm/cluster-operator/pull/871",
 				},
 			},
+			{
+				Component:   "cert-exporter",
+				Description: "Removed CPU limits.",
+				Kind:        versionbundle.KindChanged,
+				URLs: []string{
+					"https://github.com/giantswarm/cert-exporter/blob/master/CHANGELOG.md#121-2019-12-24",
+				},
+			},
+			{
+				Component:   "cert-manager",
+				Description: "Removed CPU limits.",
+				Kind:        versionbundle.KindChanged,
+				URLs: []string{
+					"https://github.com/giantswarm/cert-manager-app/blob/master/CHANGELOG.md#v103-2020-01-03",
+				},
+			},
+			{
+				Component:   "chart-operator",
+				Description: "Removed CPU limits.",
+				Kind:        versionbundle.KindChanged,
+				URLs: []string{
+					"https: //github.com/giantswarm/chart-operator/pull/335",
+				},
+			},
+			{
+				Component:   "cluster-autoscaler",
+				Description: "Removed CPU limits.",
+				Kind:        versionbundle.KindChanged,
+				URLs: []string{
+					"https://github.com/giantswarm/cluster-autoscaler-app/blob/master/CHANGELOG.md#v112-2020-01-03",
+				},
+			},
+			{
+				Component:   "external-dns",
+				Description: "Added support AWS SDK configuration with explicit credentials.",
+				Kind:        versionbundle.KindChanged,
+				URLs: []string{
+					"https://github.com/giantswarm/external-dns-app/blob/master/CHANGELOG.md#v110",
+				},
+			},
+			{
+				Component:   "external-dns",
+				Description: "Removed CPU limits.",
+				Kind:        versionbundle.KindChanged,
+				URLs: []string{
+					"https://github.com/giantswarm/external-dns-app/blob/master/CHANGELOG.md#v110",
+				},
+			},
+			{
+				Component:   "kiam",
+				Description: "Removed CPU limits.",
+				Kind:        versionbundle.KindChanged,
+				URLs: []string{
+					"https://github.com/giantswarm/kiam-app/blob/master/CHANGELOG.md#v102-2020-01-04",
+				},
+			},
+			{
+				Component:   "node-exporter",
+				Description: "Changed priority class to system-node-critical",
+				Kind:        versionbundle.KindChanged,
+				URLs: []string{
+					"https://github.com/giantswarm/node-exporter-app/blob/master/CHANGELOG.md#120-2020-01-08",
+				},
+			},
 		},
 		Components: []versionbundle.Component{
 			{


### PR DESCRIPTION
Once this is merged I'll retag and bump the version to `2.0.2-dev`.