### PR TITLE
0.23.2 release legacy

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,7 +1,7 @@
 package project
 
 var (
-	bundleVersion = "0.23.2-dev"
+	bundleVersion = "0.23.2"
 	description   = "The cluster-operator manages Kubernetes tenant cluster resources."
 	gitSHA        = "n/a"
 	name          = "cluster-operator"


### PR DESCRIPTION
0.23.2 release for legacy clusters; will roll back to dev after tag release.