### PR TITLE
fix cluster upgrade by properly propating version labels

### DIFF
--- a/service/controller/resource/updateinfrarefs/create.go
+++ b/service/controller/resource/updateinfrarefs/create.go
@@ -50,8 +50,8 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	// Syncing the provider operator version label, e.g. for aws-operator,
 	// kvm-operator or the like.
 	{
-		l := fmt.Sprintf("%s-operator", r.provider)
-		d := componentVersions[l]
+		l := fmt.Sprintf("%s-operator.giantswarm.io/version", r.provider)
+		d := componentVersions[fmt.Sprintf("%s-operator", r.provider)]
 		c, ok := ir.GetLabels()[l]
 		if ok && d != "" && d != c {
 			labels := ir.GetLabels()


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context

In the scope of removing the usage of the controller context concept we did some refactorings and oversaw an issue with how labels are propagated between CRs. [I made a comment back then](https://github.com/giantswarm/cluster-operator/pull/1065/files#r428219726) and my hunch was apparently right. I should have handled that better. 

Checking the logs of an ongoing upgrade we see that there is only the release label updated, but not the operator label. So that is missing, which this PR fixes. 

```
$ cat logs.json | gg -s obj:5zttk -s res:updateinfrarefs -f res,mes,tim -g loo
{
    "resource": "updateinfrarefs",
    "message": "finding infrastructure reference",
    "time": "11:44:05"
}
{
    "resource": "updateinfrarefs",
    "message": "found infrastructure reference",
    "time": "11:44:05"
}
{
    "resource": "updateinfrarefs",
    "message": "label value of `release.giantswarm.io/version` changed from `11.3.3` to `11.5.0`",
    "time": "11:44:05"
}
{
    "resource": "updateinfrarefs",
    "message": "updating infrastructure reference `default/5zttk`",
    "time": "11:44:05"
}
{
    "resource": "updateinfrarefs",
    "message": "updated infrastructure reference `default/5zttk`",
    "time": "11:44:05"
}
```