### PR TITLE
fix setting release versions in control plane controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix cluster upgrade by fetching release versions in Control Plane controller.
+
 
 
 ## [2.1.9] 2020-04-23

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA      = "n/a"
 	name        = "cluster-operator"
 	source      = "https://github.com/giantswarm/cluster-operator"
-	version     = "2.1.10-xh3b4sd"
+	version     = "2.1.10-dev"
 )
 
 func Description() string {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA      = "n/a"
 	name        = "cluster-operator"
 	source      = "https://github.com/giantswarm/cluster-operator"
-	version     = "2.1.10-dev"
+	version     = "2.1.10-xh3b4sd"
 )
 
 func Description() string {

--- a/service/controller/control_plane.go
+++ b/service/controller/control_plane.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	infrastructurev1alpha2 "github.com/giantswarm/apiextensions/pkg/apis/infrastructure/v1alpha2"
+	"github.com/giantswarm/clusterclient"
 	"github.com/giantswarm/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -14,8 +15,9 @@ import (
 // ControlPlaneConfig contains necessary dependencies and settings for the
 // ControlPlane controller implementation.
 type ControlPlaneConfig struct {
-	K8sClient k8sclient.Interface
-	Logger    micrologger.Logger
+	ClusterClient *clusterclient.Client
+	K8sClient     k8sclient.Interface
+	Logger        micrologger.Logger
 
 	Provider string
 }

--- a/service/controller/resource/updateinfrarefs/create.go
+++ b/service/controller/resource/updateinfrarefs/create.go
@@ -27,6 +27,12 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	if len(cc.Status.Versions) == 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "no release versions in controller context yet")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		return nil
+	}
+
 	// Here we fetch the provider specific CR defined as infrastructure reference
 	// in the CAPI type. We use an unstructured object and therefore need to set
 	// the api version and kind accordingly. If we would not do that the

--- a/service/service.go
+++ b/service/service.go
@@ -210,8 +210,9 @@ func New(config Config) (*Service, error) {
 	var controlPlaneController *controller.ControlPlane
 	{
 		c := controller.ControlPlaneConfig{
-			K8sClient: k8sClient,
-			Logger:    config.Logger,
+			ClusterClient: clusterClient,
+			K8sClient:     k8sClient,
+			Logger:        config.Logger,
 
 			Provider: provider,
 		}


### PR DESCRIPTION
## Checklist

- [x] Update changelog in CHANGELOG.md.

## Context

```
$ kubectl -n giantswarm logs --tail 1000 -f cluster-operator-fix-release-versions-6cc87f7c6-6jjjk | gg -s obj:0255b -s res:updateinfrarefs -g loo
{
    "caller": "github.com/giantswarm/cluster-operator/service/controller/resource/updateinfrarefs/create.go:42",
    "controller": "cluster-operator-control-plane-controller",
    "event": "update",
    "level": "debug",
    "loop": "219",
    "message": "finding infrastructure reference",
    "object": "/apis/infrastructure.giantswarm.io/v1alpha2/namespaces/default/g8scontrolplanes/0255b",
    "resource": "updateinfrarefs",
    "time": "13:11:31",
    "version": "65825695"
}
{
    "caller": "github.com/giantswarm/cluster-operator/service/controller/resource/updateinfrarefs/create.go:52",
    "controller": "cluster-operator-control-plane-controller",
    "event": "update",
    "level": "debug",
    "loop": "219",
    "message": "found infrastructure reference",
    "object": "/apis/infrastructure.giantswarm.io/v1alpha2/namespaces/default/g8scontrolplanes/0255b",
    "resource": "updateinfrarefs",
    "time": "13:11:31",
    "version": "65825695"
}
{
    "caller": "github.com/giantswarm/cluster-operator/service/controller/resource/updateinfrarefs/create.go:69",
    "controller": "cluster-operator-control-plane-controller",
    "event": "update",
    "level": "debug",
    "loop": "219",
    "message": "label value of `aws-operator.giantswarm.io/version` changed from `8.3.0` to `8.4.0`",
    "object": "/apis/infrastructure.giantswarm.io/v1alpha2/namespaces/default/g8scontrolplanes/0255b",
    "resource": "updateinfrarefs",
    "time": "13:11:31",
    "version": "65825695"
}
{
    "caller": "github.com/giantswarm/cluster-operator/service/controller/resource/updateinfrarefs/create.go:84",
    "controller": "cluster-operator-control-plane-controller",
    "event": "update",
    "level": "debug",
    "loop": "219",
    "message": "label value of `release.giantswarm.io/version` changed from `11.1.4` to `100.0.0`",
    "object": "/apis/infrastructure.giantswarm.io/v1alpha2/namespaces/default/g8scontrolplanes/0255b",
    "resource": "updateinfrarefs",
    "time": "13:11:31",
    "version": "65825695"
}
{
    "caller": "github.com/giantswarm/cluster-operator/service/controller/resource/updateinfrarefs/create.go:89",
    "controller": "cluster-operator-control-plane-controller",
    "event": "update",
    "level": "debug",
    "loop": "219",
    "message": "updating infrastructure reference `default/0255b`",
    "object": "/apis/infrastructure.giantswarm.io/v1alpha2/namespaces/default/g8scontrolplanes/0255b",
    "resource": "updateinfrarefs",
    "time": "13:11:31",
    "version": "65825695"
}
{
    "caller": "github.com/giantswarm/cluster-operator/service/controller/resource/updateinfrarefs/create.go:96",
    "controller": "cluster-operator-control-plane-controller",
    "event": "update",
    "level": "debug",
    "loop": "219",
    "message": "updated infrastructure reference `default/0255b`",
    "object": "/apis/infrastructure.giantswarm.io/v1alpha2/namespaces/default/g8scontrolplanes/0255b",
    "resource": "updateinfrarefs",
    "time": "13:11:31",
    "version": "65825695"
}
```