### PR TITLE
Template local cluster domain in legacy

### DIFF
--- a/flag/guest/cluster/kubernetes/api/api.go
+++ b/flag/guest/cluster/kubernetes/api/api.go
@@ -5,6 +5,7 @@ package api
 type API struct {
 	AltNames       string
 	ClusterIPRange string
+	Domain         string
 	InsecurePort   string
 	SecurePort     string
 }

--- a/main.go
+++ b/main.go
@@ -106,6 +106,8 @@ func mainE() error {
 	daemonCommand.PersistentFlags().String(f.Guest.Cluster.Calico.CIDR, "", "Prefix length for the CIDR block used by Calico.")
 	daemonCommand.PersistentFlags().String(f.Guest.Cluster.Calico.Subnet, "", "Network address for the CIDR block used by Calico.")
 	daemonCommand.PersistentFlags().String(f.Guest.Cluster.Kubernetes.API.ClusterIPRange, "", "CIDR Range for Pods in cluster.")
+	daemonCommand.PersistentFlags().String(f.Guest.Cluster.Kubernetes.API.Domain, "", "Internal Kubernetes domain.")
+
 	daemonCommand.PersistentFlags().String(f.Guest.Cluster.Vault.Certificate.TTL, "", "Vault certificate TTL.")
 
 	daemonCommand.PersistentFlags().String(f.Service.ClusterService.Address, "http://localhost:8089", "http://<host>:<port> of the cluster service.")

--- a/service/controller/aws/legacy_cluster.go
+++ b/service/controller/aws/legacy_cluster.go
@@ -33,6 +33,7 @@ type LegacyClusterConfig struct {
 	CalicoAddress        string
 	CalicoPrefixLength   string
 	ClusterIPRange       string
+	KubernetesDomain     string
 	ProjectName          string
 	Provider             string
 	RawAppDefaultConfig  string
@@ -64,6 +65,7 @@ func NewLegacyCluster(config LegacyClusterConfig) (*LegacyCluster, error) {
 			CalicoAddress:        config.CalicoAddress,
 			CalicoPrefixLength:   config.CalicoPrefixLength,
 			ClusterIPRange:       config.ClusterIPRange,
+			KubernetesDomain:     config.KubernetesDomain,
 			ProjectName:          config.ProjectName,
 			Provider:             config.Provider,
 			RawAppDefaultConfig:  config.RawAppDefaultConfig,

--- a/service/controller/aws/resource_set.go
+++ b/service/controller/aws/resource_set.go
@@ -52,6 +52,7 @@ type resourceSetConfig struct {
 	CalicoPrefixLength    string
 	ClusterIPRange        string
 	HandledVersionBundles []string
+	KubernetesDomain      string
 	ProjectName           string
 	Provider              string
 	RawAppDefaultConfig   string

--- a/service/controller/azure/legacy_cluster.go
+++ b/service/controller/azure/legacy_cluster.go
@@ -31,6 +31,7 @@ type LegacyClusterConfig struct {
 	CalicoAddress        string
 	CalicoPrefixLength   string
 	ClusterIPRange       string
+	KubernetesDomain     string
 	ProjectName          string
 	Provider             string
 	RawAppDefaultConfig  string
@@ -62,6 +63,7 @@ func NewLegacyCluster(config LegacyClusterConfig) (*LegacyCluster, error) {
 			CalicoAddress:        config.CalicoAddress,
 			CalicoPrefixLength:   config.CalicoPrefixLength,
 			ClusterIPRange:       config.ClusterIPRange,
+			KubernetesDomain:     config.KubernetesDomain,
 			ProjectName:          config.ProjectName,
 			Provider:             config.Provider,
 			RawAppDefaultConfig:  config.RawAppDefaultConfig,

--- a/service/controller/azure/resource_set.go
+++ b/service/controller/azure/resource_set.go
@@ -52,6 +52,7 @@ type resourceSetConfig struct {
 	CalicoPrefixLength    string
 	ClusterIPRange        string
 	HandledVersionBundles []string
+	KubernetesDomain      string
 	ProjectName           string
 	Provider              string
 	RawAppDefaultConfig   string

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -156,6 +156,11 @@ func DNSIP(clusterIPRange string) (string, error) {
 	return ip.String(), nil
 }
 
+// DNSInternalZone returns internal domain for guest cluster.
+func DNSInternalZone(clusterGuestConfig v1alpha1.ClusterGuestConfig) string {
+	return clusterGuestConfig.DNSInternalZone
+}
+
 // DNSZone returns common domain for guest cluster.
 func DNSZone(clusterGuestConfig v1alpha1.ClusterGuestConfig) string {
 	return clusterGuestConfig.DNSZone

--- a/service/controller/kvm/legacy_cluster.go
+++ b/service/controller/kvm/legacy_cluster.go
@@ -31,6 +31,7 @@ type LegacyClusterConfig struct {
 	CalicoAddress        string
 	CalicoPrefixLength   string
 	ClusterIPRange       string
+	KubernetesDomain     string
 	ProjectName          string
 	Provider             string
 	RawAppDefaultConfig  string
@@ -62,6 +63,7 @@ func NewLegacyCluster(config LegacyClusterConfig) (*LegacyCluster, error) {
 			CalicoAddress:        config.CalicoAddress,
 			CalicoPrefixLength:   config.CalicoPrefixLength,
 			ClusterIPRange:       config.ClusterIPRange,
+			KubernetesDomain:     config.KubernetesDomain,
 			ProjectName:          config.ProjectName,
 			Provider:             config.Provider,
 			RawAppDefaultConfig:  config.RawAppDefaultConfig,

--- a/service/controller/kvm/resource_set.go
+++ b/service/controller/kvm/resource_set.go
@@ -52,6 +52,7 @@ type resourceSetConfig struct {
 	CalicoPrefixLength    string
 	ClusterIPRange        string
 	HandledVersionBundles []string
+	KubernetesDomain      string
 	ProjectName           string
 	Provider              string
 	RawAppDefaultConfig   string

--- a/service/internal/cluster/config.go
+++ b/service/internal/cluster/config.go
@@ -20,6 +20,7 @@ type Domain struct {
 	Etcd               string
 	FlanneldEtcdClient string
 	InternalAPI        string
+	InternalKubernetes string
 	NodeOperator       string
 	Prometheus         string
 	ServiceAccount     string

--- a/service/service.go
+++ b/service/service.go
@@ -2,10 +2,11 @@ package service
 
 import (
 	"context"
-	"gopkg.in/resty.v1"
 	"net"
 	"sync"
 	"time"
+
+	"gopkg.in/resty.v1"
 
 	corev1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/apprclient"
@@ -68,6 +69,7 @@ func New(config Config) (*Service, error) {
 	calicoAddress := config.Viper.GetString(config.Flag.Guest.Cluster.Calico.Subnet)
 	calicoPrefixLength := config.Viper.GetString(config.Flag.Guest.Cluster.Calico.CIDR)
 	clusterIPRange := config.Viper.GetString(config.Flag.Guest.Cluster.Kubernetes.API.ClusterIPRange)
+	kubernetesDomain := config.Viper.GetString(config.Flag.Guest.Cluster.Kubernetes.API.Domain)
 	registryDomain := config.Viper.GetString(config.Flag.Service.Image.Registry.Domain)
 	resourceNamespace := config.Viper.GetString(config.Flag.Service.KubeConfig.Secret.Namespace)
 	provider := config.Viper.GetString(config.Flag.Service.Provider.Kind)
@@ -198,6 +200,7 @@ func New(config Config) (*Service, error) {
 			CalicoAddress:        calicoAddress,
 			CalicoPrefixLength:   calicoPrefixLength,
 			ClusterIPRange:       clusterIPRange,
+			KubernetesDomain:     kubernetesDomain,
 			ProjectName:          project.Name(),
 			RegistryDomain:       registryDomain,
 			Provider:             provider,
@@ -232,6 +235,7 @@ func New(config Config) (*Service, error) {
 			CalicoAddress:        calicoAddress,
 			CalicoPrefixLength:   calicoPrefixLength,
 			ClusterIPRange:       clusterIPRange,
+			KubernetesDomain:     kubernetesDomain,
 			ProjectName:          project.Name(),
 			Provider:             provider,
 			RawAppDefaultConfig:  config.Viper.GetString(config.Flag.Service.Release.App.Config.Default),
@@ -266,6 +270,7 @@ func New(config Config) (*Service, error) {
 			CalicoAddress:        calicoAddress,
 			CalicoPrefixLength:   calicoPrefixLength,
 			ClusterIPRange:       clusterIPRange,
+			KubernetesDomain:     kubernetesDomain,
 			ProjectName:          project.Name(),
 			Provider:             provider,
 			RawAppDefaultConfig:  config.Viper.GetString(config.Flag.Service.Release.App.Config.Default),

--- a/vendor/github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1/cluster_guest_types.go
+++ b/vendor/github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1/cluster_guest_types.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 type ClusterGuestConfig struct {
 	AvailabilityZones int `json:"availabilityZones,omitempty" yaml:"availabilityZones,omitempty"`
+	DNSInternalZone   string
 	// DNSZone for guest cluster is supplemented with host prefixes for
 	// specific services such as Kubernetes API or Etcd. In general this DNS
 	// Zone should start with `k8s` like for example


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8979

I need this to be able to pass internal domain value into certconfig of legacy cluster-operator

Vendoring will be updated after merging https://github.com/giantswarm/apiextensions/pull/335/files