### PR TITLE
Release 0.23.6

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,7 +1,7 @@
 package project
 
 var (
-	bundleVersion = "0.23.6-dev"
+	bundleVersion = "0.23.6"
 	description   = "The cluster-operator manages Kubernetes tenant cluster resources."
 	gitSHA        = "n/a"
 	name          = "cluster-operator"


### PR DESCRIPTION
Includes:
- Support xss, xs, and small cluster profile detection #963
- update of operatorkit dependency #964
- update of apiextensions dependency #967

This cluster-operator release is to be included in:
- AWS 9.0.1
- AWS 9.2.1
- KVM 11.2.1
- Azure 11.2.1
together with nginx IC App 1.6.3 https://github.com/giantswarm/nginx-ingress-controller-app/pull/39