### PR TITLE
add control plane controller

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -58,8 +58,8 @@
   revision = "25d852aebe32c875e9c044af3eef9c7dc6bc777f"
 
 [[projects]]
-  branch = "master"
-  digest = "1:c1897e8476d8c81feef6d5f77948b4a258958cec2afb0d14bc5461ef751b7b48"
+  branch = "fix-cp-schema"
+  digest = "1:7127c8ca735956e4633767ac5ac0c80817861ffe508cfd0904f1589d3969cbaf"
   name = "github.com/giantswarm/apiextensions"
   packages = [
     "pkg/apis/application/v1alpha1",
@@ -78,7 +78,7 @@
     "pkg/clientset/versioned/typed/release/v1alpha1",
   ]
   pruneopts = "UT"
-  revision = "d6884ee11480721e3a6f6a2449a130c3f1de9ba7"
+  revision = "a9e5b90a124dde85b9414353573d2e389380c071"
 
 [[projects]]
   branch = "master"
@@ -653,11 +653,11 @@
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
   pruneopts = "UT"
-  revision = "1ad67e1f0ef495d4014b6ffd8f2cf80f91fffbce"
+  revision = "2aa609cf4a9d7d1126360de73b55b6002f9e052a"
 
 [[projects]]
   branch = "master"
-  digest = "1:1cabaa095275883d57d45ead4b10b3e45473e2e14e6bb38406ca21d6c6fd50d2"
+  digest = "1:2ae1445cff31b9c820b7183be7d4e26e38069c7a9337204e31cd16b14106c794"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -669,7 +669,7 @@
     "publicsuffix",
   ]
   pruneopts = "UT"
-  revision = "46282727080fcf56da5781d0a9ef2fda184be5e6"
+  revision = "5a598a2470a0279bd28bab287167dc1ef0813153"
 
 [[projects]]
   branch = "master"
@@ -692,14 +692,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:f5cc4214d190756c642b2b78503edeb58ea5c9e426986d68ff63a393325f9c97"
+  digest = "1:e6f3eca022d18ff28112534a46d8bad7400b1523724061dff2d1bfc737bee376"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "UT"
-  revision = "cb0a6d8edb6c3528b01a0be84a5fe513dbf880a6"
+  revision = "d5e6a3e2c0ae16fc7480523ebcb7fd4dd3215489"
 
 [[projects]]
   digest = "1:8d8faad6b12a3a4c819a3f9618cb6ee1fa1cfc33253abeeea8b55336721e3405"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -58,7 +58,7 @@
   revision = "25d852aebe32c875e9c044af3eef9c7dc6bc777f"
 
 [[projects]]
-  branch = "fix-cp-schema"
+  branch = "master"
   digest = "1:114800a68b6cbcc0b7a3d22adb7b6f6652d12085bf367cef4f392c3ae27eacdf"
   name = "github.com/giantswarm/apiextensions"
   packages = [
@@ -78,7 +78,7 @@
     "pkg/clientset/versioned/typed/release/v1alpha1",
   ]
   pruneopts = "UT"
-  revision = "b9a3c4ab1705296f2fcaeeca1a2a1dc99818f2ee"
+  revision = "acdbf019d0f8cf6d839bda21fa93440fe9faad16"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -59,7 +59,7 @@
 
 [[projects]]
   branch = "fix-cp-schema"
-  digest = "1:7127c8ca735956e4633767ac5ac0c80817861ffe508cfd0904f1589d3969cbaf"
+  digest = "1:114800a68b6cbcc0b7a3d22adb7b6f6652d12085bf367cef4f392c3ae27eacdf"
   name = "github.com/giantswarm/apiextensions"
   packages = [
     "pkg/apis/application/v1alpha1",
@@ -78,7 +78,7 @@
     "pkg/clientset/versioned/typed/release/v1alpha1",
   ]
   pruneopts = "UT"
-  revision = "a9e5b90a124dde85b9414353573d2e389380c071"
+  revision = "b9a3c4ab1705296f2fcaeeca1a2a1dc99818f2ee"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -21,8 +21,8 @@
 
 
 
