### PR TITLE
Release cluster-operator 0.23.11

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,7 +1,7 @@
 package project
 
 var (
-	bundleVersion = "0.23.11-dev"
+	bundleVersion = "0.23.11"
 	description   = "The cluster-operator manages Kubernetes tenant cluster resources."
 	gitSHA        = "n/a"
 	name          = "cluster-operator"


### PR DESCRIPTION
Towards giantswarm/giantswarm#9962

Includes:
- Making NGINX optional on Azure (https://github.com/giantswarm/cluster-operator/pull/1134)

## Checklist

- [x] Update changelog in CHANGELOG.md.
