### PR TITLE
Re-enable using proxy protocol by default for AWS clusters

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA      = "n/a"
 	name        = "cluster-operator"
 	source      = "https://github.com/giantswarm/cluster-operator"
-	version     = "2.1.3-dev"
+	version     = "2.1.3"
 )
 
 func Description() string {

--- a/pkg/project/version_bundle.go
+++ b/pkg/project/version_bundle.go
@@ -9,10 +9,10 @@ func VersionBundle(p string) versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "cluster-operator",
-				Description: "TODO",
+				Description: "Re-enable proxy protocol by default for AWS clusters",
 				Kind:        versionbundle.KindChanged,
 				URLs: []string{
-					"",
+					"https://github.com/giantswarm/cluster-operator/pull/945",
 				},
 			},
 		},

--- a/service/controller/cluster_resource_set.go
+++ b/service/controller/cluster_resource_set.go
@@ -171,6 +171,7 @@ func newClusterResourceSet(config clusterResourceSetConfig) (*controller.Resourc
 			CalicoPrefixLength: config.CalicoPrefixLength,
 			ClusterIPRange:     config.ClusterIPRange,
 			DNSIP:              config.DNSIP,
+			Provider:           config.Provider,
 		}
 
 		clusterConfigMapGetter, err = clusterconfigmap.New(c)

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -53,6 +53,14 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 		ingressControllerReplicas = 20
 	}
 
+	// useProxyProtocol is only enabled by default for AWS clusters.
+	var useProxyProtocol bool
+	{
+		if r.provider == "aws" {
+			useProxyProtocol = true
+		}
+	}
+
 	configMapSpecs := []configMapSpec{
 		{
 			Name:      key.ClusterConfigMapName(&cr),
@@ -82,6 +90,9 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 			Values: map[string]interface{}{
 				"baseDomain": key.TenantEndpoint(cr, cc.Status.Endpoint.Base),
 				"clusterID":  key.ClusterID(&cr),
+				"configmap": map[string]interface{}{
+					"use-proxy-protocol": useProxyProtocol,
+				},
 				"ingressController": map[string]interface{}{
 					"replicas": ingressControllerReplicas,
 				},

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -3,6 +3,7 @@ package clusterconfigmap
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/giantswarm/microerror"
 	yaml "gopkg.in/yaml.v2"
@@ -91,7 +92,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 				"baseDomain": key.TenantEndpoint(cr, cc.Status.Endpoint.Base),
 				"clusterID":  key.ClusterID(&cr),
 				"configmap": map[string]interface{}{
-					"use-proxy-protocol": useProxyProtocol,
+					"use-proxy-protocol": strconv.FormatBool(useProxyProtocol),
 				},
 				"ingressController": map[string]interface{}{
 					"replicas": ingressControllerReplicas,

--- a/service/controller/resource/clusterconfigmap/resource.go
+++ b/service/controller/resource/clusterconfigmap/resource.go
@@ -21,6 +21,7 @@ type Config struct {
 	CalicoPrefixLength string
 	ClusterIPRange     string
 	DNSIP              string
+	Provider           string
 }
 
 // Resource implements the clusterConfigMap resource.
@@ -32,6 +33,7 @@ type Resource struct {
 	calicoPrefixLength string
 	clusterIPRange     string
 	dnsIP              string
+	provider           string
 }
 
 // New creates a new configured config map state getter resource managing
@@ -53,6 +55,9 @@ func New(config Config) (*Resource, error) {
 	if config.DNSIP == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.DNSIP must not be empty", config)
 	}
+	if config.Provider == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Provider must not be empty", config)
+	}
 
 	r := &Resource{
 		k8sClient: config.K8sClient,
@@ -62,6 +67,7 @@ func New(config Config) (*Resource, error) {
 		calicoPrefixLength: config.CalicoPrefixLength,
 		clusterIPRange:     config.ClusterIPRange,
 		dnsIP:              config.DNSIP,
+		provider:           config.Provider,
 	}
 
 	return r, nil


### PR DESCRIPTION
Same as https://github.com/giantswarm/cluster-operator/pull/944 but for master.