### PR TITLE
Migrate AWS NGINX use-proxy-protocol override

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,7 +1,7 @@
 package project
 
 var (
-	bundleVersion = "0.23.3-dev"
+	bundleVersion = "0.23.3"
 	description   = "The cluster-operator manages Kubernetes tenant cluster resources."
 	gitSHA        = "n/a"
 	name          = "cluster-operator"

--- a/pkg/project/version_bundle_aws.go
+++ b/pkg/project/version_bundle_aws.go
@@ -8,10 +8,10 @@ var versionBundleAWS = versionbundle.Bundle{
 	Changelogs: []versionbundle.Changelog{
 		{
 			Component:   "cluster-operator",
-			Description: "TODO",
+			Description: "Migrate setting use-proxy-protocol from global to NGINX configmap",
 			Kind:        versionbundle.KindChanged,
 			URLs: []string{
-				"",
+				"https://github.com/giantswarm/cluster-operator/pull/944",
 			},
 		},
 	},

--- a/pkg/project/version_bundle_azure.go
+++ b/pkg/project/version_bundle_azure.go
@@ -8,10 +8,10 @@ var versionBundleAzure = versionbundle.Bundle{
 	Changelogs: []versionbundle.Changelog{
 		{
 			Component:   "cluster-operator",
-			Description: "TODO",
+			Description: "Migrate setting use-proxy-protocol from global to NGINX configmap",
 			Kind:        versionbundle.KindChanged,
 			URLs: []string{
-				"",
+				"https://github.com/giantswarm/cluster-operator/pull/944",
 			},
 		},
 	},

--- a/pkg/project/version_bundle_kvm.go
+++ b/pkg/project/version_bundle_kvm.go
@@ -8,10 +8,10 @@ var versionBundleKVM = versionbundle.Bundle{
 	Changelogs: []versionbundle.Changelog{
 		{
 			Component:   "cluster-operator",
-			Description: "TODO",
+			Description: "Migrate setting use-proxy-protocol from global to NGINX configmap",
 			Kind:        versionbundle.KindChanged,
 			URLs: []string{
-				"",
+				"https://github.com/giantswarm/cluster-operator/pull/944",
 			},
 		},
 	},

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -115,10 +115,8 @@ func (r *StateGetter) GetDesiredState(ctx context.Context, obj interface{}) ([]*
 						"enabled": controllerServiceEnabled,
 					},
 				},
-				"global": map[string]interface{}{
-					"controller": map[string]interface{}{
-						"useProxyProtocol": useProxyProtocol,
-					},
+				"configmap": map[string]interface{}{
+					"use-proxy-protocol": useProxyProtocol,
 				},
 				"ingressController": map[string]interface{}{
 					// Legacy flag is set to true so resources created by

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -2,6 +2,7 @@ package clusterconfigmap
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/microerror"
@@ -115,8 +116,8 @@ func (r *StateGetter) GetDesiredState(ctx context.Context, obj interface{}) ([]*
 						"enabled": controllerServiceEnabled,
 					},
 				},
-				"configmap": map[string]interface{}{
-					"use-proxy-protocol": useProxyProtocol,
+				"configmap": map[string]string{
+					"use-proxy-protocol": strconv.FormatBool(useProxyProtocol),
 				},
 				"ingressController": map[string]interface{}{
 					// Legacy flag is set to true so resources created by


### PR DESCRIPTION
This fixes a leftover from configuration changes in nginx IC App https://github.com/giantswarm/nginx-ingress-controller-app/pull/26 - ensures AWS installations by default have `use-proxy-protocol` nginx configmap setting overriden to `true`.

Slack #team-halo thread https://gigantic.slack.com/archives/CR99LSZ1N/p1583155860115800