### PR TITLE
Fix the version of metrics-server

### DIFF
--- a/pkg/project/version_bundle.go
+++ b/pkg/project/version_bundle.go
@@ -33,7 +33,7 @@ func VersionBundle(p string) versionbundle.Bundle {
 			},
 			{
 				Name:    "metrics-server",
-				Version: "0.4.1",
+				Version: "0.3.3",
 			},
 			{
 				Name:    "kiam",


### PR DESCRIPTION
The current version of metrics-server component is 0.3.3, not 0.4.1.

https://github.com/giantswarm/metrics-server-app/blob/master/helm/metrics-server-app/values.yaml#L40

