### PR TITLE
helm: move resource name to helm helpers

### DIFF
--- a/helm/cluster-operator/templates/_helpers.tpl
+++ b/helm/cluster-operator/templates/_helpers.tpl
@@ -2,34 +2,34 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "cluster-operator.name" -}}
+{{- define "name" -}}
 {{- .Chart.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "cluster-operator.chart" -}}
+{{- define "chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Common labels
 */}}
-{{- define "cluster-operator.labels" -}}
-app: {{ include "cluster-operator.name" . | quote }}
+{{- define "labels.common" -}}
+app: {{ include "name" . | quote }}
+{{ include "labels.selector" . }}
 app.giantswarm.io/branch: {{ .Values.project.branch | quote }}
 app.giantswarm.io/commit: {{ .Values.project.commit | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-helm.sh/chart: {{ include "cluster-operator.chart" . | quote }}
-{{ include "cluster-operator.selectorLabels" . }}
+helm.sh/chart: {{ include "chart" . | quote }}
 {{- end -}}
 
 {{/*
 Selector labels
 */}}
-{{- define "cluster-operator.selectorLabels" -}}
+{{- define "labels.selector" -}}
+app.kubernetes.io/name: {{ include "name" . | quote }}
 app.kubernetes.io/instance: {{ .Release.Name | quote }}
-app.kubernetes.io/name: {{ include "cluster-operator.name" . | quote }}
 {{- end -}}

--- a/helm/cluster-operator/templates/_resource.tpl
+++ b/helm/cluster-operator/templates/_resource.tpl
@@ -1,0 +1,24 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Create a name stem for resource names
+
+When pods for deployments are created they have an additional 16 character
+suffix appended, e.g. "-957c9d6ff-pkzgw". Given that Kubernetes allows 63
+characters for resource names, the stem is truncated to 47 characters to leave
+room for such suffix.
+*/}}
+{{- define "resource.default.name" -}}
+{{- .Release.Name | replace "." "-" | trunc 47 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "resource.psp.name" -}}
+{{- include "resource.default.name" . -}}-psp
+{{- end -}}
+
+{{- define "resource.pullSecret.name" -}}
+{{- include "resource.default.name" . -}}-pull-secret
+{{- end -}}
+
+{{- define "resource.default.namespace" -}}
+giantswarm
+{{- end -}}

--- a/helm/cluster-operator/templates/configmap.yaml
+++ b/helm/cluster-operator/templates/configmap.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ tpl .Values.resource.default.name  . }}
-  namespace: {{ tpl .Values.resource.default.namespace  . }}
+  name: {{ include "resource.default.name"  . }}
+  namespace: {{ include "resource.default.namespace"  . }}
   labels:
-    {{- include "cluster-operator.labels" . | nindent 4 }}
+    {{- include "labels.common" . | nindent 4 }}
 data:
   config.yml: |
     server:

--- a/helm/cluster-operator/templates/deployment.yaml
+++ b/helm/cluster-operator/templates/deployment.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ tpl .Values.resource.default.name  . }}
-  namespace: {{ tpl .Values.resource.default.namespace  . }}
+  name: {{ include "resource.default.name"  . }}
+  namespace: {{ include "resource.default.namespace"  . }}
   labels:
-    {{- include "cluster-operator.labels" . | nindent 4 }}
+    {{- include "labels.common" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "cluster-operator.selectorLabels" . | nindent 6 }}
+      {{- include "labels.selector" . | nindent 6 }}
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        {{- include "cluster-operator.selectorLabels" . | nindent 8 }}
+        {{- include "labels.selector" . | nindent 8 }}
       annotations:
         releasetime: {{ $.Release.Time }}
     spec:
@@ -25,17 +25,17 @@ spec:
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
-                  {{- include "cluster-operator.selectorLabels" . | nindent 18 }}
+                  {{- include "labels.selector" . | nindent 18 }}
               topologyKey: kubernetes.io/hostname
             weight: 100
       volumes:
       - name: {{ .Chart.Name }}-configmap
         configMap:
-          name: {{ tpl .Values.resource.default.name  . }}
+          name: {{ include "resource.default.name"  . }}
           items:
           - key: config.yml
             path: config.yml
-      serviceAccountName: {{ tpl .Values.resource.default.name  . }}
+      serviceAccountName: {{ include "resource.default.name"  . }}
       securityContext:
         runAsUser: {{ .Values.pod.user.id }}
         runAsGroup: {{ .Values.pod.group.id }}
@@ -63,4 +63,4 @@ spec:
             cpu: 100m
             memory: 220Mi
       imagePullSecrets:
-      - name: {{ tpl .Values.resource.pullSecret.name . }}
+      - name: {{ include "resource.pullSecret.name" . }}

--- a/helm/cluster-operator/templates/psp.yaml
+++ b/helm/cluster-operator/templates/psp.yaml
@@ -1,9 +1,9 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ tpl .Values.resource.psp.name . }}
+  name: {{ include "resource.psp.name" . }}
   labels:
-    {{- include "cluster-operator.labels" . | nindent 4 }}
+    {{- include "labels.common" . | nindent 4 }}
 spec:
   privileged: false
   fsGroup:

--- a/helm/cluster-operator/templates/pull-secret.yaml
+++ b/helm/cluster-operator/templates/pull-secret.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 kind: Secret
 type: kubernetes.io/dockerconfigjson
 metadata:
