### PR TITLE
Classify cluster based also on worker memory capacity

### DIFF
--- a/pkg/project/version_bundle_aws.go
+++ b/pkg/project/version_bundle_aws.go
@@ -8,10 +8,10 @@ var versionBundleAWS = versionbundle.Bundle{
 	Changelogs: []versionbundle.Changelog{
 		{
 			Component:   "cluster-operator",
-			Description: "TODO",
+			Description: "Classify cluster based also on worker memory capacity, which is currently limited to / known for kvm provider only.",
 			Kind:        versionbundle.KindChanged,
 			URLs: []string{
-				"",
+				"https://github.com/giantswarm/cluster-operator/pull/977",
 			},
 		},
 	},

--- a/pkg/project/version_bundle_azure.go
+++ b/pkg/project/version_bundle_azure.go
@@ -8,10 +8,10 @@ var versionBundleAzure = versionbundle.Bundle{
 	Changelogs: []versionbundle.Changelog{
 		{
 			Component:   "cluster-operator",
-			Description: "TODO",
+			Description: "Classify cluster based also on worker memory capacity, which is currently limited to / known for kvm provider only.",
 			Kind:        versionbundle.KindChanged,
 			URLs: []string{
-				"",
+				"https://github.com/giantswarm/cluster-operator/pull/977",
 			},
 		},
 	},

--- a/pkg/project/version_bundle_kvm.go
+++ b/pkg/project/version_bundle_kvm.go
@@ -8,10 +8,10 @@ var versionBundleKVM = versionbundle.Bundle{
 	Changelogs: []versionbundle.Changelog{
 		{
 			Component:   "cluster-operator",
-			Description: "TODO",
+			Description: "Classify cluster based also on worker memory capacity, which is currently limited to / known for kvm provider only.",
 			Kind:        versionbundle.KindChanged,
 			URLs: []string{
-				"",
+				"https://github.com/giantswarm/cluster-operator/pull/977",
 			},
 		},
 	},

--- a/service/controller/aws/resource_set.go
+++ b/service/controller/aws/resource_set.go
@@ -203,12 +203,13 @@ func newResourceSet(config resourceSetConfig) (*controller.ResourceSet, error) {
 	var clusterConfigMapResource resource.Interface
 	{
 		c := clusterconfigmap.Config{
-			GetClusterConfigFunc:     getClusterConfig,
-			GetClusterObjectMetaFunc: getClusterObjectMeta,
-			GetWorkerCountFunc:       getWorkerCount,
-			GetWorkerMaxCPUCoresFunc: getWorkerMaxCPUCores,
-			K8sClient:                config.K8sClient.K8sClient(),
-			Logger:                   config.Logger,
+			GetClusterConfigFunc:         getClusterConfig,
+			GetClusterObjectMetaFunc:     getClusterObjectMeta,
+			GetWorkerCountFunc:           getWorkerCount,
+			GetWorkerMaxCPUCoresFunc:     getWorkerMaxCPUCores,
+			GetWorkerMaxMemorySizeGBFunc: getWorkerMaxMemorySizeGB,
+			K8sClient:                    config.K8sClient.K8sClient(),
+			Logger:                       config.Logger,
 
 			CalicoAddress:      config.CalicoAddress,
 			CalicoPrefixLength: config.CalicoPrefixLength,
@@ -408,6 +409,10 @@ func getWorkerCount(obj interface{}) (int, error) {
 }
 
 func getWorkerMaxCPUCores(obj interface{}) (maxCPUCores int, known bool, err error) {
+	return 0, false, nil
+}
+
+func getWorkerMaxMemorySizeGB(obj interface{}) (maxMemorySizeGB float64, known bool, err error) {
 	return 0, false, nil
 }
 

--- a/service/controller/azure/resource_set.go
+++ b/service/controller/azure/resource_set.go
@@ -200,12 +200,13 @@ func newResourceSet(config resourceSetConfig) (*controller.ResourceSet, error) {
 	var clusterConfigMapResource resource.Interface
 	{
 		c := clusterconfigmap.Config{
-			GetClusterConfigFunc:     getClusterConfig,
-			GetClusterObjectMetaFunc: getClusterObjectMeta,
-			GetWorkerCountFunc:       getWorkerCount,
-			GetWorkerMaxCPUCoresFunc: getWorkerMaxCPUCores,
-			K8sClient:                config.K8sClient.K8sClient(),
-			Logger:                   config.Logger,
+			GetClusterConfigFunc:         getClusterConfig,
+			GetClusterObjectMetaFunc:     getClusterObjectMeta,
+			GetWorkerCountFunc:           getWorkerCount,
+			GetWorkerMaxCPUCoresFunc:     getWorkerMaxCPUCores,
+			GetWorkerMaxMemorySizeGBFunc: getWorkerMaxMemorySizeGB,
+			K8sClient:                    config.K8sClient.K8sClient(),
+			Logger:                       config.Logger,
 
 			CalicoAddress:      config.CalicoAddress,
 			CalicoPrefixLength: config.CalicoPrefixLength,
@@ -401,6 +402,10 @@ func getWorkerCount(obj interface{}) (int, error) {
 }
 
 func getWorkerMaxCPUCores(obj interface{}) (maxCPUCores int, known bool, err error) {
+	return 0, false, nil
+}
+
+func getWorkerMaxMemorySizeGB(obj interface{}) (maxMemorySizeGB float64, known bool, err error) {
 	return 0, false, nil
 }
 

--- a/service/controller/kvm/key/key.go
+++ b/service/controller/kvm/key/key.go
@@ -68,3 +68,19 @@ func WorkerMaxCPUCores(kvmClusterConfig v1alpha1.KVMClusterConfig) (maxCPUCores 
 
 	return maxCPUCores, true
 }
+
+func WorkerMaxMemorySizeGB(kvmClusterConfig v1alpha1.KVMClusterConfig) (maxMemorySizeGB float64, known bool) {
+	if WorkerCount(kvmClusterConfig) == 0 {
+		return 0, false
+	}
+
+	maxMemorySizeGB = 0
+	for _, w := range kvmClusterConfig.Spec.Guest.Workers {
+		workerMemorySizeGB := w.KVMClusterConfigSpecGuestNode.MemorySizeGB
+		if workerMemorySizeGB > maxMemorySizeGB {
+			maxMemorySizeGB = workerMemorySizeGB
+		}
+	}
+
+	return maxMemorySizeGB, true
+}

--- a/service/controller/kvm/resource_set.go
+++ b/service/controller/kvm/resource_set.go
@@ -199,12 +199,13 @@ func newResourceSet(config resourceSetConfig) (*controller.ResourceSet, error) {
 	var clusterConfigMapResource resource.Interface
 	{
 		c := clusterconfigmap.Config{
-			GetClusterConfigFunc:     getClusterConfig,
-			GetClusterObjectMetaFunc: getClusterObjectMeta,
-			GetWorkerCountFunc:       getWorkerCount,
-			GetWorkerMaxCPUCoresFunc: getWorkerMaxCPUCores,
-			K8sClient:                config.K8sClient.K8sClient(),
-			Logger:                   config.Logger,
+			GetClusterConfigFunc:         getClusterConfig,
+			GetClusterObjectMetaFunc:     getClusterObjectMeta,
+			GetWorkerCountFunc:           getWorkerCount,
+			GetWorkerMaxCPUCoresFunc:     getWorkerMaxCPUCores,
+			GetWorkerMaxMemorySizeGBFunc: getWorkerMaxMemorySizeGB,
+			K8sClient:                    config.K8sClient.K8sClient(),
+			Logger:                       config.Logger,
 
 			CalicoAddress:      config.CalicoAddress,
 			CalicoPrefixLength: config.CalicoPrefixLength,
@@ -408,6 +409,17 @@ func getWorkerMaxCPUCores(obj interface{}) (maxCPUCores int, known bool, err err
 	workerMaxCPUCores, known := key.WorkerMaxCPUCores(cr)
 
 	return workerMaxCPUCores, known, nil
+}
+
+func getWorkerMaxMemorySizeGB(obj interface{}) (maxMemorySizeGB float64, known bool, err error) {
+	cr, err := key.ToCustomObject(obj)
+	if err != nil {
+		return 0, false, microerror.Mask(err)
+	}
+
+	workerMaxMemorySizeGB, known := key.WorkerMaxMemorySizeGB(cr)
+
+	return workerMaxMemorySizeGB, known, nil
 }
 
 func toClusterGuestConfig(obj interface{}) (v1alpha1.ClusterGuestConfig, error) {

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -22,8 +22,8 @@ const (
 	// They are encoded as ordered incrementing numbers so they can be compared
 	// with relational operators for equality and ineqality.
 	xxs clusterProfile = iota + 1 // worker count == 1
-	xs                            // worker count [2-3], max CPU cores < 4 or max memory < 6 GB
-	s                             // worker count > 3, max CPU cores < 4 or max memory < 6 GB
+	xs                            // worker count [2-3], max worker CPU cores < 4 or max worker memory < 6 GB
+	s                             // worker count > 3, max worker CPU cores < 4 or max worker memory < 6 GB; worker count [2-3], unknown CPU & memory
 )
 
 func (r *StateGetter) GetDesiredState(ctx context.Context, obj interface{}) ([]*corev1.ConfigMap, error) {
@@ -83,6 +83,8 @@ func (r *StateGetter) GetDesiredState(ctx context.Context, obj interface{}) ([]*
 
 		if workerCount == 1 {
 			determinedTCProfile = xxs
+		} else if workerCount < 4 && !workerMaxCPUCoresKnown && !workerMaxMemorySizeGBKnown {
+			determinedTCProfile = s
 		} else if (workerMaxCPUCoresKnown && workerMaxCPUCores < 4) || (workerMaxMemorySizeGBKnown && workerMaxMemorySizeGB < 6) {
 			if workerCount < 4 {
 				determinedTCProfile = xs

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -83,14 +83,14 @@ func (r *StateGetter) GetDesiredState(ctx context.Context, obj interface{}) ([]*
 
 		if workerCount == 1 {
 			determinedTCProfile = xxs
-		} else if workerCount < 4 && !workerMaxCPUCoresKnown && !workerMaxMemorySizeGBKnown {
-			determinedTCProfile = s
-		} else if (workerMaxCPUCoresKnown && workerMaxCPUCores < 4) || (workerMaxMemorySizeGBKnown && workerMaxMemorySizeGB < 6) {
-			if workerCount < 4 {
+		} else if workerCount < 4 {
+			if (workerMaxCPUCoresKnown && workerMaxCPUCores < 4) || (workerMaxMemorySizeGBKnown && workerMaxMemorySizeGB < 6) {
 				determinedTCProfile = xs
 			} else {
 				determinedTCProfile = s
 			}
+		} else if (workerMaxCPUCoresKnown && workerMaxCPUCores < 4) || (workerMaxMemorySizeGBKnown && workerMaxMemorySizeGB < 6) {
+			determinedTCProfile = s
 		}
 	}
 

--- a/service/controller/resource/clusterconfigmap/resource.go
+++ b/service/controller/resource/clusterconfigmap/resource.go
@@ -19,12 +19,13 @@ const (
 // Config represents the configuration used to create a new clusterConfigMap resource.
 type Config struct {
 	// Dependencies.
-	GetClusterConfigFunc     func(obj interface{}) (v1alpha1.ClusterGuestConfig, error)
-	GetClusterObjectMetaFunc func(obj interface{}) (metav1.ObjectMeta, error)
-	GetWorkerCountFunc       func(obj interface{}) (int, error)
-	GetWorkerMaxCPUCoresFunc func(obj interface{}) (maxCPUCores int, known bool, err error)
-	K8sClient                kubernetes.Interface
-	Logger                   micrologger.Logger
+	GetClusterConfigFunc         func(obj interface{}) (v1alpha1.ClusterGuestConfig, error)
+	GetClusterObjectMetaFunc     func(obj interface{}) (metav1.ObjectMeta, error)
+	GetWorkerCountFunc           func(obj interface{}) (int, error)
+	GetWorkerMaxCPUCoresFunc     func(obj interface{}) (maxCPUCores int, known bool, err error)
+	GetWorkerMaxMemorySizeGBFunc func(obj interface{}) (maxMemorySizeGB float64, known bool, err error)
+	K8sClient                    kubernetes.Interface
+	Logger                       micrologger.Logger
 
 	// Settings.
 	CalicoAddress      string
@@ -36,12 +37,13 @@ type Config struct {
 // Resource implements the clusterConfigMap resource.
 type StateGetter struct {
 	// Dependencies.
-	getClusterConfigFunc     func(obj interface{}) (v1alpha1.ClusterGuestConfig, error)
-	getClusterObjectMetaFunc func(obj interface{}) (metav1.ObjectMeta, error)
-	getWorkerCountFunc       func(obj interface{}) (int, error)
-	getWorkerMaxCPUCoresFunc func(obj interface{}) (naxCPUCores int, known bool, err error)
-	k8sClient                kubernetes.Interface
-	logger                   micrologger.Logger
+	getClusterConfigFunc         func(obj interface{}) (v1alpha1.ClusterGuestConfig, error)
+	getClusterObjectMetaFunc     func(obj interface{}) (metav1.ObjectMeta, error)
+	getWorkerCountFunc           func(obj interface{}) (int, error)
+	getWorkerMaxCPUCoresFunc     func(obj interface{}) (maxCPUCores int, known bool, err error)
+	getWorkerMaxMemorySizeGBFunc func(obj interface{}) (maxMemorySizeGB float64, known bool, err error)
+	k8sClient                    kubernetes.Interface
+	logger                       micrologger.Logger
 
 	// Settings.
 	calicoAddress      string
@@ -65,6 +67,9 @@ func New(config Config) (*StateGetter, error) {
 	if config.GetWorkerMaxCPUCoresFunc == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.GetWorkerMaxCPUCoresFunc must not be empty", config)
 	}
+	if config.GetWorkerMaxMemorySizeGBFunc == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.GetWorkerMaxMemorySizeGBFunc must not be empty", config)
+	}
 	if config.K8sClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
 	}
@@ -82,12 +87,13 @@ func New(config Config) (*StateGetter, error) {
 
 	r := &StateGetter{
 		// Dependencies.
-		getClusterConfigFunc:     config.GetClusterConfigFunc,
-		getClusterObjectMetaFunc: config.GetClusterObjectMetaFunc,
-		getWorkerCountFunc:       config.GetWorkerCountFunc,
-		getWorkerMaxCPUCoresFunc: config.GetWorkerMaxCPUCoresFunc,
-		k8sClient:                config.K8sClient,
-		logger:                   config.Logger,
+		getClusterConfigFunc:         config.GetClusterConfigFunc,
+		getClusterObjectMetaFunc:     config.GetClusterObjectMetaFunc,
+		getWorkerCountFunc:           config.GetWorkerCountFunc,
+		getWorkerMaxCPUCoresFunc:     config.GetWorkerMaxCPUCoresFunc,
+		getWorkerMaxMemorySizeGBFunc: config.GetWorkerMaxMemorySizeGBFunc,
+		k8sClient:                    config.K8sClient,
+		logger:                       config.Logger,
 
 		// Settings
 		calicoAddress:      config.CalicoAddress,


### PR DESCRIPTION
Testing [kvm 11.2.1 WIP release](https://github.com/giantswarm/releases/pull/139) showed that it would be useful to classify cluster also based on worker memory capacity. This PR also adjusts cluster classification logic to have clusters with less than 4 nodes but with high enough resources assigned classified as small and not as extra small.