### PR TITLE
Azure nic

### DIFF
--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -61,6 +61,13 @@ func (r *StateGetter) GetDesiredState(ctx context.Context, obj interface{}) ([]*
 		}
 	}
 
+	var ingressControllerLegacy bool
+	{
+		if r.provider == "kvm" {
+			ingressControllerLegacy = true
+		}
+	}
+
 	var determinedTCProfile clusterProfile
 	{
 		// this is desired, not the current number of tenant cluster worker nodes
@@ -132,7 +139,7 @@ func (r *StateGetter) GetDesiredState(ctx context.Context, obj interface{}) ([]*
 				"ingressController": map[string]interface{}{
 					// Legacy flag is set to true so resources created by
 					// legacy provider operators are not created.
-					"legacy": true,
+					"legacy": ingressControllerLegacy,
 				},
 				"provider": r.provider,
 			},

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -111,7 +111,6 @@ func (r *StateGetter) GetDesiredState(ctx context.Context, obj interface{}) ([]*
 				"clusterID":  key.ClusterID(clusterConfig),
 				"controller": map[string]interface{}{
 					"service": map[string]interface{}{
-						"enabled":               false,
 						"externalTrafficPolicy": "Local",
 						"type":                  "internal",
 					},

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -63,8 +63,9 @@ func (r *StateGetter) GetDesiredState(ctx context.Context, obj interface{}) ([]*
 
 	var ingressControllerLegacy bool
 	{
-		if r.provider == "kvm" {
-			ingressControllerLegacy = true
+		ingressControllerLegacy = true
+		if r.provider == "azure" {
+			ingressControllerLegacy = false
 		}
 	}
 

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -61,6 +61,10 @@ func (r *StateGetter) GetDesiredState(ctx context.Context, obj interface{}) ([]*
 		}
 	}
 
+	// The legacy flag is used by the Nginx Ingress Controller app to avoid creating a LoadBalancer service.
+	// This was needed on Azure clusters because the azure operator used to manage the load balancer.
+	// Since NGINX Ingress Controller 1.6.10, the LB is created by the managed app, hence the need of setting
+	// the legacy flag to false for Azure clusters.
 	var ingressControllerLegacy bool
 	{
 		ingressControllerLegacy = true

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -41,20 +41,6 @@ func (r *StateGetter) GetDesiredState(ctx context.Context, obj interface{}) ([]*
 		return nil, microerror.Mask(err)
 	}
 
-	// controllerServiceEnabled is true for Azure legacy clusters. For AWS and
-	// KVM legacy clusters this service is disabled and it is created via
-	// ignition.
-	var controllerServiceEnabled bool
-	{
-		if r.provider == "azure" {
-			controllerServiceEnabled = true
-		} else if r.provider == "aws" || r.provider == "kvm" {
-			controllerServiceEnabled = false
-		} else {
-			return nil, microerror.Maskf(executionFailedError, "invalid provider %#q", r.provider)
-		}
-	}
-
 	// useProxyProtocol is only enabled by default for AWS clusters.
 	var useProxyProtocol bool
 	{
@@ -125,7 +111,9 @@ func (r *StateGetter) GetDesiredState(ctx context.Context, obj interface{}) ([]*
 				"clusterID":  key.ClusterID(clusterConfig),
 				"controller": map[string]interface{}{
 					"service": map[string]interface{}{
-						"enabled": controllerServiceEnabled,
+						"enabled":               false,
+						"externalTrafficPolicy": "Local",
+						"type":                  "internal",
 					},
 				},
 				"configmap": map[string]string{

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -134,6 +134,7 @@ func (r *StateGetter) GetDesiredState(ctx context.Context, obj interface{}) ([]*
 					// legacy provider operators are not created.
 					"legacy": true,
 				},
+				"provider": r.provider,
 			},
 		},
 	}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/9962

This PR changes the default configuration for the nginx ingress controller app on `Azure clusters`.

The changes in the configuration are:

- disable the nodePort service
- set the `legacy` flag to false
- add the `provider` field

These changes are needed to upgrade the nginx ingress controller app to version 1.6.10 and make it optional on azure tenant clusters.