### PR TITLE
fix linter issues

### DIFF
--- a/service/collector/cluster.go
+++ b/service/collector/cluster.go
@@ -81,6 +81,8 @@ func (c *Cluster) Collect(ch chan<- prometheus.Metric) error {
 	}
 
 	for _, cl := range list.Items {
+		cl := cl // dereferencing pointer value into new scope
+
 		cr := c.newCommonClusterObjectFunc()
 		{
 			err := c.k8sClient.CtrlClient().Get(

--- a/service/collector/node_pool.go
+++ b/service/collector/node_pool.go
@@ -96,6 +96,8 @@ func (np *NodePool) Collect(ch chan<- prometheus.Metric) error {
 	nodePoolMap := make(map[string][]nodePool)
 
 	for _, md := range list.Items {
+		md := md // dereferencing pointer value into new scope
+
 		np := nodePool{
 			id:      key.MachineDeployment(&md),
 			desired: int(md.Status.Replicas),

--- a/service/controller/resource/updateg8scontrolplanes/create.go
+++ b/service/controller/resource/updateg8scontrolplanes/create.go
@@ -36,6 +36,8 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	for _, cp := range cpList.Items {
+		cp := cp // dereferencing pointer value into new scope
+
 		var updated bool
 
 		// Syncing the cluster-operator version.

--- a/service/controller/resource/updatemachinedeployments/create.go
+++ b/service/controller/resource/updatemachinedeployments/create.go
@@ -36,6 +36,8 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	for _, md := range mdList.Items {
+		md := md // dereferencing pointer value into new scope
+
 		var updated bool
 
 		// Syncing the cluster-operator version.


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.


## Context

I have a newer version of `golangci-lint` and already get this. 

```
$ CGO_ENABLED=0 golangci-lint run -E gosec -E goconst
service/collector/cluster.go:103:19: G601: Implicit memory aliasing in for loop. (gosec)
				key.ClusterID(&cl),
```