### PR TITLE
Release 0.23.8

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,7 +1,7 @@
 package project
 
 var (
-	bundleVersion = "0.23.8-dev"
+	bundleVersion = "0.23.8"
 	description   = "The cluster-operator manages Kubernetes tenant cluster resources."
 	gitSHA        = "n/a"
 	name          = "cluster-operator"

--- a/pkg/project/version_bundle_aws.go
+++ b/pkg/project/version_bundle_aws.go
@@ -8,10 +8,10 @@ var versionBundleAWS = versionbundle.Bundle{
 	Changelogs: []versionbundle.Changelog{
 		{
 			Component:   "cluster-operator",
-			Description: "TODO",
+			Description: "Classify cluster based also on worker memory capacity, which is currently limited to / known for kvm provider only.",
 			Kind:        versionbundle.KindChanged,
 			URLs: []string{
-				"",
+				"https://github.com/giantswarm/cluster-operator/pull/977",
 			},
 		},
 	},

--- a/pkg/project/version_bundle_azure.go
+++ b/pkg/project/version_bundle_azure.go
@@ -8,10 +8,10 @@ var versionBundleAzure = versionbundle.Bundle{
 	Changelogs: []versionbundle.Changelog{
 		{
 			Component:   "cluster-operator",
-			Description: "TODO",
+			Description: "Classify cluster based also on worker memory capacity, which is currently limited to / known for kvm provider only.",
 			Kind:        versionbundle.KindChanged,
 			URLs: []string{
-				"",
+				"https://github.com/giantswarm/cluster-operator/pull/977",
 			},
 		},
 	},

--- a/pkg/project/version_bundle_kvm.go
+++ b/pkg/project/version_bundle_kvm.go
@@ -8,10 +8,10 @@ var versionBundleKVM = versionbundle.Bundle{
 	Changelogs: []versionbundle.Changelog{
 		{
 			Component:   "cluster-operator",
-			Description: "TODO",
+			Description: "Classify cluster based also on worker memory capacity, which is currently limited to / known for kvm provider only.",
 			Kind:        versionbundle.KindChanged,
 			URLs: []string{
-				"",
+				"https://github.com/giantswarm/cluster-operator/pull/977",
 			},
 		},
 	},


### PR DESCRIPTION
I made a mistake, when tagging 0.23.7 release chose wrong branch - master instead of legacy. Will remove 0.23.7 from all app collections upon releasing 0.23.8 and switching only release, kvm 11.2.1 WIP which is using 0.23.7