### PR TITLE
legacy: Update kube-state-metrics, merge changelogs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ workflows:
 
       # build and push chart to app catalog
       - architect/push-to-app-catalog:
-          name: push-cluster-operator-to-app-catalog
+          name: push-cluster-operator-to-control-plane-app-catalog
           app_catalog: "control-plane-catalog"
           app_catalog_test: "control-plane-test-catalog"
           chart: "cluster-operator"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ workflows:
           app_name: "cluster-operator"
           app_collection_repo: "aws-app-collection"
           requires:
-            - push-cluster-operator-to-app-catalog
+            - push-cluster-operator-to-control-plane-app-catalog
           filters:
             branches:
               ignore: /.*/
@@ -113,7 +113,7 @@ workflows:
           app_name: "cluster-operator"
           app_collection_repo: "azure-app-collection"
           requires:
-            - push-cluster-operator-to-app-catalog
+            - push-cluster-operator-to-control-plane-app-catalog
           filters:
             branches:
               ignore: /.*/
@@ -126,7 +126,7 @@ workflows:
           app_name: "cluster-operator"
           app_collection_repo: "kvm-app-collection"
           requires:
-            - push-cluster-operator-to-app-catalog
+            - push-cluster-operator-to-control-plane-app-catalog
           filters:
             branches:
               ignore: /.*/

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,7 +1,7 @@
 package project
 
 var (
-	bundleVersion = "0.21.2"
+	bundleVersion = "0.21.3"
 	description   = "The cluster-operator manages Kubernetes tenant cluster resources."
 	gitSHA        = "n/a"
 	name          = "cluster-operator"

--- a/pkg/project/version_bundle_aws.go
+++ b/pkg/project/version_bundle_aws.go
@@ -7,11 +7,27 @@ import (
 var versionBundleAWS = versionbundle.Bundle{
 	Changelogs: []versionbundle.Changelog{
 		{
+			Component:   "cluster-operator",
+			Description: "Add additional settings for coredns to cluster configmap.",
+			Kind:        versionbundle.KindAdded,
+			URLs: []string{
+				"https://github.com/giantswarm/cluster-operator/pull/871",
+			},
+		},
+		{
 			Component:   "chart-operator",
 			Description: "Adjust ClusterRole permissions.",
 			Kind:        versionbundle.KindChanged,
 			URLs: []string{
 				"https://github.com/giantswarm/chart-operator/releases/tag/v0.11.3",
+			},
+		},
+		{
+			Component:   "chart-operator",
+			Description: "Remove CPU limits.",
+			Kind:        versionbundle.KindRemoved,
+			URLs: []string{
+				"https://github.com/giantswarm/chart-operator/releases/tag/v0.11.2",
 			},
 		},
 		{
@@ -31,6 +47,14 @@ var versionBundleAWS = versionbundle.Bundle{
 			},
 		},
 		{
+			Component:   "cert-manager",
+			Description: "Remove CPU limits.",
+			Kind:        versionbundle.KindRemoved,
+			URLs: []string{
+				"https://github.com/giantswarm/cert-manager-app/releases/tag/v1.0.2",
+			},
+		},
+		{
 			Component:   "kiam",
 			Description: "Improve helm chart for clusters with restrictive network policies.",
 			Kind:        versionbundle.KindChanged,
@@ -47,6 +71,14 @@ var versionBundleAWS = versionbundle.Bundle{
 			},
 		},
 		{
+			Component:   "kiam",
+			Description: "Remove CPU limits.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/kiam-app/releases/tag/v1.0.1",
+			},
+		},
+		{
 			Component:   "metrics-server",
 			Description: "Update manifests for Kubernetes 1.16 compatibility.",
 			Kind:        versionbundle.KindChanged,
@@ -54,11 +86,117 @@ var versionBundleAWS = versionbundle.Bundle{
 				"https://github.com/giantswarm/metrics-server-app/releases/tag/v1.0.0",
 			},
 		},
+		{
+			Component:   "cert-exporter",
+			Description: "Remove CPU limits.",
+			Kind:        versionbundle.KindRemoved,
+			URLs: []string{
+				"https://github.com/giantswarm/cert-exporter/releases/tag/v1.2.1",
+			},
+		},
+		{
+			Component:   "cluster-autoscaler",
+			Description: "Update to v1.16.2.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/cluster-autoscaler-app/releases/tag/v1.1.2",
+			},
+		},
+		{
+			Component:   "cluster-autoscaler",
+			Description: "Remove CPU limits.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/cluster-autoscaler-app/releases/tag/v1.1.1",
+			},
+		},
+		{
+			Component:   "coredns",
+			Description: "Update manifests for Kubernetes 1.16 compatibility.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/coredns-app/releases/tag/v1.1.3",
+				"https://github.com/giantswarm/coredns-app/releases/tag/v1.1.2",
+			},
+		},
+		{
+			Component:   "coredns",
+			Description: "Remove CPU limits.",
+			Kind:        versionbundle.KindRemoved,
+			URLs: []string{
+				"https://github.com/giantswarm/coredns-app/releases/tag/v1.1.1",
+			},
+		},
+		{
+			Component:   "external-dns",
+			Description: "Add support AWS SDK configuration with explicit credentials.",
+			Kind:        versionbundle.KindAdded,
+			URLs: []string{
+				"https://github.com/giantswarm/external-dns-app/releases/tag/v1.1.0",
+			},
+		},
+		{
+			Component:   "external-dns",
+			Description: "Remove CPU limits.",
+			Kind:        versionbundle.KindRemoved,
+			URLs: []string{
+				"https://github.com/giantswarm/external-dns-app/releases/tag/v1.0.1",
+			},
+		},
+		{
+			Component:   "kube-state-metrics",
+			Description: "Update to upstream version 1.9.2.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/kube-state-metrics-app/releases/tag/v1.0.1",
+			},
+		},
+		{
+			Component:   "net-exporter",
+			Description: "Change priority class to system-node-critical.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/net-exporter/releases/tag/v1.5.1",
+				"https://github.com/giantswarm/net-exporter/releases/tag/v1.5.0",
+			},
+		},
+		{
+			Component:   "node-exporter",
+			Description: "Change priority class to system-node-critical.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/node-exporter-app/releases/tag/v1.2.0",
+			},
+		},
+		{
+			Component:   "node-exporter",
+			Description: "Update dependencies to support Kubernetes 1.16.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/node-exporter-app/releases/tag/v1.1.1",
+			},
+		},
+		{
+			Component:   "node-exporter",
+			Description: "Update to upstream version 0.18.1.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/node-exporter-app/releases/tag/v1.1.0",
+			},
+		},
+		{
+			Component:   "nginx-ingress-controller",
+			Description: "Update manifests for Kubernetes 1.16.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/nginx-ingress-controller-app/releases/tag/v1.1.1",
+			},
+		},
 	},
 	Components: []versionbundle.Component{
 		{
 			Name:    "kube-state-metrics",
-			Version: "1.9.0",
+			Version: "1.9.2",
 		},
 		{
 			Name:    "nginx-ingress-controller",

--- a/pkg/project/version_bundle_aws.go
+++ b/pkg/project/version_bundle_aws.go
@@ -11,7 +11,7 @@ var versionBundleAWS = versionbundle.Bundle{
 			Description: "Add additional settings for coredns to cluster configmap.",
 			Kind:        versionbundle.KindAdded,
 			URLs: []string{
-				"https://github.com/giantswarm/cluster-operator/pull/871",
+				"https://github.com/giantswarm/cluster-operator/pull/873",
 			},
 		},
 		{
@@ -217,6 +217,18 @@ var versionBundleAWS = versionbundle.Bundle{
 		{
 			Name:    "metrics-server",
 			Version: "0.3.3",
+		},
+		{
+			Name:    "kiam",
+			Version: "3.4.0",
+		},
+		{
+			Name:    "external-dns",
+			Version: "0.5.11",
+		},
+		{
+			Name:    "cert-manager",
+			Version: "0.9.0",
 		},
 	},
 	Name:     "cluster-operator",

--- a/pkg/project/version_bundle_azure.go
+++ b/pkg/project/version_bundle_azure.go
@@ -7,11 +7,27 @@ import (
 var versionBundleAzure = versionbundle.Bundle{
 	Changelogs: []versionbundle.Changelog{
 		{
+			Component:   "cluster-operator",
+			Description: "Add additional settings for coredns to cluster configmap.",
+			Kind:        versionbundle.KindAdded,
+			URLs: []string{
+				"https://github.com/giantswarm/cluster-operator/pull/871",
+			},
+		},
+		{
 			Component:   "chart-operator",
 			Description: "Adjust ClusterRole permissions.",
 			Kind:        versionbundle.KindChanged,
 			URLs: []string{
 				"https://github.com/giantswarm/chart-operator/releases/tag/v0.11.3",
+			},
+		},
+		{
+			Component:   "chart-operator",
+			Description: "Remove CPU limits.",
+			Kind:        versionbundle.KindRemoved,
+			URLs: []string{
+				"https://github.com/giantswarm/chart-operator/releases/tag/v0.11.2",
 			},
 		},
 		{
@@ -22,11 +38,101 @@ var versionBundleAzure = versionbundle.Bundle{
 				"https://github.com/giantswarm/metrics-server-app/releases/tag/v1.0.0",
 			},
 		},
+		{
+			Component:   "cert-exporter",
+			Description: "Remove CPU limits.",
+			Kind:        versionbundle.KindRemoved,
+			URLs: []string{
+				"https://github.com/giantswarm/cert-exporter/releases/tag/v1.2.1",
+			},
+		},
+		{
+			Component:   "coredns",
+			Description: "Update manifests for Kubernetes 1.16 compatibility.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/coredns-app/releases/tag/v1.1.3",
+				"https://github.com/giantswarm/coredns-app/releases/tag/v1.1.2",
+			},
+		},
+		{
+			Component:   "coredns",
+			Description: "Remove CPU limits.",
+			Kind:        versionbundle.KindRemoved,
+			URLs: []string{
+				"https://github.com/giantswarm/coredns-app/releases/tag/v1.1.1",
+			},
+		},
+		{
+			Component:   "external-dns",
+			Description: "Add support AWS SDK configuration with explicit credentials.",
+			Kind:        versionbundle.KindAdded,
+			URLs: []string{
+				"https://github.com/giantswarm/external-dns-app/releases/tag/v1.1.0",
+			},
+		},
+		{
+			Component:   "external-dns",
+			Description: "Remove CPU limits.",
+			Kind:        versionbundle.KindRemoved,
+			URLs: []string{
+				"https://github.com/giantswarm/external-dns-app/releases/tag/v1.0.1",
+			},
+		},
+		{
+			Component:   "kube-state-metrics",
+			Description: "Update to upstream version 1.9.2.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/kube-state-metrics-app/releases/tag/v1.0.1",
+			},
+		},
+		{
+			Component:   "net-exporter",
+			Description: "Change priority class to system-node-critical.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/net-exporter/releases/tag/v1.5.1",
+				"https://github.com/giantswarm/net-exporter/releases/tag/v1.5.0",
+			},
+		},
+		{
+			Component:   "node-exporter",
+			Description: "Change priority class to system-node-critical.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/node-exporter-app/releases/tag/v1.2.0",
+			},
+		},
+		{
+			Component:   "node-exporter",
+			Description: "Update dependencies to support Kubernetes 1.16.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/node-exporter-app/releases/tag/v1.1.1",
+			},
+		},
+		{
+			Component:   "node-exporter",
+			Description: "Update to upstream version 0.18.1.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/node-exporter-app/releases/tag/v1.1.0",
+			},
+		},
+		{
+			Component:   "nginx-ingress-controller",
+			Description: "Update manifests for Kubernetes 1.16.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/nginx-ingress-controller-app/releases/tag/v1.1.1",
+			},
+		},
 	},
 	Components: []versionbundle.Component{
 		{
 			Name:    "kube-state-metrics",
-			Version: "1.9.0",
+			Version: "1.9.2",
 		},
 		{
 			Name:    "nginx-ingress-controller",

--- a/pkg/project/version_bundle_azure.go
+++ b/pkg/project/version_bundle_azure.go
@@ -11,7 +11,7 @@ var versionBundleAzure = versionbundle.Bundle{
 			Description: "Add additional settings for coredns to cluster configmap.",
 			Kind:        versionbundle.KindAdded,
 			URLs: []string{
-				"https://github.com/giantswarm/cluster-operator/pull/871",
+				"https://github.com/giantswarm/cluster-operator/pull/873",
 			},
 		},
 		{

--- a/pkg/project/version_bundle_azure.go
+++ b/pkg/project/version_bundle_azure.go
@@ -150,6 +150,10 @@ var versionBundleAzure = versionbundle.Bundle{
 			Name:    "metrics-server",
 			Version: "0.3.3",
 		},
+		{
+			Name:    "external-dns",
+			Version: "0.5.11",
+		},
 	},
 	Name:     "cluster-operator",
 	Provider: "azure",

--- a/pkg/project/version_bundle_kvm.go
+++ b/pkg/project/version_bundle_kvm.go
@@ -116,7 +116,7 @@ var versionBundleKVM = versionbundle.Bundle{
 	Components: []versionbundle.Component{
 		{
 			Name:    "kube-state-metrics",
-			Version: "1.9.0",
+			Version: "1.9.2",
 		},
 		{
 			Name:    "nginx-ingress-controller",

--- a/pkg/project/version_bundle_kvm.go
+++ b/pkg/project/version_bundle_kvm.go
@@ -7,6 +7,14 @@ import (
 var versionBundleKVM = versionbundle.Bundle{
 	Changelogs: []versionbundle.Changelog{
 		{
+			Component:   "cluster-operator",
+			Description: "Add additional settings for coredns to cluster configmap.",
+			Kind:        versionbundle.KindAdded,
+			URLs: []string{
+				"https://github.com/giantswarm/cluster-operator/pull/871",
+			},
+		},
+		{
 			Component:   "chart-operator",
 			Description: "Adjust ClusterRole permissions.",
 			Kind:        versionbundle.KindChanged,
@@ -15,11 +23,93 @@ var versionBundleKVM = versionbundle.Bundle{
 			},
 		},
 		{
+			Component:   "chart-operator",
+			Description: "Remove CPU limits.",
+			Kind:        versionbundle.KindRemoved,
+			URLs: []string{
+				"https://github.com/giantswarm/chart-operator/releases/tag/v0.11.2",
+			},
+		},
+		{
 			Component:   "metrics-server",
 			Description: "Update manifests for Kubernetes 1.16 compatibility.",
 			Kind:        versionbundle.KindChanged,
 			URLs: []string{
 				"https://github.com/giantswarm/metrics-server-app/releases/tag/v1.0.0",
+			},
+		},
+		{
+			Component:   "cert-exporter",
+			Description: "Remove CPU limits.",
+			Kind:        versionbundle.KindRemoved,
+			URLs: []string{
+				"https://github.com/giantswarm/cert-exporter/releases/tag/v1.2.1",
+			},
+		},
+		{
+			Component:   "coredns",
+			Description: "Update manifests for Kubernetes 1.16 compatibility.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/coredns-app/releases/tag/v1.1.3",
+				"https://github.com/giantswarm/coredns-app/releases/tag/v1.1.2",
+			},
+		},
+		{
+			Component:   "coredns",
+			Description: "Remove CPU limits.",
+			Kind:        versionbundle.KindRemoved,
+			URLs: []string{
+				"https://github.com/giantswarm/coredns-app/releases/tag/v1.1.1",
+			},
+		},
+		{
+			Component:   "kube-state-metrics",
+			Description: "Update to upstream version 1.9.2.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/kube-state-metrics-app/releases/tag/v1.0.1",
+			},
+		},
+		{
+			Component:   "net-exporter",
+			Description: "Change priority class to system-node-critical.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/net-exporter/releases/tag/v1.5.1",
+				"https://github.com/giantswarm/net-exporter/releases/tag/v1.5.0",
+			},
+		},
+		{
+			Component:   "node-exporter",
+			Description: "Change priority class to system-node-critical.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/node-exporter-app/releases/tag/v1.2.0",
+			},
+		},
+		{
+			Component:   "node-exporter",
+			Description: "Update dependencies to support Kubernetes 1.16.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/node-exporter-app/releases/tag/v1.1.1",
+			},
+		},
+		{
+			Component:   "node-exporter",
+			Description: "Update to upstream version 0.18.1.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/node-exporter-app/releases/tag/v1.1.0",
+			},
+		},
+		{
+			Component:   "nginx-ingress-controller",
+			Description: "Update manifests for Kubernetes 1.16.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/nginx-ingress-controller-app/releases/tag/v1.1.1",
 			},
 		},
 	},

