### PR TITLE
Use next patch version for legacy

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,7 +1,7 @@
 package project
 
 var (
-	bundleVersion = "0.24.0-dev"
+	bundleVersion = "0.23.2-dev"
 	description   = "The cluster-operator manages Kubernetes tenant cluster resources."
 	gitSHA        = "n/a"
 	name          = "cluster-operator"


### PR DESCRIPTION
Last legacy release was 0.23.1 so this should be next patch version.

See https://github.com/giantswarm/cluster-operator/pull/926#discussion_r381925382.