### PR TITLE
add deleteinfrarefs handler

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA      = "n/a"
 	name        = "cluster-operator"
 	source      = "https://github.com/giantswarm/cluster-operator"
-	version     = "2.2.1-dev"
+	version     = "2.2.1-xh3b4sd"
 )
 
 func Description() string {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA      = "n/a"
 	name        = "cluster-operator"
 	source      = "https://github.com/giantswarm/cluster-operator"
-	version     = "2.2.1-xh3b4sd"
+	version     = "2.2.1-dev"
 )
 
 func Description() string {

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -34,6 +34,7 @@ import (
 	"github.com/giantswarm/cluster-operator/service/controller/resource/clusterstatus"
 	"github.com/giantswarm/cluster-operator/service/controller/resource/cpnamespace"
 	"github.com/giantswarm/cluster-operator/service/controller/resource/deletecrs"
+	"github.com/giantswarm/cluster-operator/service/controller/resource/deleteinfrarefs"
 	"github.com/giantswarm/cluster-operator/service/controller/resource/encryptionkey"
 	"github.com/giantswarm/cluster-operator/service/controller/resource/keepforcrs"
 	"github.com/giantswarm/cluster-operator/service/controller/resource/keepforinfrarefs"
@@ -328,6 +329,21 @@ func newClusterResources(config ClusterConfig) ([]resource.Interface, error) {
 		}
 	}
 
+	var deleteInfraRefsResource resource.Interface
+	{
+		c := deleteinfrarefs.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+
+			ToObjRef: toClusterObjRef,
+		}
+
+		deleteInfraRefsResource, err = deleteinfrarefs.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var encryptionKeyGetter secretresource.StateGetter
 	{
 		c := encryptionkey.Config{
@@ -576,6 +592,7 @@ func newClusterResources(config ClusterConfig) ([]resource.Interface, error) {
 		// Following resources manage tenant cluster deletion events.
 		deleteG8sControlPlaneCRsResource,
 		deleteMachineDeploymentCRsResource,
+		deleteInfraRefsResource,
 		keepForG8sControlPlaneCRsResource,
 		keepForMachineDeploymentCRsResource,
 		keepForInfraRefsResource,

--- a/service/controller/control_plane.go
+++ b/service/controller/control_plane.go
@@ -19,6 +19,7 @@ import (
 	"github.com/giantswarm/cluster-operator/pkg/project"
 	"github.com/giantswarm/cluster-operator/service/controller/controllercontext"
 	"github.com/giantswarm/cluster-operator/service/controller/key"
+	"github.com/giantswarm/cluster-operator/service/controller/resource/deleteinfrarefs"
 	"github.com/giantswarm/cluster-operator/service/controller/resource/keepforinfrarefs"
 	"github.com/giantswarm/cluster-operator/service/controller/resource/updateinfrarefs"
 	"github.com/giantswarm/cluster-operator/service/internal/releaseversion"
@@ -86,6 +87,21 @@ func NewControlPlane(config ControlPlaneConfig) (*ControlPlane, error) {
 func newControlPlaneResources(config ControlPlaneConfig) ([]resource.Interface, error) {
 	var err error
 
+	var deleteInfraRefsResource resource.Interface
+	{
+		c := deleteinfrarefs.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+
+			ToObjRef: toG8sControlPlaneObjRef,
+		}
+
+		deleteInfraRefsResource, err = deleteinfrarefs.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var keepForInfraRefsResource resource.Interface
 	{
 		c := keepforinfrarefs.Config{
@@ -119,6 +135,7 @@ func newControlPlaneResources(config ControlPlaneConfig) ([]resource.Interface, 
 	}
 
 	resources := []resource.Interface{
+		deleteInfraRefsResource,
 		keepForInfraRefsResource,
 		updateInfraRefsResource,
 	}

--- a/service/controller/machine_deployment.go
+++ b/service/controller/machine_deployment.go
@@ -21,6 +21,7 @@ import (
 	"github.com/giantswarm/cluster-operator/pkg/project"
 	"github.com/giantswarm/cluster-operator/service/controller/controllercontext"
 	"github.com/giantswarm/cluster-operator/service/controller/key"
+	"github.com/giantswarm/cluster-operator/service/controller/resource/deleteinfrarefs"
 	"github.com/giantswarm/cluster-operator/service/controller/resource/keepforinfrarefs"
 	"github.com/giantswarm/cluster-operator/service/controller/resource/machinedeploymentstatus"
 	"github.com/giantswarm/cluster-operator/service/controller/resource/tenantclients"
@@ -91,6 +92,21 @@ func NewMachineDeployment(config MachineDeploymentConfig) (*MachineDeployment, e
 
 func newMachineDeploymentResources(config MachineDeploymentConfig) ([]resource.Interface, error) {
 	var err error
+
+	var deleteInfraRefsResource resource.Interface
+	{
+		c := deleteinfrarefs.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+
+			ToObjRef: toMachineDeploymentObjRef,
+		}
+
+		deleteInfraRefsResource, err = deleteinfrarefs.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
 
 	var keepForInfraRefsResource resource.Interface
 	{
@@ -175,10 +191,11 @@ func newMachineDeploymentResources(config MachineDeploymentConfig) ([]resource.I
 		// keepForInfraRefsResource needs to run before
 		// machineDeploymentStatusResource because keepForInfraRefsResource keeps
 		// finalizers where machineDeploymentStatusResource does not.
-		keepForInfraRefsResource,
 		machineDeploymentStatusResource,
 
 		// Following resources manage resources in the control plane.
+		deleteInfraRefsResource,
+		keepForInfraRefsResource,
 		updateInfraRefsResource,
 	}
 

--- a/service/controller/resource/deleteinfrarefs/create.go
+++ b/service/controller/resource/deleteinfrarefs/create.go
@@ -1,0 +1,9 @@
+package deleteinfrarefs
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/resource/deleteinfrarefs/delete.go
+++ b/service/controller/resource/deleteinfrarefs/delete.go
@@ -1,0 +1,60 @@
+package deleteinfrarefs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/giantswarm/cluster-operator/service/controller/key"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	cr, err := meta.Accessor(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	or, err := r.toObjRef(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	var ir *unstructured.Unstructured
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finding infrastructure reference")
+
+		ir = &unstructured.Unstructured{}
+		ir.SetAPIVersion(or.APIVersion)
+		ir.SetKind(or.Kind)
+
+		err = r.k8sClient.CtrlClient().Get(ctx, key.ObjRefToNamespacedName(or), ir)
+		if apierrors.IsNotFound(err) {
+			// At this point the runtime object linked in the infrastructure reference
+			// does not exist anymore, which means the deletion of the parent can
+			// continue now.
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find infrastructure reference")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "found infrastructure reference")
+	}
+
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting object %#q of type %T for tenant cluster %#q", fmt.Sprintf("%s/%s", or.Namespace, or.Name), or.Kind, key.ClusterID(cr)))
+
+		err = r.k8sClient.CtrlClient().Delete(ctx, ir)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted object %#q of type %T for tenant cluster %#q", fmt.Sprintf("%s/%s", or.Namespace, or.Name), or.Kind, key.ClusterID(cr)))
+	}
+
+	return nil
+}

--- a/service/controller/resource/deleteinfrarefs/error.go
+++ b/service/controller/resource/deleteinfrarefs/error.go
@@ -1,0 +1,14 @@
+package deleteinfrarefs
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/resource/deleteinfrarefs/resource.go
+++ b/service/controller/resource/deleteinfrarefs/resource.go
@@ -1,0 +1,52 @@
+package deleteinfrarefs
+
+import (
+	"github.com/giantswarm/k8sclient/v3/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	Name = "deleteinfrarefs"
+)
+
+type Config struct {
+	K8sClient k8sclient.Interface
+	Logger    micrologger.Logger
+
+	ToObjRef func(v interface{}) (corev1.ObjectReference, error)
+}
+
+type Resource struct {
+	k8sClient k8sclient.Interface
+	logger    micrologger.Logger
+
+	toObjRef func(v interface{}) (corev1.ObjectReference, error)
+}
+
+func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	if config.ToObjRef == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ToObjRef must not be empty", config)
+	}
+
+	r := &Resource{
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+
+		toObjRef: config.ToObjRef,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/resource/machinedeploymentstatus/resource.go
+++ b/service/controller/resource/machinedeploymentstatus/resource.go
@@ -97,7 +97,7 @@ func (r *Resource) ensure(ctx context.Context, obj interface{}) error {
 
 		r.logger.LogCtx(ctx, "level", "debug", "message", "updated status of machine deployment")
 
-		if key.IsDeleted(&cr) {
+		if key.IsDeleted(cr) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "keeping finalizers")
 			finalizerskeptcontext.SetKept(ctx)
 		}

--- a/service/controller/resource/machinedeploymentstatus/resource.go
+++ b/service/controller/resource/machinedeploymentstatus/resource.go
@@ -6,6 +6,7 @@ import (
 	"github.com/giantswarm/k8sclient/v3/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/controller/context/finalizerskeptcontext"
 	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
 	apiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 
@@ -95,6 +96,12 @@ func (r *Resource) ensure(ctx context.Context, obj interface{}) error {
 		}
 
 		r.logger.LogCtx(ctx, "level", "debug", "message", "updated status of machine deployment")
+
+		if key.IsDeleted(&cr) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "keeping finalizers")
+			finalizerskeptcontext.SetKept(ctx)
+		}
+
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
 		reconciliationcanceledcontext.SetCanceled(ctx)
 	}


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

Towards https://github.com/giantswarm/giantswarm/issues/10710. With this it should be possible to simply delete the `Cluster` CR in order to delete the whole TC. As of now we have still certain logic in our `api` gateway which deletes all kinds of different CRs upon request to delete a TC. 