### PR TITLE
legacy: Prepare next release, update cluster-autoscaler

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,7 +1,7 @@
 package project
 
 var (
-	bundleVersion = "0.21.4-dev"
+	bundleVersion = "0.21.3"
 	description   = "The cluster-operator manages Kubernetes tenant cluster resources."
 	gitSHA        = "n/a"
 	name          = "cluster-operator"

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,7 +1,7 @@
 package project
 
 var (
-	bundleVersion = "0.21.3"
+	bundleVersion = "0.21.4"
 	description   = "The cluster-operator manages Kubernetes tenant cluster resources."
 	gitSHA        = "n/a"
 	name          = "cluster-operator"

--- a/pkg/project/version_bundle_aws.go
+++ b/pkg/project/version_bundle_aws.go
@@ -8,10 +8,188 @@ var versionBundleAWS = versionbundle.Bundle{
 	Changelogs: []versionbundle.Changelog{
 		{
 			Component:   "cluster-operator",
-			Description: "TODO",
+			Description: "Add additional settings for coredns to cluster configmap.",
 			Kind:        versionbundle.KindAdded,
 			URLs: []string{
-				"TODO",
+				"https://github.com/giantswarm/cluster-operator/pull/873",
+			},
+		},
+		{
+			Component:   "chart-operator",
+			Description: "Adjust ClusterRole permissions.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/chart-operator/releases/tag/v0.11.3",
+			},
+		},
+		{
+			Component:   "chart-operator",
+			Description: "Remove CPU limits.",
+			Kind:        versionbundle.KindRemoved,
+			URLs: []string{
+				"https://github.com/giantswarm/chart-operator/releases/tag/v0.11.2",
+			},
+		},
+		{
+			Component:   "cert-manager",
+			Description: "Improve helm chart for clusters with restrictive network policies.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/cert-manager-app/releases/tag/v1.0.4",
+			},
+		},
+		{
+			Component:   "cert-manager",
+			Description: "Update manifests for Kubernetes 1.16 compatibility.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/cert-manager-app/releases/tag/v1.0.3",
+			},
+		},
+		{
+			Component:   "cert-manager",
+			Description: "Remove CPU limits.",
+			Kind:        versionbundle.KindRemoved,
+			URLs: []string{
+				"https://github.com/giantswarm/cert-manager-app/releases/tag/v1.0.2",
+			},
+		},
+		{
+			Component:   "kiam",
+			Description: "Improve helm chart for clusters with restrictive network policies.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/kiam-app/releases/tag/v1.0.3",
+			},
+		},
+		{
+			Component:   "kiam",
+			Description: "Update manifests for Kubernetes 1.16 compatibility.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/kiam-app/releases/tag/v1.0.2",
+			},
+		},
+		{
+			Component:   "kiam",
+			Description: "Remove CPU limits.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/kiam-app/releases/tag/v1.0.1",
+			},
+		},
+		{
+			Component:   "metrics-server",
+			Description: "Update manifests for Kubernetes 1.16 compatibility.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/metrics-server-app/releases/tag/v1.0.0",
+			},
+		},
+		{
+			Component:   "cert-exporter",
+			Description: "Remove CPU limits.",
+			Kind:        versionbundle.KindRemoved,
+			URLs: []string{
+				"https://github.com/giantswarm/cert-exporter/releases/tag/v1.2.1",
+			},
+		},
+		{
+			Component:   "cluster-autoscaler",
+			Description: "Update to v1.16.2.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/cluster-autoscaler-app/releases/tag/v1.1.2",
+			},
+		},
+		{
+			Component:   "cluster-autoscaler",
+			Description: "Remove CPU limits.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/cluster-autoscaler-app/releases/tag/v1.1.1",
+			},
+		},
+		{
+			Component:   "coredns",
+			Description: "Update manifests for Kubernetes 1.16 compatibility.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/coredns-app/releases/tag/v1.1.3",
+				"https://github.com/giantswarm/coredns-app/releases/tag/v1.1.2",
+			},
+		},
+		{
+			Component:   "coredns",
+			Description: "Remove CPU limits.",
+			Kind:        versionbundle.KindRemoved,
+			URLs: []string{
+				"https://github.com/giantswarm/coredns-app/releases/tag/v1.1.1",
+			},
+		},
+		{
+			Component:   "external-dns",
+			Description: "Add support AWS SDK configuration with explicit credentials.",
+			Kind:        versionbundle.KindAdded,
+			URLs: []string{
+				"https://github.com/giantswarm/external-dns-app/releases/tag/v1.1.0",
+			},
+		},
+		{
+			Component:   "external-dns",
+			Description: "Remove CPU limits.",
+			Kind:        versionbundle.KindRemoved,
+			URLs: []string{
+				"https://github.com/giantswarm/external-dns-app/releases/tag/v1.0.1",
+			},
+		},
+		{
+			Component:   "kube-state-metrics",
+			Description: "Update to upstream version 1.9.2.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/kube-state-metrics-app/releases/tag/v1.0.1",
+			},
+		},
+		{
+			Component:   "net-exporter",
+			Description: "Change priority class to system-node-critical.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/net-exporter/releases/tag/v1.5.1",
+				"https://github.com/giantswarm/net-exporter/releases/tag/v1.5.0",
+			},
+		},
+		{
+			Component:   "node-exporter",
+			Description: "Change priority class to system-node-critical.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/node-exporter-app/releases/tag/v1.2.0",
+			},
+		},
+		{
+			Component:   "node-exporter",
+			Description: "Update dependencies to support Kubernetes 1.16.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/node-exporter-app/releases/tag/v1.1.1",
+			},
+		},
+		{
+			Component:   "node-exporter",
+			Description: "Update to upstream version 0.18.1.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/node-exporter-app/releases/tag/v1.1.0",
+			},
+		},
+		{
+			Component:   "nginx-ingress-controller",
+			Description: "Update manifests for Kubernetes 1.16.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/nginx-ingress-controller-app/releases/tag/v1.1.1",
 			},
 		},
 	},

