### PR TITLE
legacy: Update kiam, chart-operator, and cert-manager apps

### DIFF
--- a/service/controller/aws/key/key.go
+++ b/service/controller/aws/key/key.go
@@ -19,7 +19,7 @@ func AppSpecs() []key.AppSpec {
 			ClusterAPIOnly:  true,
 			Namespace:       metav1.NamespaceSystem,
 			UseUpgradeForce: true,
-			Version:         "1.0.3",
+			Version:         "1.0.4",
 		},
 		{
 			App:             "cluster-autoscaler",
@@ -45,7 +45,7 @@ func AppSpecs() []key.AppSpec {
 			ClusterAPIOnly:  true,
 			Namespace:       metav1.NamespaceSystem,
 			UseUpgradeForce: true,
-			Version:         "1.0.2",
+			Version:         "1.0.3",
 		},
 	}
 }

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -93,7 +93,7 @@ func CommonAppSpecs() []AppSpec {
 			Chart:           "chart-operator",
 			Namespace:       "giantswarm",
 			UseUpgradeForce: true,
-			Version:         "0.11.2",
+			Version:         "0.11.3",
 		},
 		{
 			// coredns must be installed second as its a requirement for other


### PR DESCRIPTION
Updates cert-manager to https://github.com/giantswarm/cert-manager-app/releases/tag/v1.0.4 and kiam to https://github.com/giantswarm/kiam-app/releases/tag/v1.0.3 and chart-operator to https://github.com/giantswarm/chart-operator/releases/tag/v0.11.3.

Legacy port of https://github.com/giantswarm/cluster-operator/pull/887.