### PR TITLE
run go mod tidy in dependabot builds

### DIFF
--- a/.github/workflows/go-mod-tidy.yaml
+++ b/.github/workflows/go-mod-tidy.yaml
@@ -1,0 +1,40 @@
+# Credit: https://github.com/crazy-max/diun
+name: go-mod-tidy
+
+on:
+  push:
+    branches:
+      - 'dependabot/**'
+
+jobs:
+  fix:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v1
+      -
+        # https://github.com/actions/checkout/issues/6
+        name: Fix detached HEAD
+        run: git checkout ${GITHUB_REF#refs/heads/}
+      -
+        name: Tidy
+        run: |
+          rm -f go.sum
+          go mod tidy
+      -
+        name: Set up Git
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+      -
+        name: Commit and push changes
+        run: |
+          git add .
+          if output=$(git status --porcelain) && [ ! -z "$output" ]; then
+            git commit -m 'Fix go modules'
+            git push
+          fi


### PR DESCRIPTION
Replicating from https://github.com/giantswarm/kvm-operator/blob/master/.github/workflows/tidy.yml as discussed in SIG RelEng. Without this most `dependabot` builds fail. 