-[[override]]
-  branch = "fix-cp-schema"
+[[constraint]]
+  branch = "master"
   name = "github.com/giantswarm/apiextensions"
 
 [[constraint]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -21,8 +21,8 @@
 
 
 
-[[constraint]]
-  branch = "master"
+[[override]]
+  branch = "fix-cp-schema"
   name = "github.com/giantswarm/apiextensions"
 
 [[constraint]]

--- a/helm/cluster-operator/templates/psp.yaml
+++ b/helm/cluster-operator/templates/psp.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ tpl .Values.resource.psp.name . }}
@@ -8,7 +8,7 @@ spec:
     rule: MustRunAs
     ranges:
       - min: 1
-        max: 65535 
+        max: 65535
   runAsUser:
     rule: MustRunAsNonRoot
   runAsGroup:

--- a/helm/cluster-operator/templates/rbac.yaml
+++ b/helm/cluster-operator/templates/rbac.yaml
@@ -66,6 +66,8 @@ rules:
       - awsclusters/status
       - awsmachinedeployments
       - awsmachinedeployments/status
+      - g8scontrolplanes
+      - g8scontrolplanes/status
     verbs:
       - "*"
   - apiGroups:

--- a/service/controller/control_plane.go
+++ b/service/controller/control_plane.go
@@ -1,0 +1,71 @@
+package controller
+
+import (
+	infrastructurev1alpha2 "github.com/giantswarm/apiextensions/pkg/apis/infrastructure/v1alpha2"
+	"github.com/giantswarm/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/controller"
+	"k8s.io/apimachinery/pkg/runtime"
+	apiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
+
+	"github.com/giantswarm/cluster-operator/pkg/project"
+)
+
+// ControlPlaneConfig contains necessary dependencies and settings for the
+// ControlPlane controller implementation.
+type ControlPlaneConfig struct {
+	K8sClient k8sclient.Interface
+	Logger    micrologger.Logger
+}
+
+type ControlPlane struct {
+	*controller.Controller
+}
+
+func NewControlPlane(config ControlPlaneConfig) (*ControlPlane, error) {
+	var err error
+
+	var resourceSet *controller.ResourceSet
+	{
+		c := clusterResourceSetConfig{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+		}
+
+		resourceSet, err = newClusterResourceSet(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var controlPlaneController *controller.Controller
+	{
+		c := controller.Config{
+			CRD:       infrastructurev1alpha2.NewG8sControlPlaneCRD(),
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+			ResourceSets: []*controller.ResourceSet{
+				resourceSet,
+			},
+			NewRuntimeObjectFunc: func() runtime.Object {
+				return new(apiv1alpha2.Cluster)
+			},
+
+			// Name is used to compute finalizer names. This here results in something
+			// like operatorkit.giantswarm.io/cluster-operator-control-plane-controller.
+			Name: project.Name() + "-control-plane-controller",
+		}
+
+		controlPlaneController, err = controller.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	c := &ControlPlane{
+		Controller: controlPlaneController,
+	}
+
+	return c, nil
+}

--- a/service/controller/control_plane.go
+++ b/service/controller/control_plane.go
@@ -27,12 +27,12 @@ func NewControlPlane(config ControlPlaneConfig) (*ControlPlane, error) {
 
 	var resourceSet *controller.ResourceSet
 	{
-		c := clusterResourceSetConfig{
+		c := controlPlaneResourceSetConfig{
 			K8sClient: config.K8sClient,
 			Logger:    config.Logger,
 		}
 
-		resourceSet, err = newClusterResourceSet(c)
+		resourceSet, err = newControlPlaneResourceSet(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}

--- a/service/controller/control_plane.go
+++ b/service/controller/control_plane.go
@@ -7,7 +7,6 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/operatorkit/controller"
 	"k8s.io/apimachinery/pkg/runtime"
-	apiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 
 	"github.com/giantswarm/cluster-operator/pkg/project"
 )
@@ -49,7 +48,7 @@ func NewControlPlane(config ControlPlaneConfig) (*ControlPlane, error) {
 				resourceSet,
 			},
 			NewRuntimeObjectFunc: func() runtime.Object {
-				return new(apiv1alpha2.Cluster)
+				return new(infrastructurev1alpha2.G8sControlPlane)
 			},
 
 			// Name is used to compute finalizer names. This here results in something

--- a/service/controller/control_plane_resource_set.go
+++ b/service/controller/control_plane_resource_set.go
@@ -1,0 +1,106 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/giantswarm/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/resource"
+	"github.com/giantswarm/operatorkit/resource/wrapper/metricsresource"
+	"github.com/giantswarm/operatorkit/resource/wrapper/retryresource"
+
+	"github.com/giantswarm/cluster-operator/pkg/project"
+	"github.com/giantswarm/cluster-operator/service/controller/controllercontext"
+	"github.com/giantswarm/cluster-operator/service/controller/key"
+	"github.com/giantswarm/cluster-operator/service/controller/resource/workercount"
+)
+
+// controlPlaneResourceSetConfig contains necessary dependencies and settings for
+// Cluster API's Cluster controller ResourceSet configuration.
+type controlPlaneResourceSetConfig struct {
+	K8sClient k8sclient.Interface
+	Logger    micrologger.Logger
+}
+
+// newControlPlaneResourceSet returns a configured Control Plane Controller
+// ResourceSet.
+func newControlPlaneResourceSet(config controlPlaneResourceSetConfig) (*controller.ResourceSet, error) {
+	var err error
+
+	// TODO this resource must be replaced with some real resource. This is just a
+	// stub for now.
+	var workerCountResource resource.Interface
+	{
+		c := workercount.Config{
+			Logger: config.Logger,
+
+			ToClusterFunc: toClusterFunc,
+		}
+
+		workerCountResource, err = workercount.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	resources := []resource.Interface{
+		workerCountResource,
+	}
+
+	// Wrap resources with retry and metrics.
+	{
+		c := retryresource.WrapConfig{
+			Logger: config.Logger,
+		}
+
+		resources, err = retryresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	{
+		c := metricsresource.WrapConfig{}
+		resources, err = metricsresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	initCtxFunc := func(ctx context.Context, obj interface{}) (context.Context, error) {
+		ctx = controllercontext.NewContext(ctx, controllercontext.Context{})
+		return ctx, nil
+	}
+
+	handlesFunc := func(obj interface{}) bool {
+		cr, err := key.ToCluster(obj)
+		if err != nil {
+			return false
+		}
+
+		if key.OperatorVersion(&cr) == project.BundleVersion() {
+			return true
+		}
+
+		return false
+	}
+
+	var resourceSet *controller.ResourceSet
+	{
+		c := controller.ResourceSetConfig{
+			Handles:   handlesFunc,
+			InitCtx:   initCtxFunc,
+			Logger:    config.Logger,
+			Resources: resources,
+		}
+
+		resourceSet, err = controller.NewResourceSet(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return resourceSet, nil
+}

--- a/vendor/github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1/app_types.go
+++ b/vendor/github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1/app_types.go
@@ -139,43 +139,43 @@ func NewAppTypeMeta() metav1.TypeMeta {
 
 // App CRs might look something like the following.
 //
-//    apiVersion: application.giantswarm.io/v1alpha1
-//    kind: App
-//    metadata:
-//      name: "prometheus"
-//      labels:
-//        app-operator.giantswarm.io/version: "1.0.0"
+//     apiVersion: application.giantswarm.io/v1alpha1
+//     kind: App
+//     metadata:
+//       name: "prometheus"
+//       labels:
+//         app-operator.giantswarm.io/version: "1.0.0"
 //
-//    spec:
-//      catalog: "giantswarm"
-//      name: "prometheus"
-//      namespace: "monitoring"
-//      version: "1.0.0"
-//      config:
-//        configMap:
-//          name: "prometheus-values"
-//          namespace: "monitoring"
-//        secret:
-//          name: "prometheus-secrets"
-//          namespace: "monitoring"
-//        kubeConfig:
-//          inCluster: false
-//          context:
-//            name: "giantswarm-12345"
-//          secret:
-//            name: "giantswarm-12345"
-//            namespace: "giantswarm"
-//          userConfig:
-//            configMap:
-//              name: "prometheus-user-values"
-//              namespace: "monitoring"
+//     spec:
+//       catalog: "giantswarm"
+//       name: "prometheus"
+//       namespace: "monitoring"
+//       version: "1.0.0"
+//       config:
+//         configMap:
+//           name: "prometheus-values"
+//           namespace: "monitoring"
+//         secret:
+//           name: "prometheus-secrets"
+//           namespace: "monitoring"
+//         kubeConfig:
+//           inCluster: false
+//           context:
+//             name: "giantswarm-12345"
+//           secret:
+//             name: "giantswarm-12345"
+//             namespace: "giantswarm"
+//           userConfig:
+//             configMap:
+//               name: "prometheus-user-values"
+//               namespace: "monitoring"
 //
-//    status:
-// 	appVersion: "2.4.3" # Optional value from Chart.yaml with the version of the deployed app.
-//      release:
-//        lastDeployed: "2018-11-30T21:06:20Z"
-//        status: "DEPLOYED"
-//      version: "1.1.0" # Required value from Chart.yaml with the version of the chart.
+//     status:
+//       appVersion: "2.4.3" # Optional value from Chart.yaml with the version of the deployed app.
+//       release:
+//         lastDeployed: "2018-11-30T21:06:20Z"
+//         status: "DEPLOYED"
+//       version: "1.1.0" # Required value from Chart.yaml with the version of the chart.
 //
 type App struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/vendor/github.com/giantswarm/apiextensions/pkg/apis/infrastructure/v1alpha2/aws_control_plane_types.go
+++ b/vendor/github.com/giantswarm/apiextensions/pkg/apis/infrastructure/v1alpha2/aws_control_plane_types.go
@@ -35,10 +35,6 @@ spec:
         properties:
           spec:
             properties:
-              availabilityZones:
-                items:
-                  type: string
-                type: array
               instanceType:
                 type: string
             type: object

--- a/vendor/github.com/giantswarm/apiextensions/pkg/apis/infrastructure/v1alpha2/aws_control_plane_types.go
+++ b/vendor/github.com/giantswarm/apiextensions/pkg/apis/infrastructure/v1alpha2/aws_control_plane_types.go
@@ -27,10 +27,25 @@ spec:
   subresources:
     status: {}
   versions:
-    - name: v1alpha2
-      served: true
-      storage: true
-      schema :
+  - name: v1alpha1
+    served: false
+    storage: false
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              availabilityZones:
+                items:
+                  type: string
+                type: array
+              instanceType:
+                type: string
+            type: object
+  - name: v1alpha2
+    served: true
+    storage: true
+    schema:
       openAPIV3Schema:
         properties:
           spec:

--- a/vendor/github.com/giantswarm/apiextensions/pkg/apis/infrastructure/v1alpha2/g8s_control_plane_types.go
+++ b/vendor/github.com/giantswarm/apiextensions/pkg/apis/infrastructure/v1alpha2/g8s_control_plane_types.go
@@ -26,6 +26,28 @@ spec:
   subresources:
     status: {}
   versions:
+  - name: v1alpha1
+    served: false
+    storage: false
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              replicas:
+                type: int
+              infrastructureRef:
+                properties:
+                  kind:
+                    type: string
+                  namespace:
+                    type: string
+                  name:
+                    type: string
+                  apiVersion:
+                    type: string
+                type: object
+            type: object
   - name: v1alpha2
     served: true
     storage: true

--- a/vendor/github.com/giantswarm/apiextensions/pkg/apis/infrastructure/v1alpha2/g8s_control_plane_types.go
+++ b/vendor/github.com/giantswarm/apiextensions/pkg/apis/infrastructure/v1alpha2/g8s_control_plane_types.go
@@ -36,17 +36,6 @@ spec:
             properties:
               replicas:
                 type: int
-              infrastructureRef:
-                properties:
-                  kind:
-                    type: string
-                  namespace:
-                    type: string
-                  name:
-                    type: string
-                  apiVersion:
-                    type: string
-                type: object
             type: object
   - name: v1alpha2
     served: true

--- a/vendor/golang.org/x/net/http2/http2.go
+++ b/vendor/golang.org/x/net/http2/http2.go
@@ -19,7 +19,6 @@ package http2 // import "golang.org/x/net/http2"
 import (
 	"bufio"
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -172,11 +171,6 @@ func (s SettingID) String() string {
 	}
 	return fmt.Sprintf("UNKNOWN_SETTING_%d", uint16(s))
 }
-
-var (
-	errInvalidHeaderFieldName  = errors.New("http2: invalid header field name")
-	errInvalidHeaderFieldValue = errors.New("http2: invalid header field value")
-)
 
 // validWireHeaderFieldName reports whether v is a valid header field
 // name (key). See httpguts.ValidHeaderName for the base rules.

--- a/vendor/golang.org/x/net/http2/transport.go
+++ b/vendor/golang.org/x/net/http2/transport.go
@@ -2198,8 +2198,6 @@ func (rl *clientConnReadLoop) processData(f *DataFrame) error {
 	return nil
 }
 
-var errInvalidTrailers = errors.New("http2: invalid trailers")
-
 func (rl *clientConnReadLoop) endStream(cs *clientStream) {
 	// TODO: check that any declared content-length matches, like
 	// server.go's (*stream).endStream method.
@@ -2430,7 +2428,6 @@ func (cc *ClientConn) writeStreamReset(streamID uint32, code ErrCode, err error)
 var (
 	errResponseHeaderListSize = errors.New("http2: response header list larger than advertised limit")
 	errRequestHeaderListSize  = errors.New("http2: request header list larger than peer's advertised limit")
-	errPseudoTrailers         = errors.New("http2: invalid pseudo header in trailers")
 )
 
 func (cc *ClientConn) logf(format string, args ...interface{}) {

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_386.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_386.go
@@ -55,6 +55,16 @@ type Timex struct {
 	_         [44]byte
 }
 
+const (
+	TIME_OK    = 0x0
+	TIME_INS   = 0x1
+	TIME_DEL   = 0x2
+	TIME_OOP   = 0x3
+	TIME_WAIT  = 0x4
+	TIME_ERROR = 0x5
+	TIME_BAD   = 0x5
+)
+
 type Time_t int32
 
 type Tms struct {

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_amd64.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_amd64.go
@@ -55,6 +55,16 @@ type Timex struct {
 	_         [44]byte
 }
 
+const (
+	TIME_OK    = 0x0
+	TIME_INS   = 0x1
+	TIME_DEL   = 0x2
+	TIME_OOP   = 0x3
+	TIME_WAIT  = 0x4
+	TIME_ERROR = 0x5
+	TIME_BAD   = 0x5
+)
+
 type Time_t int64
 
 type Tms struct {

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_arm.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_arm.go
@@ -55,6 +55,16 @@ type Timex struct {
 	_         [44]byte
 }
 
+const (
+	TIME_OK    = 0x0
+	TIME_INS   = 0x1
+	TIME_DEL   = 0x2
+	TIME_OOP   = 0x3
+	TIME_WAIT  = 0x4
+	TIME_ERROR = 0x5
+	TIME_BAD   = 0x5
+)
+
 type Time_t int32
 
 type Tms struct {

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_arm64.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_arm64.go
@@ -55,6 +55,16 @@ type Timex struct {
 	_         [44]byte
 }
 
+const (
+	TIME_OK    = 0x0
+	TIME_INS   = 0x1
+	TIME_DEL   = 0x2
+	TIME_OOP   = 0x3
+	TIME_WAIT  = 0x4
+	TIME_ERROR = 0x5
+	TIME_BAD   = 0x5
+)
+
 type Time_t int64
 
 type Tms struct {

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_mips.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_mips.go
@@ -55,6 +55,16 @@ type Timex struct {
 	_         [44]byte
 }
 
+const (
+	TIME_OK    = 0x0
+	TIME_INS   = 0x1
+	TIME_DEL   = 0x2
+	TIME_OOP   = 0x3
+	TIME_WAIT  = 0x4
+	TIME_ERROR = 0x5
+	TIME_BAD   = 0x5
+)
+
 type Time_t int32
 
 type Tms struct {

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_mips64.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_mips64.go
@@ -55,6 +55,16 @@ type Timex struct {
 	_         [44]byte
 }
 
+const (
+	TIME_OK    = 0x0
+	TIME_INS   = 0x1
+	TIME_DEL   = 0x2
+	TIME_OOP   = 0x3
+	TIME_WAIT  = 0x4
+	TIME_ERROR = 0x5
+	TIME_BAD   = 0x5
+)
+
 type Time_t int64
 
 type Tms struct {

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_mips64le.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_mips64le.go
@@ -55,6 +55,16 @@ type Timex struct {
 	_         [44]byte
 }
 
+const (
+	TIME_OK    = 0x0
+	TIME_INS   = 0x1
+	TIME_DEL   = 0x2
+	TIME_OOP   = 0x3
+	TIME_WAIT  = 0x4
+	TIME_ERROR = 0x5
+	TIME_BAD   = 0x5
+)
+
 type Time_t int64
 
 type Tms struct {

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_mipsle.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_mipsle.go
@@ -55,6 +55,16 @@ type Timex struct {
 	_         [44]byte
 }
 
+const (
+	TIME_OK    = 0x0
+	TIME_INS   = 0x1
+	TIME_DEL   = 0x2
+	TIME_OOP   = 0x3
+	TIME_WAIT  = 0x4
+	TIME_ERROR = 0x5
+	TIME_BAD   = 0x5
+)
+
 type Time_t int32
 
 type Tms struct {

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_ppc64.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_ppc64.go
@@ -55,6 +55,16 @@ type Timex struct {
 	_         [44]byte
 }
 
+const (
+	TIME_OK    = 0x0
+	TIME_INS   = 0x1
+	TIME_DEL   = 0x2
+	TIME_OOP   = 0x3
+	TIME_WAIT  = 0x4
+	TIME_ERROR = 0x5
+	TIME_BAD   = 0x5
+)
+
 type Time_t int64
 
 type Tms struct {

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_ppc64le.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_ppc64le.go
@@ -55,6 +55,16 @@ type Timex struct {
 	_         [44]byte
 }
 
+const (
+	TIME_OK    = 0x0
+	TIME_INS   = 0x1
+	TIME_DEL   = 0x2
+	TIME_OOP   = 0x3
+	TIME_WAIT  = 0x4
+	TIME_ERROR = 0x5
+	TIME_BAD   = 0x5
+)
+
 type Time_t int64
 
 type Tms struct {

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_riscv64.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_riscv64.go
@@ -55,6 +55,16 @@ type Timex struct {
 	_         [44]byte
 }
 
+const (
+	TIME_OK    = 0x0
+	TIME_INS   = 0x1
+	TIME_DEL   = 0x2
+	TIME_OOP   = 0x3
+	TIME_WAIT  = 0x4
+	TIME_ERROR = 0x5
+	TIME_BAD   = 0x5
+)
+
 type Time_t int64
 
 type Tms struct {

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_s390x.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_s390x.go
@@ -55,6 +55,16 @@ type Timex struct {
 	_         [44]byte
 }
 
+const (
+	TIME_OK    = 0x0
+	TIME_INS   = 0x1
+	TIME_DEL   = 0x2
+	TIME_OOP   = 0x3
+	TIME_WAIT  = 0x4
+	TIME_ERROR = 0x5
+	TIME_BAD   = 0x5
+)
+
 type Time_t int64
 
 type Tms struct {

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_sparc64.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_sparc64.go
@@ -56,6 +56,16 @@ type Timex struct {
 	_         [44]byte
 }
 
+const (
+	TIME_OK    = 0x0
+	TIME_INS   = 0x1
+	TIME_DEL   = 0x2
+	TIME_OOP   = 0x3
+	TIME_WAIT  = 0x4
+	TIME_ERROR = 0x5
+	TIME_BAD   = 0x5
+)
+
 type Time_t int64
 
 type Tms struct {


### PR DESCRIPTION
> {"caller":"github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/backoff/notifier.go:13","controller":"cluster-operator-control-plane-controller","level":"warning","message":"retrying backoff in '1s' due to error","stack":"[{/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:185: } {/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:242: } {/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/k8sclient/k8scrdclient/k8scrdclient.go:48: } {/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/k8sclient/k8scrdclient/k8scrdclient.go:85: } {CustomResourceDefinition.apiextensions.k8s.io \"g8scontrolplanes.infrastructure.giantswarm.io\" is invalid: spec.versions: Invalid value: []apiextensions.CustomResourceDefinitionVersion{apiextensions.CustomResourceDefinitionVersion{Name:\"v1alpha2\", Served:true, Storage:true, Schema:(*apiextensions.CustomResourceValidation)(0xc014f72af8), Subresources:(*apiextensions.CustomResourceSubresources)(nil), AdditionalPrinterColumns:[]apiextensions.CustomResourceColumnDefinition(nil)}}: per-version schemas may not all be set to identical values (top-level validation should be used instead)}]","time":"2020-02-20T17:52:34.454316+00:00"}