### PR TITLE
Align with nginx 1.7.0 changes

### DIFF
--- a/pkg/project/version_bundle_aws.go
+++ b/pkg/project/version_bundle_aws.go
@@ -8,9 +8,11 @@ var versionBundleAWS = versionbundle.Bundle{
 	Changelogs: []versionbundle.Changelog{
 		{
 			Component:   Name(),
-			Description: "TODO",
+			Description: "Align with NGINX IC App 1.7.0, move of LB Service management from azure-operator to the app itself",
 			Kind:        versionbundle.KindChanged,
-			URLs:        []string{},
+			URLs: []string{
+				"https://github.com/giantswarm/cluster-operator/pull/1067",
+			},
 		},
 	},
 	Components: []versionbundle.Component{},

--- a/pkg/project/version_bundle_azure.go
+++ b/pkg/project/version_bundle_azure.go
@@ -8,9 +8,11 @@ var versionBundleAzure = versionbundle.Bundle{
 	Changelogs: []versionbundle.Changelog{
 		{
 			Component:   Name(),
-			Description: "TODO",
+			Description: "Align with NGINX IC App 1.7.0, move of LB Service management from azure-operator to the app itself",
 			Kind:        versionbundle.KindChanged,
-			URLs:        []string{},
+			URLs: []string{
+				"https://github.com/giantswarm/cluster-operator/pull/1067",
+			},
 		},
 	},
 	Components: []versionbundle.Component{},

--- a/pkg/project/version_bundle_kvm.go
+++ b/pkg/project/version_bundle_kvm.go
@@ -8,9 +8,11 @@ var versionBundleKVM = versionbundle.Bundle{
 	Changelogs: []versionbundle.Changelog{
 		{
 			Component:   Name(),
-			Description: "TODO",
+			Description: "Align with NGINX IC App 1.7.0, move of LB Service management from azure-operator to the app itself",
 			Kind:        versionbundle.KindChanged,
-			URLs:        []string{},
+			URLs: []string{
+				"https://github.com/giantswarm/cluster-operator/pull/1067",
+			},
 		},
 	},
 	Components: []versionbundle.Component{},

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -132,7 +132,6 @@ func (r *StateGetter) GetDesiredState(ctx context.Context, obj interface{}) ([]*
 				"configmap": map[string]string{
 					"use-proxy-protocol": strconv.FormatBool(useProxyProtocol),
 				},
-				"provider": r.provider,
 			},
 		},
 	}


### PR DESCRIPTION
This PR aligns customization of ingress controller ConfigMap for legacy releases with nginx app 1.7.0 changes in https://github.com/giantswarm/nginx-ingress-controller-app/pull/73:
- drops IC legacy flag,
- disables IC app LB Service for legacy aws and kvm
- stops setting provider in ingress-values ConfigMap, introduced in 0.23.9 (it was redundant, see discussion in https://github.com/giantswarm/cluster-operator/pull/1050/files#r446887615)

## Checklist

- [x] Update changelog in CHANGELOG.md.
