### PR TITLE
Changelog about user app override

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA      = "n/a"
 	name        = "cluster-operator"
 	source      = "https://github.com/giantswarm/cluster-operator"
-	version     = "2.1.2-dev"
+	version     = "2.1.2"
 )
 
 func Description() string {

--- a/pkg/project/version_bundle.go
+++ b/pkg/project/version_bundle.go
@@ -9,10 +9,10 @@ func VersionBundle(p string) versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "cluster-operator",
-				Description: "Moved default app list from cluster-operator code to release repository.",
+				Description: "User app override rules applied",
 				Kind:        versionbundle.KindChanged,
 				URLs: []string{
-					"https://github.com/giantswarm/cluster-operator/pull/889",
+					"https://github.com/giantswarm/cluster-operator/pull/930",
 				},
 			},
 		},


### PR DESCRIPTION
Toward giantswarm/giantswarm#9037

Following actions from https://github.com/giantswarm/cluster-operator/pull/930

I forgot to update the changelog, and bring a new version into the repo. 