### PR TITLE
Use time.After to handle unresponsive tenant clusters

### DIFF
--- a/service/controller/controllercontext/status.go
+++ b/service/controller/controllercontext/status.go
@@ -1,7 +1,12 @@
 package controllercontext
 
 type ContextStatus struct {
-	Worker ContextStatusWorker
+	TenantCluster ContextStatusTenantCluster
+	Worker        ContextStatusWorker
+}
+
+type ContextStatusTenantCluster struct {
+	IsUnavailable bool
 }
 
 type ContextStatusWorker struct {

--- a/service/controller/resource/appmigration/create.go
+++ b/service/controller/resource/appmigration/create.go
@@ -92,6 +92,8 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			return nil
 		}
+	default:
+		// Fall through.
 	}
 
 	res := <-ch

--- a/service/controller/resource/appmigration/types.go
+++ b/service/controller/resource/appmigration/types.go
@@ -1,7 +1,16 @@
 package appmigration
 
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+)
+
 type Patch struct {
 	Op    string      `json:"op"`
 	Path  string      `json:"path"`
 	Value interface{} `json:"value"`
+}
+
+type response struct {
+	ChartConfigs []v1alpha1.ChartConfig
+	Error        error
 }


### PR DESCRIPTION
Follow up to https://github.com/giantswarm/app-operator/pull/198.

The appmigration resource uses a short timeout of 3 secs. The configmapmigration and app resources that follow are canceled if there is a timeout.

This is so the operator copes better with unavailable tenant clusters.