### PR TITLE
drop CRD management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change resource order for more efficient reconciliation.
 - Emit metrics for reconciled runtime objects only.
+- Drop CRD management to not ensure CRDs in operators anymore.
 
 
 

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -60,7 +60,6 @@ func NewCluster(config ClusterConfig) (*Cluster, error) {
 	var clusterController *controller.Controller
 	{
 		c := controller.Config{
-			CRD:       infrastructurev1alpha2.NewClusterCRD(),
 			K8sClient: config.K8sClient,
 			Logger:    config.Logger,
 			ResourceSets: []*controller.ResourceSet{

--- a/service/controller/control_plane.go
+++ b/service/controller/control_plane.go
@@ -40,7 +40,6 @@ func NewControlPlane(config ControlPlaneConfig) (*ControlPlane, error) {
 	var controlPlaneController *controller.Controller
 	{
 		c := controller.Config{
-			CRD:       infrastructurev1alpha2.NewG8sControlPlaneCRD(),
 			K8sClient: config.K8sClient,
 			Logger:    config.Logger,
 			ResourceSets: []*controller.ResourceSet{

--- a/service/controller/machine_deployment.go
+++ b/service/controller/machine_deployment.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	infrastructurev1alpha2 "github.com/giantswarm/apiextensions/pkg/apis/infrastructure/v1alpha2"
 	"github.com/giantswarm/clusterclient"
 	"github.com/giantswarm/k8sclient"
 	"github.com/giantswarm/microerror"
@@ -43,7 +42,6 @@ func NewMachineDeployment(config MachineDeploymentConfig) (*MachineDeployment, e
 	var clusterController *controller.Controller
 	{
 		c := controller.Config{
-			CRD:       infrastructurev1alpha2.NewMachineDeploymentCRD(),
 			K8sClient: config.K8sClient,
 			Logger:    config.Logger,
 			ResourceSets: []*controller.ResourceSet{


### PR DESCRIPTION
With https://github.com/giantswarm/opsctl/pull/596 we do not want to ensure CRDs in the operators. This is because of complications with the CRD update mechanism, which we work around by having a single authority managing CRDs. 

## Checklist

- [x] Update changelog in CHANGELOG.md.