-  name: {{ tpl .Values.resource.pullSecret.name . }}
-  namespace: {{ tpl .Values.resource.pullSecret.namespace . }}
+  name: {{ include "resource.pullSecret.name" . }}
+  namespace: {{ include "resource.default.namespace" . }}
   labels:
-    {{- include "cluster-operator.labels" . | nindent 4 }}
+    {{- include "labels.common" . | nindent 4 }}
 data:
   .dockerconfigjson: {{ .Values.Installation.V1.Secret.Registry.PullSecret.DockerConfigJSON | b64enc | quote }}

--- a/helm/cluster-operator/templates/rbac.yaml
+++ b/helm/cluster-operator/templates/rbac.yaml
@@ -1,9 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ tpl .Values.resource.default.name  . }}
+  name: {{ include "resource.default.name"  . }}
   labels:
-    {{- include "cluster-operator.labels" . | nindent 4 }}
+    {{- include "labels.common" . | nindent 4 }}
 rules:
   - apiGroups:
       - ""
@@ -90,24 +90,24 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ tpl .Values.resource.default.name  . }}
+  name: {{ include "resource.default.name"  . }}
   labels:
-    {{- include "cluster-operator.labels" . | nindent 4 }}
+    {{- include "labels.common" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: {{ tpl .Values.resource.default.name  . }}
-    namespace: {{ tpl .Values.resource.default.namespace  . }}
+    name: {{ include "resource.default.name"  . }}
+    namespace: {{ include "resource.default.namespace"  . }}
 roleRef:
   kind: ClusterRole
-  name: {{ tpl .Values.resource.default.name  . }}
+  name: {{ include "resource.default.name"  . }}
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ tpl .Values.resource.psp.name . }}
+  name: {{ include "resource.psp.name" . }}
   labels:
-    {{- include "cluster-operator.labels" . | nindent 4 }}
+    {{- include "labels.common" . | nindent 4 }}
 rules:
   - apiGroups:
       - extensions
@@ -116,19 +116,19 @@ rules:
     verbs:
       - use
     resourceNames:
-      - {{ tpl .Values.resource.psp.name . }}
+      - {{ include "resource.psp.name" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ tpl .Values.resource.psp.name . }}
+  name: {{ include "resource.psp.name" . }}
   labels:
-    {{- include "cluster-operator.labels" . | nindent 4 }}
+    {{- include "labels.common" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: {{ tpl .Values.resource.default.name  . }}
-    namespace: {{ tpl .Values.resource.default.namespace  . }}
+    name: {{ include "resource.default.name"  . }}
+    namespace: {{ include "resource.default.namespace"  . }}
 roleRef:
   kind: ClusterRole
-  name: {{ tpl .Values.resource.psp.name . }}
+  name: {{ include "resource.psp.name" . }}
   apiGroup: rbac.authorization.k8s.io

--- a/helm/cluster-operator/templates/service-account.yaml
+++ b/helm/cluster-operator/templates/service-account.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ tpl .Values.resource.default.name  . }}
-  namespace: {{ tpl .Values.resource.default.namespace  . }}
+  name: {{ include "resource.default.name"  . }}
+  namespace: {{ include "resource.default.namespace"  . }}
   labels:
-    {{- include "cluster-operator.labels" . | nindent 4 }}
+    {{- include "labels.common" . | nindent 4 }}

--- a/helm/cluster-operator/templates/service.yaml
+++ b/helm/cluster-operator/templates/service.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ tpl .Values.resource.default.name  . }}
-  namespace: {{ tpl .Values.resource.default.namespace  . }}
+  name: {{ include "resource.default.name"  . }}
+  namespace: {{ include "resource.default.namespace"  . }}
   labels:
-    {{- include "cluster-operator.labels" . | nindent 4 }}
+    {{- include "labels.common" . | nindent 4 }}
   annotations:
     prometheus.io/scrape: "true"
 spec:
   ports:
   - port: 8000
   selector:
-    {{- include "cluster-operator.selectorLabels" . | nindent 4 }}
+    {{- include "labels.selector" . | nindent 4 }}

--- a/helm/cluster-operator/values.yaml
+++ b/helm/cluster-operator/values.yaml
@@ -13,24 +13,3 @@ pod:
 project:
   branch: "[[ .Branch ]]"
   commit: "[[ .SHA ]]"
-# Resource names are truncated to 47 characters.
-#
-# Kubernetes allows 63 characters limit for resource names. When pods for
-# deployments are created they have additional 16 characters suffix, e.g.
-# "-957c9d6ff-pkzgw" and we want to have room for those suffixes.
-#
-# NOTE: All values under resource key need to be used with `tpl` to render them
-# correctly in the templates. This is because helm doesn't template values.yaml
-# file and it has to be a valid json. Example usage:
-#
-#     {{ tpl .Values.resource.default.name . }}.
-#
-resource:
-  default:
-    name: '{{ .Release.Name | replace "." "-" | trunc 47 }}'
-    namespace: "giantswarm"
-  psp:
-    name: '{{ .Release.Name | replace "." "-" | trunc 47 }}-psp'
-  pullSecret:
-    name: '{{ .Release.Name | replace "." "-" | trunc 47 }}-pull-secret'
-    namespace: "giantswarm"


### PR DESCRIPTION
Towards: giantswarm/giantswarm#9878

Move helm chart variables to helm helpers to reduce repetition in charts' values.yaml file.


## Checklist

- [ ] Update changelog in CHANGELOG.md.