### PR TITLE
update G8sControlPlane CRs on updates

### DIFF
--- a/service/controller/cluster_resource_set.go
+++ b/service/controller/cluster_resource_set.go
@@ -38,6 +38,7 @@ import (
 	"github.com/giantswarm/cluster-operator/service/controller/resource/kubeconfig"
 	"github.com/giantswarm/cluster-operator/service/controller/resource/releaseversions"
 	"github.com/giantswarm/cluster-operator/service/controller/resource/tenantclients"
+	"github.com/giantswarm/cluster-operator/service/controller/resource/updateg8scontrolplanes"
 	"github.com/giantswarm/cluster-operator/service/controller/resource/updateinfrarefs"
 	"github.com/giantswarm/cluster-operator/service/controller/resource/updatemachinedeployments"
 	"github.com/giantswarm/cluster-operator/service/controller/resource/workercount"
@@ -363,6 +364,19 @@ func newClusterResourceSet(config clusterResourceSetConfig) (*controller.Resourc
 		}
 	}
 
+	var updateG8sControlPlanesResource resource.Interface
+	{
+		c := updateg8scontrolplanes.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+		}
+
+		updateG8sControlPlanesResource, err = updateg8scontrolplanes.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var updateInfraRefsResource resource.Interface
 	{
 		c := updateinfrarefs.Config{
@@ -424,6 +438,7 @@ func newClusterResourceSet(config clusterResourceSetConfig) (*controller.Resourc
 		clusterConfigMapResource,
 		kubeConfigResource,
 		appResource,
+		updateG8sControlPlanesResource,
 		updateMachineDeploymentsResource,
 		updateInfraRefsResource,
 		keepForInfraRefsResource,

--- a/service/controller/resource/updateg8scontrolplanes/create.go
+++ b/service/controller/resource/updateg8scontrolplanes/create.go
@@ -1,0 +1,80 @@
+package updateg8scontrolplanes
+
+import (
+	"context"
+	"fmt"
+
+	infrastructurev1alpha2 "github.com/giantswarm/apiextensions/pkg/apis/infrastructure/v1alpha2"
+	"github.com/giantswarm/microerror"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/cluster-operator/pkg/label"
+	"github.com/giantswarm/cluster-operator/service/controller/key"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	cr, err := key.ToCluster(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	cpList := &infrastructurev1alpha2.G8sControlPlaneList{}
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finding G8sControlPlanes for tenant cluster")
+
+		err = r.k8sClient.CtrlClient().List(
+			ctx,
+			cpList,
+			client.InNamespace(cr.Namespace),
+			client.MatchingLabels{label.Cluster: key.ClusterID(&cr)},
+		)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d G8sControlPlanes for tenant cluster", len(cpList.Items)))
+	}
+
+	for _, cp := range cpList.Items {
+		var updated bool
+
+		// Syncing the cluster-operator version.
+		{
+			l := label.OperatorVersion
+			d, ok := cr.Labels[l]
+			c := cp.Labels[l]
+			if ok && d != "" && d != c {
+				cp.Labels[l] = d
+				updated = true
+
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("label value of %#q changed from %#q to %#q", l, c, d))
+			}
+		}
+
+		// Syncing the Giant Swarm Release version.
+		{
+			l := label.ReleaseVersion
+			d, ok := cr.Labels[l]
+			c := cp.Labels[l]
+			if ok && d != "" && d != c {
+				cp.Labels[l] = d
+				updated = true
+
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("label value of %#q changed from %#q to %#q", l, c, d))
+			}
+		}
+
+		if updated {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating G8sControlPlane %#q for tenant cluster %#q", cp.Namespace+"/"+cp.Name, key.ClusterID(&cr)))
+
+			err = r.k8sClient.CtrlClient().Update(ctx, &cp)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updated G8sControlPlane %#q for tenant cluster %#q", cp.Namespace+"/"+cp.Name, key.ClusterID(&cr)))
+		}
+	}
+
+	return nil
+}

--- a/service/controller/resource/updateg8scontrolplanes/delete.go
+++ b/service/controller/resource/updateg8scontrolplanes/delete.go
@@ -1,0 +1,9 @@
+package updateg8scontrolplanes
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/resource/updateg8scontrolplanes/error.go
+++ b/service/controller/resource/updateg8scontrolplanes/error.go
@@ -1,0 +1,14 @@
+package updateg8scontrolplanes
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/resource/updateg8scontrolplanes/resource.go
+++ b/service/controller/resource/updateg8scontrolplanes/resource.go
@@ -1,0 +1,49 @@
+package updateg8scontrolplanes
+
+import (
+	"github.com/giantswarm/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+const (
+	Name = "updateg8scontrolplanes"
+)
+
+type Config struct {
+	K8sClient k8sclient.Interface
+	Logger    micrologger.Logger
+}
+
+// Resource implements the operatorkit resource interface to propagate the
+// following version labels from Cluster CRs to G8sControlPlane CRs.
+//
+//     cluster-operator.giantswarm.io/version
+//     release.giantswarm.io/version
+//
+// This process ensures to distribute the right version labels among CAPI CRs
+// during Tenant Cluster upgrades.
+type Resource struct {
+	k8sClient k8sclient.Interface
+	logger    micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}


### PR DESCRIPTION
This is necessary to handle updates properly. When Cluster CRs get their version labels updated, the changes are propagated to G8sControlPlane CRs with this PR. 