--- a/pkg/project/version_bundle_aws.go
+++ b/pkg/project/version_bundle_aws.go
@@ -96,6 +96,14 @@ var versionBundleAWS = versionbundle.Bundle{
 		},
 		{
 			Component:   "cluster-autoscaler",
+			Description: "Adjust RBAC permissions.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/cluster-autoscaler-app/releases/tag/v1.1.3",
+			},
+		},
+		{
+			Component:   "cluster-autoscaler",
 			Description: "Update to v1.16.2.",
 			Kind:        versionbundle.KindChanged,
 			URLs: []string{
@@ -141,6 +149,14 @@ var versionBundleAWS = versionbundle.Bundle{
 			Kind:        versionbundle.KindRemoved,
 			URLs: []string{
 				"https://github.com/giantswarm/external-dns-app/releases/tag/v1.0.1",
+			},
+		},
+		{
+			Component:   "kube-state-metrics",
+			Description: "Adjust RBAC permissions.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/kube-state-metrics-app/releases/tag/v1.0.2",
 			},
 		},
 		{

--- a/pkg/project/version_bundle_azure.go
+++ b/pkg/project/version_bundle_azure.go
@@ -8,10 +8,124 @@ var versionBundleAzure = versionbundle.Bundle{
 	Changelogs: []versionbundle.Changelog{
 		{
 			Component:   "cluster-operator",
-			Description: "TODO",
+			Description: "Add additional settings for coredns to cluster configmap.",
 			Kind:        versionbundle.KindAdded,
 			URLs: []string{
-				"TODO",
+				"https://github.com/giantswarm/cluster-operator/pull/873",
+			},
+		},
+		{
+			Component:   "chart-operator",
+			Description: "Adjust ClusterRole permissions.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/chart-operator/releases/tag/v0.11.3",
+			},
+		},
+		{
+			Component:   "chart-operator",
+			Description: "Remove CPU limits.",
+			Kind:        versionbundle.KindRemoved,
+			URLs: []string{
+				"https://github.com/giantswarm/chart-operator/releases/tag/v0.11.2",
+			},
+		},
+		{
+			Component:   "metrics-server",
+			Description: "Update manifests for Kubernetes 1.16 compatibility.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/metrics-server-app/releases/tag/v1.0.0",
+			},
+		},
+		{
+			Component:   "cert-exporter",
+			Description: "Remove CPU limits.",
+			Kind:        versionbundle.KindRemoved,
+			URLs: []string{
+				"https://github.com/giantswarm/cert-exporter/releases/tag/v1.2.1",
+			},
+		},
+		{
+			Component:   "coredns",
+			Description: "Update manifests for Kubernetes 1.16 compatibility.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/coredns-app/releases/tag/v1.1.3",
+				"https://github.com/giantswarm/coredns-app/releases/tag/v1.1.2",
+			},
+		},
+		{
+			Component:   "coredns",
+			Description: "Remove CPU limits.",
+			Kind:        versionbundle.KindRemoved,
+			URLs: []string{
+				"https://github.com/giantswarm/coredns-app/releases/tag/v1.1.1",
+			},
+		},
+		{
+			Component:   "external-dns",
+			Description: "Add support AWS SDK configuration with explicit credentials.",
+			Kind:        versionbundle.KindAdded,
+			URLs: []string{
+				"https://github.com/giantswarm/external-dns-app/releases/tag/v1.1.0",
+			},
+		},
+		{
+			Component:   "external-dns",
+			Description: "Remove CPU limits.",
+			Kind:        versionbundle.KindRemoved,
+			URLs: []string{
+				"https://github.com/giantswarm/external-dns-app/releases/tag/v1.0.1",
+			},
+		},
+		{
+			Component:   "kube-state-metrics",
+			Description: "Update to upstream version 1.9.2.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/kube-state-metrics-app/releases/tag/v1.0.1",
+			},
+		},
+		{
+			Component:   "net-exporter",
+			Description: "Change priority class to system-node-critical.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/net-exporter/releases/tag/v1.5.1",
+				"https://github.com/giantswarm/net-exporter/releases/tag/v1.5.0",
+			},
+		},
+		{
+			Component:   "node-exporter",
+			Description: "Change priority class to system-node-critical.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/node-exporter-app/releases/tag/v1.2.0",
+			},
+		},
+		{
+			Component:   "node-exporter",
+			Description: "Update dependencies to support Kubernetes 1.16.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/node-exporter-app/releases/tag/v1.1.1",
+			},
+		},
+		{
+			Component:   "node-exporter",
+			Description: "Update to upstream version 0.18.1.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/node-exporter-app/releases/tag/v1.1.0",
+			},
+		},
+		{
+			Component:   "nginx-ingress-controller",
+			Description: "Update manifests for Kubernetes 1.16.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/nginx-ingress-controller-app/releases/tag/v1.1.1",
 			},
 		},
 	},

