### PR TITLE
Update Alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.11
 
 RUN apk add --no-cache ca-certificates
 


### PR DESCRIPTION
Updating to the latest release of Alpine (3.11).

The current version of alpine (3.8) is not supported anymore (EOS 2020-05-01).
