### PR TITLE
fix PSP api version

### DIFF
--- a/helm/cluster-operator/templates/psp.yaml
+++ b/helm/cluster-operator/templates/psp.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ tpl .Values.resource.psp.name . }}
@@ -8,7 +8,7 @@ spec:
     rule: MustRunAs
     ranges:
       - min: 1
-        max: 65535 
+        max: 65535
   runAsUser:
     rule: MustRunAsNonRoot
   runAsGroup:


### PR DESCRIPTION
Coming from https://gigantic.slack.com/archives/C76JX6YLQ/p1582535793004300. The CP got updated and we missed to bump `cluster-operator`. 