### PR TITLE
Remove calico error checks due to azure

### DIFF
--- a/service/controller/resource/clusterconfigmap/resource.go
+++ b/service/controller/resource/clusterconfigmap/resource.go
@@ -47,12 +47,6 @@ func New(config Config) (*Resource, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 
-	if config.CalicoAddress == "" {
-		return nil, microerror.Maskf(invalidConfigError, "%T.CalicoAddress must not be empty", config)
-	}
-	if config.CalicoPrefixLength == "" {
-		return nil, microerror.Maskf(invalidConfigError, "%T.CalicoPrefixLength must not be empty", config)
-	}
 	if config.ClusterIPRange == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ClusterIPRange must not be empty", config)
 	}


### PR DESCRIPTION
These error checks were making the operator crash in Azure control planes.

I compared with thiccc and there we don't check for these errors. This value being blank is fine on azure.

See https://github.com/giantswarm/coredns-app/blob/2a41a795c4ee39de8a73b81e924f3977f7eab5b7/helm/coredns-app/templates/configmap.yaml#L18