--- a/pkg/project/version_bundle_azure.go
+++ b/pkg/project/version_bundle_azure.go
@@ -81,6 +81,14 @@ var versionBundleAzure = versionbundle.Bundle{
 		},
 		{
 			Component:   "kube-state-metrics",
+			Description: "Adjust RBAC permissions.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/kube-state-metrics-app/releases/tag/v1.0.2",
+			},
+		},
+		{
+			Component:   "kube-state-metrics",
 			Description: "Update to upstream version 1.9.2.",
 			Kind:        versionbundle.KindChanged,
 			URLs: []string{

--- a/pkg/project/version_bundle_kvm.go
+++ b/pkg/project/version_bundle_kvm.go
@@ -8,10 +8,108 @@ var versionBundleKVM = versionbundle.Bundle{
 	Changelogs: []versionbundle.Changelog{
 		{
 			Component:   "cluster-operator",
-			Description: "TODO",
+			Description: "Add additional settings for coredns to cluster configmap.",
 			Kind:        versionbundle.KindAdded,
 			URLs: []string{
-				"TODO",
+				"https://github.com/giantswarm/cluster-operator/pull/873",
+			},
+		},
+		{
+			Component:   "chart-operator",
+			Description: "Adjust ClusterRole permissions.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/chart-operator/releases/tag/v0.11.3",
+			},
+		},
+		{
+			Component:   "chart-operator",
+			Description: "Remove CPU limits.",
+			Kind:        versionbundle.KindRemoved,
+			URLs: []string{
+				"https://github.com/giantswarm/chart-operator/releases/tag/v0.11.2",
+			},
+		},
+		{
+			Component:   "metrics-server",
+			Description: "Update manifests for Kubernetes 1.16 compatibility.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/metrics-server-app/releases/tag/v1.0.0",
+			},
+		},
+		{
+			Component:   "cert-exporter",
+			Description: "Remove CPU limits.",
+			Kind:        versionbundle.KindRemoved,
+			URLs: []string{
+				"https://github.com/giantswarm/cert-exporter/releases/tag/v1.2.1",
+			},
+		},
+		{
+			Component:   "coredns",
+			Description: "Update manifests for Kubernetes 1.16 compatibility.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/coredns-app/releases/tag/v1.1.3",
+				"https://github.com/giantswarm/coredns-app/releases/tag/v1.1.2",
+			},
+		},
+		{
+			Component:   "coredns",
+			Description: "Remove CPU limits.",
+			Kind:        versionbundle.KindRemoved,
+			URLs: []string{
+				"https://github.com/giantswarm/coredns-app/releases/tag/v1.1.1",
+			},
+		},
+		{
+			Component:   "kube-state-metrics",
+			Description: "Update to upstream version 1.9.2.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/kube-state-metrics-app/releases/tag/v1.0.1",
+			},
+		},
+		{
+			Component:   "net-exporter",
+			Description: "Change priority class to system-node-critical.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/net-exporter/releases/tag/v1.5.1",
+				"https://github.com/giantswarm/net-exporter/releases/tag/v1.5.0",
+			},
+		},
+		{
+			Component:   "node-exporter",
+			Description: "Change priority class to system-node-critical.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/node-exporter-app/releases/tag/v1.2.0",
+			},
+		},
+		{
+			Component:   "node-exporter",
+			Description: "Update dependencies to support Kubernetes 1.16.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/node-exporter-app/releases/tag/v1.1.1",
+			},
+		},
+		{
+			Component:   "node-exporter",
+			Description: "Update to upstream version 0.18.1.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/node-exporter-app/releases/tag/v1.1.0",
+			},
+		},
+		{
+			Component:   "nginx-ingress-controller",
+			Description: "Update manifests for Kubernetes 1.16.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/nginx-ingress-controller-app/releases/tag/v1.1.1",
 			},
 		},
 	},

