### PR TITLE
Update kiam, chart-operator, and cert-manager apps

### DIFF
--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -49,7 +49,7 @@ func CommonAppSpecs() []AppSpec {
 			Chart:           "chart-operator",
 			Namespace:       "giantswarm",
 			UseUpgradeForce: true,
-			Version:         "0.11.2",
+			Version:         "0.11.3",
 		},
 		{
 			// coredns must be installed second as its a requirement for other

--- a/service/controller/key/provider_appspecs.go
+++ b/service/controller/key/provider_appspecs.go
@@ -15,7 +15,7 @@ func AWSAppSpecs() []AppSpec {
 			ClusterAPIOnly:  true,
 			Namespace:       metav1.NamespaceSystem,
 			UseUpgradeForce: true,
-			Version:         "1.0.3",
+			Version:         "1.0.4",
 		},
 		{
 			App:             "cluster-autoscaler",
@@ -41,7 +41,7 @@ func AWSAppSpecs() []AppSpec {
 			ClusterAPIOnly:  true,
 			Namespace:       metav1.NamespaceSystem,
 			UseUpgradeForce: true,
-			Version:         "1.0.2",
+			Version:         "1.0.3",
 		},
 	}
 }


### PR DESCRIPTION
Updates cert-manager to https://github.com/giantswarm/cert-manager-app/releases/tag/v1.0.4 and kiam to https://github.com/giantswarm/kiam-app/releases/tag/v1.0.3 and chart-operator to https://github.com/giantswarm/chart-operator/releases/tag/v0.11.3.