--- a/pkg/project/version_bundle_kvm.go
+++ b/pkg/project/version_bundle_kvm.go
@@ -11,7 +11,7 @@ var versionBundleKVM = versionbundle.Bundle{
 			Description: "Add additional settings for coredns to cluster configmap.",
 			Kind:        versionbundle.KindAdded,
 			URLs: []string{
-				"https://github.com/giantswarm/cluster-operator/pull/871",
+				"https://github.com/giantswarm/cluster-operator/pull/873",
 			},
 		},
 		{

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -120,7 +120,7 @@ func CommonAppSpecs() []AppSpec {
 			Chart:           "kube-state-metrics-app",
 			Namespace:       metav1.NamespaceSystem,
 			UseUpgradeForce: true,
-			Version:         "1.0.0",
+			Version:         "1.0.1",
 		},
 		{
 			App:             "metrics-server",


### PR DESCRIPTION
Release 9.0.0 included cluster-operator@0.21.0. Since then, we have had v0.21.1 which was focused on removing CPU limits and updating manifests for 1.16. v0.21.2 was incorrectly released today with missing changelogs. I tried to fix it, but CPs didn't pull the updated image due to `imagePullPolicy: IfNotPresent`. Moreover, @sslavic just noticed that kube-state-metrics addons-resizer sidecar was failing due 1.16 incompatibility.

This PR merges changelogs from 0.21.1 and 0.21.2, updates kube-state-metrics to 1.0.1 (upstream 1.9.2) to fix all of the aforementioned issues, and bumps the version to 0.21.3 for immediate release.