### PR TITLE
Fix wrong metrics server version in legacy

### DIFF
--- a/pkg/project/version_bundle_aws.go
+++ b/pkg/project/version_bundle_aws.go
@@ -36,7 +36,7 @@ var versionBundleAWS = versionbundle.Bundle{
 		},
 		{
 			Name:    "metrics-server",
-			Version: "0.4.1",
+			Version: "0.3.3",
 		},
 	},
 	Name:     "cluster-operator",

--- a/pkg/project/version_bundle_azure.go
+++ b/pkg/project/version_bundle_azure.go
@@ -32,7 +32,7 @@ var versionBundleAzure = versionbundle.Bundle{
 		},
 		{
 			Name:    "metrics-server",
-			Version: "0.4.1",
+			Version: "0.3.3",
 		},
 	},
 	Name:     "cluster-operator",

--- a/pkg/project/version_bundle_kvm.go
+++ b/pkg/project/version_bundle_kvm.go
@@ -32,7 +32,7 @@ var versionBundleKVM = versionbundle.Bundle{
 		},
 		{
 			Name:    "metrics-server",
-			Version: "0.4.1",
+			Version: "0.3.3",
 		},
 	},
 	Name:     "cluster-operator",


### PR DESCRIPTION
Following https://github.com/giantswarm/cluster-operator/pull/884
https://github.com/giantswarm/cluster-operator/pull/884#issuecomment-573889676