### PR TITLE
Release 0.23.7

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,7 +1,7 @@
 package project
 
 var (
-	bundleVersion = "0.23.7-dev"
+	bundleVersion = "0.23.7"
 	description   = "The cluster-operator manages Kubernetes tenant cluster resources."
 	gitSHA        = "n/a"
 	name          = "cluster-operator"


### PR DESCRIPTION
Includes:
- Classify cluster based also on worker memory capacity (https://github.com/giantswarm/cluster-operator/pull/977)

This cluster-operator release is to be included in:
- AWS 9.0.1
- AWS 9.2.2
- KVM 11.2.1
- Azure 11.2.1

together with NGINX IC App 1.6.5 giantswarm/nginx-ingress-controller-app#42