### PR TITLE
update infra refs for Control Plane CRs

### DIFF
--- a/service/controller/control_plane.go
+++ b/service/controller/control_plane.go
@@ -16,6 +16,8 @@ import (
 type ControlPlaneConfig struct {
 	K8sClient k8sclient.Interface
 	Logger    micrologger.Logger
+
+	Provider string
 }
 
 type ControlPlane struct {
@@ -30,6 +32,8 @@ func NewControlPlane(config ControlPlaneConfig) (*ControlPlane, error) {
 		c := controlPlaneResourceSetConfig{
 			K8sClient: config.K8sClient,
 			Logger:    config.Logger,
+
+			Provider: config.Provider,
 		}
 
 		resourceSet, err = newControlPlaneResourceSet(c)

--- a/service/controller/control_plane_resource_set.go
+++ b/service/controller/control_plane_resource_set.go
@@ -16,6 +16,7 @@ import (
 	"github.com/giantswarm/cluster-operator/service/controller/controllercontext"
 	"github.com/giantswarm/cluster-operator/service/controller/key"
 	"github.com/giantswarm/cluster-operator/service/controller/resource/keepforinfrarefs"
+	"github.com/giantswarm/cluster-operator/service/controller/resource/updateinfrarefs"
 )
 
 // controlPlaneResourceSetConfig contains necessary dependencies and settings for
@@ -23,6 +24,8 @@ import (
 type controlPlaneResourceSetConfig struct {
 	K8sClient k8sclient.Interface
 	Logger    micrologger.Logger
+
+	Provider string
 }
 
 // newControlPlaneResourceSet returns a configured Control Plane Controller
@@ -45,8 +48,25 @@ func newControlPlaneResourceSet(config controlPlaneResourceSetConfig) (*controll
 		}
 	}
 
+	var updateInfraRefsResource resource.Interface
+	{
+		c := updateinfrarefs.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+
+			ToObjRef: toClusterObjRef,
+			Provider: config.Provider,
+		}
+
+		updateInfraRefsResource, err = updateinfrarefs.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	resources := []resource.Interface{
 		keepForInfraRefsResource,
+		updateInfraRefsResource,
 	}
 
 	// Wrap resources with retry and metrics.

--- a/service/controller/control_plane_resource_set.go
+++ b/service/controller/control_plane_resource_set.go
@@ -54,7 +54,7 @@ func newControlPlaneResourceSet(config controlPlaneResourceSetConfig) (*controll
 			K8sClient: config.K8sClient,
 			Logger:    config.Logger,
 
-			ToObjRef: toClusterObjRef,
+			ToObjRef: toG8sControlPlaneObjRef,
 			Provider: config.Provider,
 		}
 

--- a/service/service.go
+++ b/service/service.go
@@ -186,6 +186,8 @@ func New(config Config) (*Service, error) {
 		c := controller.ControlPlaneConfig{
 			K8sClient: k8sClient,
 			Logger:    config.Logger,
+
+			Provider: provider,
 		}
 
 		controlPlaneController, err = controller.NewControlPlane(c)


### PR DESCRIPTION
This is to update the version labels of Control Plane CRs which means propagating them from the generic to the provider specific CR. 