--- a/pkg/project/version_bundle_kvm.go
+++ b/pkg/project/version_bundle_kvm.go
@@ -65,6 +65,14 @@ var versionBundleKVM = versionbundle.Bundle{
 		},
 		{
 			Component:   "kube-state-metrics",
+			Description: "Adjust RBAC permissions.",
+			Kind:        versionbundle.KindChanged,
+			URLs: []string{
+				"https://github.com/giantswarm/kube-state-metrics-app/releases/tag/v1.0.2",
+			},
+		},
+		{
+			Component:   "kube-state-metrics",
 			Description: "Update to upstream version 1.9.2.",
 			Kind:        versionbundle.KindChanged,
 			URLs: []string{

--- a/service/controller/aws/key/key.go
+++ b/service/controller/aws/key/key.go
@@ -27,7 +27,7 @@ func AppSpecs() []key.AppSpec {
 			Chart:           "cluster-autoscaler-app",
 			Namespace:       metav1.NamespaceSystem,
 			UseUpgradeForce: true,
-			Version:         "1.1.2",
+			Version:         "1.1.3",
 		},
 		{
 			App:             "external-dns",

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -120,7 +120,7 @@ func CommonAppSpecs() []AppSpec {
 			Chart:           "kube-state-metrics-app",
 			Namespace:       metav1.NamespaceSystem,
 			UseUpgradeForce: true,
-			Version:         "1.0.1",
+			Version:         "1.0.2",
 		},
 		{
 			App:             "metrics-server",


### PR DESCRIPTION
Includes https://github.com/giantswarm/cluster-autoscaler-app/releases/tag/v1.1.3 and https://github.com/giantswarm/kube-state-metrics-app/releases/tag/v1.0.2 for now. Reverted changelogs because cluster-operator v0.21.2 and v0.21.3 were not included in any active release.