### PR TITLE
fix cluster deletion by not creating k8s client

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 The cluster-operator is an in-cluster agent that handles Giant Swarm guest
 cluster specific resources.
 
+
+
 ## Branches
 
 - `thiccc`
@@ -49,4 +51,3 @@ contribution workflow as well as reporting bugs.
 
 cluster-operator is under the Apache 2.0 license. See the [LICENSE](LICENSE) file for
 details.
-

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,7 +1,7 @@
 package project
 
 var (
-	bundleVersion = "0.23.1"
+	bundleVersion = "0.23.2-dev"
 	description   = "The cluster-operator manages Kubernetes tenant cluster resources."
 	gitSHA        = "n/a"
 	name          = "cluster-operator"

--- a/pkg/project/version_bundle_aws.go
+++ b/pkg/project/version_bundle_aws.go
@@ -8,10 +8,10 @@ var versionBundleAWS = versionbundle.Bundle{
 	Changelogs: []versionbundle.Changelog{
 		{
 			Component:   "cluster-operator",
-			Description: "Linking a custom configMaps for default apps",
+			Description: "Fix cluster deletion by gracefully handling Tenant Cluster API errors.",
 			Kind:        versionbundle.KindChanged,
 			URLs: []string{
-				"https://github.com/giantswarm/cluster-operator/pull/924",
+				"https://github.com/giantswarm/cluster-operator/pull/936",
 			},
 		},
 	},

--- a/pkg/project/version_bundle_azure.go
+++ b/pkg/project/version_bundle_azure.go
@@ -8,10 +8,10 @@ var versionBundleAzure = versionbundle.Bundle{
 	Changelogs: []versionbundle.Changelog{
 		{
 			Component:   "cluster-operator",
-			Description: "Linking a custom configMaps for default apps",
+			Description: "Fix cluster deletion by gracefully handling Tenant Cluster API errors.",
 			Kind:        versionbundle.KindChanged,
 			URLs: []string{
-				"https://github.com/giantswarm/cluster-operator/pull/924",
+				"https://github.com/giantswarm/cluster-operator/pull/936",
 			},
 		},
 	},

--- a/pkg/project/version_bundle_kvm.go
+++ b/pkg/project/version_bundle_kvm.go
@@ -8,10 +8,10 @@ var versionBundleKVM = versionbundle.Bundle{
 	Changelogs: []versionbundle.Changelog{
 		{
 			Component:   "cluster-operator",
-			Description: "Linking a custom configMaps for default apps",
+			Description: "Fix cluster deletion by gracefully handling Tenant Cluster API errors.",
 			Kind:        versionbundle.KindChanged,
 			URLs: []string{
-				"https://github.com/giantswarm/cluster-operator/pull/924",
+				"https://github.com/giantswarm/cluster-operator/pull/936",
 			},
 		},
 	},

--- a/service/controller/resource/tenantclients/create.go
+++ b/service/controller/resource/tenantclients/create.go
@@ -3,13 +3,68 @@ package tenantclients
 import (
 	"context"
 
+	"github.com/giantswarm/errors/tenant"
+	"github.com/giantswarm/k8sclient"
 	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/tenantcluster"
+	"k8s.io/client-go/rest"
+
+	"github.com/giantswarm/cluster-operator/service/controller/controllercontext"
+	"github.com/giantswarm/cluster-operator/service/controller/key"
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
-	err := r.ensure(ctx, obj)
+	cr, err := r.toClusterConfigFunc(obj)
 	if err != nil {
 		return microerror.Mask(err)
+	}
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	var tenantAPIDomain string
+	{
+		tenantAPIDomain, err = key.APIDomain(cr)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	var restConfig *rest.Config
+	{
+		restConfig, err = r.tenant.NewRestConfig(ctx, key.ClusterID(cr), tenantAPIDomain)
+		if tenantcluster.IsTimeout(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "timeout fetching certificates")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+			return nil
+
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	var k8sClient k8sclient.Interface
+	{
+		c := k8sclient.ClientsConfig{
+			Logger:     r.logger,
+			RestConfig: rest.CopyConfig(restConfig),
+		}
+
+		k8sClient, err = k8sclient.NewClients(c)
+		if tenant.IsAPINotAvailable(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant API not available yet")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+			return nil
+
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	{
+		cc.Client.TenantCluster.G8s = k8sClient.G8sClient()
+		cc.Client.TenantCluster.K8s = k8sClient.K8sClient()
 	}
 
 	return nil

--- a/service/controller/resource/tenantclients/delete.go
+++ b/service/controller/resource/tenantclients/delete.go
@@ -2,15 +2,13 @@ package tenantclients
 
 import (
 	"context"
-
-	"github.com/giantswarm/microerror"
 )
 
+// EnsureDeleted is not putting the tenant clients into the controller context
+// because we do not want to interact with the Tenant Cluster API on delete
+// events. This is to reduce eventual friction. Cluster deletion should not be
+// affected only because the Tenant Cluster API is not available for some
+// reason. Other resources must not rely on tenant clients on delete events.
 func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
-	err := r.ensure(ctx, obj)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
 	return nil
 }

--- a/service/controller/resource/tenantclients/resource.go
+++ b/service/controller/resource/tenantclients/resource.go
@@ -1,18 +1,10 @@
 package tenantclients
 
 import (
-	"context"
-
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
-	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
-	"github.com/giantswarm/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/tenantcluster"
-	"k8s.io/client-go/kubernetes"
-
-	"github.com/giantswarm/cluster-operator/service/controller/controllercontext"
-	"github.com/giantswarm/cluster-operator/service/controller/key"
 )
 
 const (
@@ -53,56 +45,4 @@ func New(config Config) (*Resource, error) {
 
 func (r *Resource) Name() string {
 	return Name
-}
-
-func (r *Resource) ensure(ctx context.Context, obj interface{}) error {
-	cr, err := r.toClusterConfigFunc(obj)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-	cc, err := controllercontext.FromContext(ctx)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	var tenantAPIDomain string
-	{
-		tenantAPIDomain, err = key.APIDomain(cr)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-	}
-
-	var g8sClient versioned.Interface
-	var k8sClient kubernetes.Interface
-	{
-		tenantRestConfig, err := r.tenant.NewRestConfig(ctx, key.ClusterID(cr), tenantAPIDomain)
-		if tenantcluster.IsTimeout(err) {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "timeout fetching certificates")
-			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-			return nil
-
-		} else if err != nil {
-			return microerror.Mask(err)
-		}
-
-		tenantClientsConfig := k8sclient.ClientsConfig{
-			Logger:     r.logger,
-			RestConfig: tenantRestConfig,
-		}
-		tenantK8sClients, err := k8sclient.NewClients(tenantClientsConfig)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		g8sClient = tenantK8sClients.G8sClient()
-		k8sClient = tenantK8sClients.K8sClient()
-	}
-
-	{
-		cc.Client.TenantCluster.G8s = g8sClient
-		cc.Client.TenantCluster.K8s = k8sClient
-	}
-
-	return nil
 }


### PR DESCRIPTION
Coming from https://gigantic.slack.com/archives/CHAHY6VMF/p1582555602005300. This is based off of `v0.23.1` aiming to create a new patch `v0.23.2`. 