### PR TITLE
Stop setting IC replicas count

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA      = "n/a"
 	name        = "cluster-operator"
 	source      = "https://github.com/giantswarm/cluster-operator"
-	version     = "2.1.4-dev"
+	version     = "2.1.4"
 )
 
 func Description() string {

--- a/pkg/project/version_bundle.go
+++ b/pkg/project/version_bundle.go
@@ -9,10 +9,10 @@ func VersionBundle(p string) versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "cluster-operator",
-				Description: "TODO",
+				Description: "Stop setting IC replicas count",
 				Kind:        versionbundle.KindChanged,
 				URLs: []string{
-					"",
+					"https://github.com/giantswarm/cluster-operator/pull/949",
 				},
 			},
 		},

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -33,27 +33,6 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 		calicoCIDRBlock = cidrBlock(r.calicoAddress, r.calicoPrefixLength)
 	}
 
-	var ingressControllerReplicas int32
-	{
-		// We set the number of replicas to the number of worker nodes. This is
-		// set by the workercount resource which returns a map with each node
-		// pool and its current number of nodes.
-		for _, v := range cc.Status.Worker {
-			ingressControllerReplicas += v.Nodes
-		}
-	}
-
-	// We limit the number of replicas to 20 as running more than this does
-	// not make sense.
-	//
-	// TODO: Remove Ingress Controller configmap once HPA is enabled by default.
-	//
-	//	https://github.com/giantswarm/giantswarm/issues/8080
-	//
-	if ingressControllerReplicas > 20 {
-		ingressControllerReplicas = 20
-	}
-
 	// useProxyProtocol is only enabled by default for AWS clusters.
 	var useProxyProtocol bool
 	{
@@ -93,9 +72,6 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 				"clusterID":  key.ClusterID(&cr),
 				"configmap": map[string]interface{}{
 					"use-proxy-protocol": strconv.FormatBool(useProxyProtocol),
-				},
-				"ingressController": map[string]interface{}{
-					"replicas": ingressControllerReplicas,
 				},
 			},
 		},


### PR DESCRIPTION
With HPA enabled, cluster-operator setting IC replicas count is not only no longer needed, but every time cluster changes cluster-operator would updated the IC ConfigMap resulting in IC redeployment and resetting the Deployment and HPA state.