### PR TITLE
pkg, service: replace `bundleVersion` with `version`

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,17 +1,12 @@
 package project
 
 var (
-	bundleVersion = "2.1.2-dev"
-	description   = "The cluster-operator manages Kubernetes tenant cluster resources."
-	gitSHA        = "n/a"
-	name          = "cluster-operator"
-	source        = "https://github.com/giantswarm/cluster-operator"
-	version       = "n/a"
+	description = "The cluster-operator manages Kubernetes tenant cluster resources."
+	gitSHA      = "n/a"
+	name        = "cluster-operator"
+	source      = "https://github.com/giantswarm/cluster-operator"
+	version     = "2.1.2-dev"
 )
-
-func BundleVersion() string {
-	return bundleVersion
-}
 
 func Description() string {
 	return description

--- a/pkg/project/version_bundle.go
+++ b/pkg/project/version_bundle.go
@@ -19,6 +19,6 @@ func VersionBundle(p string) versionbundle.Bundle {
 		Components: []versionbundle.Component{},
 		Name:       "cluster-operator",
 		Provider:   p,
-		Version:    BundleVersion(),
+		Version:    Version(),
 	}
 }

--- a/service/controller/cluster_resource_set.go
+++ b/service/controller/cluster_resource_set.go
@@ -443,7 +443,7 @@ func newClusterResourceSet(config clusterResourceSetConfig) (*controller.Resourc
 			return false
 		}
 
-		if key.OperatorVersion(&cr) == project.BundleVersion() {
+		if key.OperatorVersion(&cr) == project.Version() {
 			return true
 		}
 

--- a/service/controller/control_plane_resource_set.go
+++ b/service/controller/control_plane_resource_set.go
@@ -80,7 +80,7 @@ func newControlPlaneResourceSet(config controlPlaneResourceSetConfig) (*controll
 			return false
 		}
 
-		if key.OperatorVersion(&cr) == project.BundleVersion() {
+		if key.OperatorVersion(&cr) == project.Version() {
 			return true
 		}
 

--- a/service/controller/machine_deployment_resource_set.go
+++ b/service/controller/machine_deployment_resource_set.go
@@ -169,7 +169,7 @@ func newMachineDeploymentResourceSet(config machineDeploymentResourceSetConfig) 
 			return false
 		}
 
-		if key.OperatorVersion(&cr) == project.BundleVersion() {
+		if key.OperatorVersion(&cr) == project.Version() {
 			return true
 		}
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8637

We want to invert how the project version is maintained and now that
it isn't injected during the build from git data, we can remove the
separate concept of _bundle version_ and replace it with just _version_.