### PR TITLE
change resource order for more efficient reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change resource order for more efficient reconciliation.
+
 
 
 ## [2.1.7] 2020-04-06

--- a/service/controller/cluster_resource_set.go
+++ b/service/controller/cluster_resource_set.go
@@ -437,7 +437,6 @@ func newClusterResourceSet(config clusterResourceSetConfig) (*controller.Resourc
 		updateG8sControlPlanesResource,
 		updateMachineDeploymentsResource,
 		updateInfraRefsResource,
-		keepForInfraRefsResource,
 
 		// Following resources manage CR status information.
 		clusterIDResource,
@@ -445,6 +444,7 @@ func newClusterResourceSet(config clusterResourceSetConfig) (*controller.Resourc
 
 		// Following resources manage tenant cluster deletion events.
 		cleanupMachineDeployments,
+		keepForInfraRefsResource,
 	}
 
 	// Wrap resources with retry and metrics.

--- a/service/controller/cluster_resource_set.go
+++ b/service/controller/cluster_resource_set.go
@@ -427,10 +427,6 @@ func newClusterResourceSet(config clusterResourceSetConfig) (*controller.Resourc
 		tenantClientsResource,
 		workerCountResource,
 
-		// Following resources manage CR status information.
-		clusterIDResource,
-		clusterStatusResource,
-
 		// Following resources manage resources in the control plane.
 		cpNamespaceResource,
 		encryptionKeyResource,
@@ -442,6 +438,10 @@ func newClusterResourceSet(config clusterResourceSetConfig) (*controller.Resourc
 		updateMachineDeploymentsResource,
 		updateInfraRefsResource,
 		keepForInfraRefsResource,
+
+		// Following resources manage CR status information.
+		clusterIDResource,
+		clusterStatusResource,
 
 		// Following resources manage tenant cluster deletion events.
 		cleanupMachineDeployments,


### PR DESCRIPTION
The problem we see right now is that when creating Tenant Clusters things like key-pair or encryption key creation take a lot time and cause reconciliation overhead across multiple dependent loops. This is due to the CR status managing resources which cancel the reconciliation before any business logic is being executed. This leads to a lot of wait time. I checked the resources and thought it should be easy and good to simply change the order to improve the situation. 

## Checklist

- [x] Update changelog in CHANGELOG.md.
