### PR TITLE
Cluster transition

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA      = "n/a"
 	name        = "cluster-operator"
 	source      = "https://github.com/giantswarm/cluster-operator"
-	version     = "2.3.1"
+	version     = "2.3.2-dev"
 )
 
 func Description() string {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA      = "n/a"
 	name        = "cluster-operator"
 	source      = "https://github.com/giantswarm/cluster-operator"
-	version     = "2.3.2-dev"
+	version     = "2.3.1"
 )
 
 func Description() string {

--- a/service/collector/cluster.go
+++ b/service/collector/cluster.go
@@ -94,6 +94,7 @@ func (c *Cluster) Collect(ch chan<- prometheus.Metric) error {
 			)
 			if apierrors.IsNotFound(err) {
 				c.logger.LogCtx(ctx, "level", "warning", "message", fmt.Sprintf("could not find object reference %#q", cl.GetName()))
+				continue
 			} else if err != nil {
 				return microerror.Mask(err)
 			}

--- a/service/collector/cluster_transition.go
+++ b/service/collector/cluster_transition.go
@@ -14,7 +14,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/cluster-operator/pkg/label"
-	"github.com/giantswarm/cluster-operator/pkg/project"
 	"github.com/giantswarm/cluster-operator/service/controller/key"
 )
 
@@ -147,7 +146,8 @@ func (ct *ClusterTransition) Collect(ch chan<- prometheus.Metric) error {
 		err := ct.k8sClient.CtrlClient().List(
 			ctx,
 			&list,
-			client.MatchingLabels{label.OperatorVersion: project.Version()},
+			//client.MatchingLabels{label.OperatorVersion: project.Version()},
+			client.MatchingLabels{label.OperatorVersion: "2.2.0"},
 		)
 		if err != nil {
 			return microerror.Mask(err)

--- a/service/collector/cluster_transition.go
+++ b/service/collector/cluster_transition.go
@@ -93,7 +93,7 @@ func (ct *ClusterTransition) Collect(ch chan<- prometheus.Metric) error {
 			ctx,
 			&list,
 			//client.MatchingLabels{label.OperatorVersion: project.Version()},
-			client.MatchingLabels{label.OperatorVersion: "2.3.0"},
+			client.MatchingLabels{label.OperatorVersion: "2.3.1"},
 		)
 		if err != nil {
 			return microerror.Mask(err)

--- a/service/collector/cluster_transition.go
+++ b/service/collector/cluster_transition.go
@@ -70,8 +70,8 @@ func NewClusterTransition(config ClusterTransitionConfig) (*ClusterTransition, e
 	}
 
 	ct := &ClusterTransition{
-		k8sClient:                  config.K8sClient,
-		logger:                     config.Logger,
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
 
 		newCommonClusterObjectFunc: config.NewCommonClusterObjectFunc,
 	}

--- a/service/collector/cluster_transition.go
+++ b/service/collector/cluster_transition.go
@@ -140,7 +140,7 @@ func (ct *ClusterTransition) Collect(ch chan<- prometheus.Metric) error {
 				}
 			}
 			{
-				if cr.GetCommonClusterStatus().HasUpdatingCondition() && cr.GetCommonClusterStatus().HasUpdatedCondition() { // && !ok {
+				if cr.GetCommonClusterStatus().HasUpdatingCondition() && cr.GetCommonClusterStatus().HasUpdatedCondition() {
 					t1 := cr.GetCommonClusterStatus().GetUpdatingCondition().LastTransitionTime.Time
 					t2 := cr.GetCommonClusterStatus().GetUpdatedCondition().LastTransitionTime.Time
 					ch <- prometheus.MustNewConstMetric(

--- a/service/collector/cluster_transition.go
+++ b/service/collector/cluster_transition.go
@@ -85,8 +85,6 @@ func NewClusterTransition(config ClusterTransitionConfig) (*ClusterTransition, e
 }
 
 func (ct *ClusterTransition) Collect(ch chan<- prometheus.Metric) error {
-	//var err error
-
 	ctx := context.Background()
 
 	var list apiv1alpha2.ClusterList
@@ -121,15 +119,15 @@ func (ct *ClusterTransition) Collect(ch chan<- prometheus.Metric) error {
 
 		{
 			{
-				if cr.GetCommonClusterStatus().HasCreatingCondition() && cr.GetCommonClusterStatus().HasCreatedCondition() { //&& !ok {
+				if cr.GetCommonClusterStatus().HasCreatingCondition() && cr.GetCommonClusterStatus().HasCreatedCondition() {
 					t1 := cr.GetCommonClusterStatus().GetCreatingCondition().LastTransitionTime.Time
 					t2 := cr.GetCommonClusterStatus().GetCreatedCondition().LastTransitionTime.Time
 					ch <- prometheus.MustNewConstMetric(
 						clusterTransitionCreateDesc,
 						prometheus.GaugeValue,
 						t2.Sub(t1).Seconds(),
-						key.ClusterID(&cl),
-						key.ReleaseVersion(&cl),
+						key.ClusterID(cr),
+						key.ReleaseVersion(cr),
 					)
 				}
 
@@ -144,8 +142,8 @@ func (ct *ClusterTransition) Collect(ch chan<- prometheus.Metric) error {
 							clusterTransitionCreateDesc,
 							prometheus.GaugeValue,
 							float64(999999999999),
-							key.ClusterID(&cl),
-							key.ReleaseVersion(&cl),
+							key.ClusterID(cr),
+							key.ReleaseVersion(cr),
 						)
 					}
 				}
@@ -158,8 +156,8 @@ func (ct *ClusterTransition) Collect(ch chan<- prometheus.Metric) error {
 						clusterTransitionUpdateDesc,
 						prometheus.GaugeValue,
 						t2.Sub(t1).Seconds(),
-						key.ClusterID(&cl),
-						key.ReleaseVersion(&cl),
+						key.ClusterID(cr),
+						key.ReleaseVersion(cr),
 					)
 				}
 
@@ -174,8 +172,8 @@ func (ct *ClusterTransition) Collect(ch chan<- prometheus.Metric) error {
 							clusterTransitionCreateDesc,
 							prometheus.GaugeValue,
 							float64(999999999999),
-							key.ClusterID(&cl),
-							key.ReleaseVersion(&cl),
+							key.ClusterID(cr),
+							key.ReleaseVersion(cr),
 						)
 					}
 				}

--- a/service/collector/cluster_transition.go
+++ b/service/collector/cluster_transition.go
@@ -52,6 +52,7 @@ type ClusterTransitionConfig struct {
 type ClusterTransition struct {
 	k8sClient                  k8sclient.Interface
 	logger                     micrologger.Logger
+
 	newCommonClusterObjectFunc func() infrastructurev1alpha2.CommonClusterObject
 }
 

--- a/service/collector/cluster_transition.go
+++ b/service/collector/cluster_transition.go
@@ -238,6 +238,7 @@ func (ct *ClusterTransition) Collect(ch chan<- prometheus.Metric) error {
 		}
 	}
 	ct.clusterTransitionCreateHistogramVec.Ensure(clusters)
+	ct.clusterTransitionUpdateHistogramVec.Ensure(clusters)
 
 	for cluster, histogram := range ct.clusterTransitionCreateHistogramVec.Histograms() {
 		ch <- prometheus.MustNewConstHistogram(

--- a/service/collector/cluster_transition.go
+++ b/service/collector/cluster_transition.go
@@ -5,15 +5,16 @@ import (
 	"time"
 
 	infrastructurev1alpha2 "github.com/giantswarm/apiextensions/pkg/apis/infrastructure/v1alpha2"
-	"github.com/giantswarm/cluster-operator/pkg/label"
-	"github.com/giantswarm/cluster-operator/pkg/project"
-	"github.com/giantswarm/cluster-operator/service/controller/key"
 	"github.com/giantswarm/k8sclient/v3/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/prometheus/client_golang/prometheus"
 	apiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/cluster-operator/pkg/label"
+	"github.com/giantswarm/cluster-operator/pkg/project"
+	"github.com/giantswarm/cluster-operator/service/controller/key"
 )
 
 var (

--- a/service/collector/cluster_transition.go
+++ b/service/collector/cluster_transition.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/cluster-operator/pkg/label"
+	"github.com/giantswarm/cluster-operator/pkg/project"
 	"github.com/giantswarm/cluster-operator/service/controller/key"
 )
 
@@ -37,15 +38,6 @@ var (
 		},
 		nil,
 	)
-	//clusterTransitionDeleteDesc *prometheus.Desc = prometheus.NewDesc(
-	//	prometheus.BuildFQName(namespace, subsystemCluster, "delete_transition"),
-	//	"Latest cluster deletion transition.",
-	//	[]string{
-	//		"cluster_id",
-	//		"release_version",
-	//	},
-	//	nil,
-	//)
 )
 
 type ClusterTransitionConfig struct {
@@ -92,8 +84,7 @@ func (ct *ClusterTransition) Collect(ch chan<- prometheus.Metric) error {
 		err := ct.k8sClient.CtrlClient().List(
 			ctx,
 			&list,
-			//client.MatchingLabels{label.OperatorVersion: project.Version()},
-			client.MatchingLabels{label.OperatorVersion: "2.3.1"},
+			client.MatchingLabels{label.OperatorVersion: project.Version()},
 		)
 		if err != nil {
 			return microerror.Mask(err)
@@ -186,7 +177,6 @@ func (ct *ClusterTransition) Collect(ch chan<- prometheus.Metric) error {
 func (ct *ClusterTransition) Describe(ch chan<- *prometheus.Desc) error {
 	ch <- clusterTransitionCreateDesc
 	ch <- clusterTransitionUpdateDesc
-	//	ch <- clusterTransitionDeleteDesc
 
 	return nil
 }

--- a/service/collector/cluster_transition.go
+++ b/service/collector/cluster_transition.go
@@ -64,6 +64,7 @@ func NewClusterTransition(config ClusterTransitionConfig) (*ClusterTransition, e
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
+
 	if config.NewCommonClusterObjectFunc == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.NewCommonClusterObjectFunc must not be empty", config)
 	}

--- a/service/collector/cluster_transition.go
+++ b/service/collector/cluster_transition.go
@@ -1,0 +1,118 @@
+package collector
+
+import (
+	"github.com/giantswarm/exporterkit/histogramvec"
+	"github.com/giantswarm/microerror"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	createTransitionBucketStart      = 0.001
+	createTransitionBucketFactor     = 2
+	createTransitionBucketNumBuckets = 5
+	updateTransitionBucketStart      = 0.001
+	updateTransitionBucketFactor     = 2
+	updateTransitionBucketNumBuckets = 5
+	deleteTransitionBucketStart      = 0.001
+	deleteTransitionBucketFactor     = 2
+	deleteTransitionBucketNumBuckets = 5
+)
+
+var (
+	createTransitionBuckets                      = []float64{600, 750, 900, 1050, 1200, 1350, 1500, 1650, 1800}
+	updateTransitionBuckets                      = []float64{3600, 3900, 4200, 4500, 4800, 5100, 5400, 5700, 6000, 6300, 6600, 6900, 7200}
+	deleteTransitionBuckets                      = []float64{3600, 3900, 4200, 4500, 4800, 5100, 5400, 5700, 6000, 6300, 6600, 6900, 7200}
+	clusterTransitionCreateDesc *prometheus.Desc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, subsystemCluster, "create_transition"),
+		"Latest cluster creation transition.",
+		[]string{
+			"cluster_id",
+			"release_version",
+		},
+		nil,
+	)
+	clusterTransitionUpdateDesc *prometheus.Desc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, subsystemCluster, "update_transition"),
+		"Latest cluster update transition.",
+		[]string{
+			"cluster_id",
+			"release_version",
+		},
+		nil,
+	)
+	clusterTransitionDeleteDesc *prometheus.Desc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, subsystemCluster, "delete_transition"),
+		"Latest cluster deletion transition.",
+		[]string{
+			"cluster_id",
+			"release_version",
+		},
+		nil,
+	)
+)
+
+// ClusterTransitionCollect implements the ClusterTransitionCollector interface, exposing cluster transition information.
+type ClusterTransitionCollector struct {
+	clusterTransitionCreateHistogramVec  *histogramvec.HistogramVec
+	clusterTransitionUpdateHistogramVec  *histogramvec.HistogramVec
+	clusterTransitionDeleteHistogramVec  *histogramvec.HistogramVec
+	clusterTransitionCreateHistogramDesc *prometheus.Desc
+	clusterTransitionUpdateHistogramDesc *prometheus.Desc
+	clusterTransitionDeleteHistogramDesc *prometheus.Desc
+}
+
+//TODO
+func NewClusterTransition() (*ClusterTransitionCollector, error) {
+	var clusterTransitionCreateHistogramVec *histogramvec.HistogramVec
+	var err error
+	{
+		c := histogramvec.Config{
+			BucketLimits: prometheus.ExponentialBuckets(
+				createTransitionBucketStart,
+				createTransitionBucketFactor,
+				createTransitionBucketNumBuckets,
+			),
+		}
+		clusterTransitionCreateHistogramVec, err = histogramvec.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+	var clusterTransitionUpdateHistogramVec *histogramvec.HistogramVec
+	{
+		c := histogramvec.Config{
+			BucketLimits: prometheus.ExponentialBuckets(
+				updateTransitionBucketStart,
+				updateTransitionBucketFactor,
+				updateTransitionBucketNumBuckets,
+			),
+		}
+		clusterTransitionUpdateHistogramVec, err = histogramvec.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+	var clusterTransitionDeleteHistogramVec *histogramvec.HistogramVec
+	{
+		c := histogramvec.Config{
+			BucketLimits: prometheus.ExponentialBuckets(
+				deleteTransitionBucketStart,
+				deleteTransitionBucketFactor,
+				deleteTransitionBucketNumBuckets),
+		}
+		clusterTransitionDeleteHistogramVec, err = histogramvec.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	collector := &ClusterTransitionCollector{
+		clusterTransitionCreateHistogramVec:  clusterTransitionCreateHistogramVec,
+		clusterTransitionCreateHistogramDesc: clusterTransitionCreateDesc,
+		clusterTransitionUpdateHistogramVec:  clusterTransitionUpdateHistogramVec,
+		clusterTransitionUpdateHistogramDesc: clusterTransitionUpdateDesc,
+		clusterTransitionDeleteHistogramVec:  clusterTransitionDeleteHistogramVec,
+		clusterTransitionDeleteHistogramDesc: clusterTransitionDeleteDesc,
+	}
+	return collector, nil
+}

--- a/service/collector/cluster_transition.go
+++ b/service/collector/cluster_transition.go
@@ -180,12 +180,12 @@ func (ct *ClusterTransition) Collect(ch chan<- prometheus.Metric) error {
 		var err error
 		{
 			clusterHistogram := ct.clusterTransitionCreateHistogramVec.Histograms()
-			_, ok := clusterHistogram[cr.GetClusterName()]
+			_, ok := clusterHistogram[cr.GetName()]
 
 			if cr.GetCommonClusterStatus().HasCreatingCondition() && cr.GetCommonClusterStatus().HasCreatedCondition() && !ok {
-				t1 := cr.GetCommonClusterStatus().GetCreatingCondition().LastTransitionTime.Time.Second()
-				t2 := cr.GetCommonClusterStatus().GetCreatedCondition().LastTransitionTime.Time.Second()
-				err = ct.clusterTransitionCreateHistogramVec.Add(cr.GetName(), float64(t1-t2))
+				t1 := cr.GetCommonClusterStatus().GetCreatingCondition().LastTransitionTime.Time
+				t2 := cr.GetCommonClusterStatus().GetCreatedCondition().LastTransitionTime.Time
+				err = ct.clusterTransitionCreateHistogramVec.Add(cr.GetName(), t2.Sub(t1).Seconds())
 				if err != nil {
 					return microerror.Mask(err)
 				}

--- a/service/collector/cluster_transition.go
+++ b/service/collector/cluster_transition.go
@@ -53,6 +53,7 @@ type ClusterTransition struct {
 	k8sClient k8sclient.Interface
 	logger    micrologger.Logger
 
+
 	newCommonClusterObjectFunc func() infrastructurev1alpha2.CommonClusterObject
 }
 

--- a/service/collector/cluster_transition.go
+++ b/service/collector/cluster_transition.go
@@ -53,7 +53,6 @@ type ClusterTransition struct {
 	k8sClient k8sclient.Interface
 	logger    micrologger.Logger
 
-
 	newCommonClusterObjectFunc func() infrastructurev1alpha2.CommonClusterObject
 }
 

--- a/service/collector/cluster_transition.go
+++ b/service/collector/cluster_transition.go
@@ -105,6 +105,7 @@ func (ct *ClusterTransition) Collect(ch chan<- prometheus.Metric) error {
 			)
 			if apierrors.IsNotFound(err) {
 				ct.logger.LogCtx(ctx, "level", "warning", "message", fmt.Sprintf("could not find object reference %#q", cl.GetName()))
+				continue
 			} else if err != nil {
 				return microerror.Mask(err)
 			}

--- a/service/collector/cluster_transition.go
+++ b/service/collector/cluster_transition.go
@@ -212,7 +212,7 @@ func (ct *ClusterTransition) Collect(ch chan<- prometheus.Metric) error {
 	for cluster, histogram := range ct.clusterTransitionCreateHistogramVec.Histograms() {
 		ch <- prometheus.MustNewConstHistogram(
 			clusterTransitionCreateDesc,
-			uint64(1), float64(1), histogram.Buckets(),
+			histogram.Count(), histogram.Sum(), histogram.Buckets(),
 			cluster,
 			releases[cluster],
 		)

--- a/service/collector/cluster_transition.go
+++ b/service/collector/cluster_transition.go
@@ -6,18 +6,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-const (
-	createTransitionBucketStart      = 0.001
-	createTransitionBucketFactor     = 2
-	createTransitionBucketNumBuckets = 5
-	updateTransitionBucketStart      = 0.001
-	updateTransitionBucketFactor     = 2
-	updateTransitionBucketNumBuckets = 5
-	deleteTransitionBucketStart      = 0.001
-	deleteTransitionBucketFactor     = 2
-	deleteTransitionBucketNumBuckets = 5
-)
-
 var (
 	createTransitionBuckets                      = []float64{600, 750, 900, 1050, 1200, 1350, 1500, 1650, 1800}
 	updateTransitionBuckets                      = []float64{3600, 3900, 4200, 4500, 4800, 5100, 5400, 5700, 6000, 6300, 6600, 6900, 7200}
@@ -64,11 +52,7 @@ func NewClusterTransition() (*ClusterTransition, error) {
 	var err error
 	{
 		c := histogramvec.Config{
-			BucketLimits: prometheus.ExponentialBuckets(
-				createTransitionBucketStart,
-				createTransitionBucketFactor,
-				createTransitionBucketNumBuckets,
-			),
+			BucketLimits: createTransitionBuckets,
 		}
 		clusterTransitionCreateHistogramVec, err = histogramvec.New(c)
 		if err != nil {
@@ -78,11 +62,7 @@ func NewClusterTransition() (*ClusterTransition, error) {
 	var clusterTransitionUpdateHistogramVec *histogramvec.HistogramVec
 	{
 		c := histogramvec.Config{
-			BucketLimits: prometheus.ExponentialBuckets(
-				updateTransitionBucketStart,
-				updateTransitionBucketFactor,
-				updateTransitionBucketNumBuckets,
-			),
+			BucketLimits: updateTransitionBuckets,
 		}
 		clusterTransitionUpdateHistogramVec, err = histogramvec.New(c)
 		if err != nil {
@@ -92,10 +72,7 @@ func NewClusterTransition() (*ClusterTransition, error) {
 	var clusterTransitionDeleteHistogramVec *histogramvec.HistogramVec
 	{
 		c := histogramvec.Config{
-			BucketLimits: prometheus.ExponentialBuckets(
-				deleteTransitionBucketStart,
-				deleteTransitionBucketFactor,
-				deleteTransitionBucketNumBuckets),
+			BucketLimits: deleteTransitionBuckets,
 		}
 		clusterTransitionDeleteHistogramVec, err = histogramvec.New(c)
 		if err != nil {
@@ -112,6 +89,17 @@ func NewClusterTransition() (*ClusterTransition, error) {
 }
 
 func (ct *ClusterTransition) Collect(ch chan<- prometheus.Metric) error {
+	// ct.clusterTransitionCreateHistogramVec.Add(clusterID, observedTime.Seconds())
+	// creation timestamp of metadata cluster?
+	// Status Control Plane Initialized: false Infrastructure Ready: false
+
+	//ct.clusterTransitionCreateHistogramVec.Ensure(clusters)
+	//for host, histogram := range ct.clusterTransitionCreateHistogramVec.Histograms() {
+	//ch <- prometheus.MustNewConstHistogram(
+	//	clusterTransitionCreateDesc,
+	//	histogram.Count(), histogram.Sum(), histogram.Buckets(),
+	//	clusterID,
+	//)
 	return nil
 }
 

--- a/service/collector/cluster_transition.go
+++ b/service/collector/cluster_transition.go
@@ -247,6 +247,15 @@ func (ct *ClusterTransition) Collect(ch chan<- prometheus.Metric) error {
 		)
 	}
 
+	for cluster, histogram := range ct.clusterTransitionUpdateHistogramVec.Histograms() {
+		ch <- prometheus.MustNewConstHistogram(
+			clusterTransitionUpdateDesc,
+			histogram.Count(), histogram.Sum(), histogram.Buckets(),
+			cluster,
+			releases[cluster],
+		)
+	}
+
 	return nil
 }
 

--- a/service/collector/cluster_transition.go
+++ b/service/collector/cluster_transition.go
@@ -50,8 +50,8 @@ type ClusterTransitionConfig struct {
 // ClusterTransition implements the ClusterTransition interface, exposing
 // cluster transition information.
 type ClusterTransition struct {
-	k8sClient                  k8sclient.Interface
-	logger                     micrologger.Logger
+	k8sClient k8sclient.Interface
+	logger    micrologger.Logger
 
 	newCommonClusterObjectFunc func() infrastructurev1alpha2.CommonClusterObject
 }

--- a/service/collector/cluster_transition.go
+++ b/service/collector/cluster_transition.go
@@ -102,8 +102,6 @@ func (ct *ClusterTransition) Collect(ch chan<- prometheus.Metric) error {
 		}
 	}
 
-	var clusters []string
-	releases := map[string]string{}
 	for _, cl := range list.Items {
 		cl := cl // dereferencing pointer value into new scope
 
@@ -121,8 +119,6 @@ func (ct *ClusterTransition) Collect(ch chan<- prometheus.Metric) error {
 			}
 		}
 
-		clusters = append(clusters, cr.GetName())
-		releases[cr.GetName()] = key.ReleaseVersion(cr)
 		{
 			{
 				if cr.GetCommonClusterStatus().HasCreatingCondition() && cr.GetCommonClusterStatus().HasCreatedCondition() { //&& !ok {

--- a/service/collector/cluster_transition.go
+++ b/service/collector/cluster_transition.go
@@ -51,18 +51,15 @@ var (
 	)
 )
 
-// ClusterTransitionCollect implements the ClusterTransitionCollector interface, exposing cluster transition information.
-type ClusterTransitionCollector struct {
-	clusterTransitionCreateHistogramVec  *histogramvec.HistogramVec
-	clusterTransitionUpdateHistogramVec  *histogramvec.HistogramVec
-	clusterTransitionDeleteHistogramVec  *histogramvec.HistogramVec
-	clusterTransitionCreateHistogramDesc *prometheus.Desc
-	clusterTransitionUpdateHistogramDesc *prometheus.Desc
-	clusterTransitionDeleteHistogramDesc *prometheus.Desc
+//ClusterTransition implements the ClusterTransition interface, exposing cluster transition information.
+type ClusterTransition struct {
+	clusterTransitionCreateHistogramVec *histogramvec.HistogramVec
+	clusterTransitionUpdateHistogramVec *histogramvec.HistogramVec
+	clusterTransitionDeleteHistogramVec *histogramvec.HistogramVec
 }
 
-//TODO
-func NewClusterTransition() (*ClusterTransitionCollector, error) {
+//NewClusterTransition initiates cluster transition metrics
+func NewClusterTransition() (*ClusterTransition, error) {
 	var clusterTransitionCreateHistogramVec *histogramvec.HistogramVec
 	var err error
 	{
@@ -106,13 +103,22 @@ func NewClusterTransition() (*ClusterTransitionCollector, error) {
 		}
 	}
 
-	collector := &ClusterTransitionCollector{
-		clusterTransitionCreateHistogramVec:  clusterTransitionCreateHistogramVec,
-		clusterTransitionCreateHistogramDesc: clusterTransitionCreateDesc,
-		clusterTransitionUpdateHistogramVec:  clusterTransitionUpdateHistogramVec,
-		clusterTransitionUpdateHistogramDesc: clusterTransitionUpdateDesc,
-		clusterTransitionDeleteHistogramVec:  clusterTransitionDeleteHistogramVec,
-		clusterTransitionDeleteHistogramDesc: clusterTransitionDeleteDesc,
+	collector := &ClusterTransition{
+		clusterTransitionCreateHistogramVec: clusterTransitionCreateHistogramVec,
+		clusterTransitionUpdateHistogramVec: clusterTransitionUpdateHistogramVec,
+		clusterTransitionDeleteHistogramVec: clusterTransitionDeleteHistogramVec,
 	}
 	return collector, nil
+}
+
+func (ct *ClusterTransition) Collect(ch chan<- prometheus.Metric) error {
+	return nil
+}
+
+func (ct *ClusterTransition) Describe(ch chan<- *prometheus.Desc) error {
+	ch <- clusterTransitionCreateDesc
+	ch <- clusterTransitionUpdateDesc
+	ch <- clusterTransitionDeleteDesc
+
+	return nil
 }

--- a/service/collector/cluster_transition.go
+++ b/service/collector/cluster_transition.go
@@ -180,8 +180,8 @@ func (ct *ClusterTransition) Collect(ch chan<- prometheus.Metric) error {
 		var err error
 		{
 			if cr.GetCommonClusterStatus().HasCreatingCondition() && cr.GetCommonClusterStatus().HasCreatedCondition() {
-				t1 := cr.GetCommonClusterStatus().GetCreatingCondition().LastTransitionTime.Time.Unix()
-				t2 := cr.GetCommonClusterStatus().GetCreatedCondition().LastTransitionTime.Time.Unix()
+				t1 := cr.GetCommonClusterStatus().GetCreatingCondition().LastTransitionTime.Time.Second()
+				t2 := cr.GetCommonClusterStatus().GetCreatedCondition().LastTransitionTime.Time.Second()
 				err = ct.clusterTransitionCreateHistogramVec.Add(cr.GetName(), float64(t1-t2))
 				if err != nil {
 					return microerror.Mask(err)

--- a/service/collector/cluster_transition.go
+++ b/service/collector/cluster_transition.go
@@ -123,6 +123,10 @@ func NewClusterTransition(config ClusterTransitionConfig) (*ClusterTransition, e
 		clusterTransitionCreateHistogramVec: clusterTransitionCreateHistogramVec,
 		clusterTransitionUpdateHistogramVec: clusterTransitionUpdateHistogramVec,
 		clusterTransitionDeleteHistogramVec: clusterTransitionDeleteHistogramVec,
+
+		k8sClient:                  config.K8sClient,
+		logger:                     config.Logger,
+		newCommonClusterObjectFunc: config.NewCommonClusterObjectFunc,
 	}
 	return collector, nil
 }
@@ -174,7 +178,7 @@ func (ct *ClusterTransition) Collect(ch chan<- prometheus.Metric) error {
 				maxUpdateInterval := clusterTransistionCreating.Add(2 * time.Hour)
 
 				if now.After(maxUpdateInterval) {
-					ct.clusterTransitionCreateHistogramVec.WithLabelValues(cr.GetClusterName()).Observe(float64(999999999999))
+					ct.clusterTransitionCreateHistogramVec.WithLabelValues(cr.GetClusterName()).Observe(float64(99999999999))
 				}
 
 			}

--- a/service/collector/cluster_transition.go
+++ b/service/collector/cluster_transition.go
@@ -206,13 +206,12 @@ func (ct *ClusterTransition) Collect(ch chan<- prometheus.Metric) error {
 
 		}
 	}
-
 	ct.clusterTransitionCreateHistogramVec.Ensure(clusters)
 
 	for cluster, histogram := range ct.clusterTransitionCreateHistogramVec.Histograms() {
 		ch <- prometheus.MustNewConstHistogram(
 			clusterTransitionCreateDesc,
-			histogram.Count(), histogram.Sum(), histogram.Buckets(),
+			histogram.Count()-1, histogram.Sum(), histogram.Buckets(),
 			cluster,
 			releases[cluster],
 		)

--- a/service/collector/cluster_transition.go
+++ b/service/collector/cluster_transition.go
@@ -170,6 +170,7 @@ func (ct *ClusterTransition) Collect(ch chan<- prometheus.Metric) error {
 
 				if now.After(maxCreateInterval) {
 					ct.clusterTransitionCreateHistogramVec.WithLabelValues(cr.GetClusterName()).Observe(float64(999999999999))
+					ct.clusterTransitionCreateHistogramVec.Collect(ch)
 				}
 
 			}
@@ -181,7 +182,6 @@ func (ct *ClusterTransition) Collect(ch chan<- prometheus.Metric) error {
 				if now.After(maxUpdateInterval) {
 					ct.clusterTransitionCreateHistogramVec.WithLabelValues(cr.GetClusterName()).Observe(float64(99999999999))
 				}
-
 			}
 
 			if cr.GetCommonClusterStatus().HasCreatingCondition() && cr.GetCommonClusterStatus().HasCreatedCondition() {
@@ -190,6 +190,7 @@ func (ct *ClusterTransition) Collect(ch chan<- prometheus.Metric) error {
 
 				deltaCreate := clusterTransistionCreated - clusterTransitionCreating
 				ct.clusterTransitionCreateHistogramVec.WithLabelValues(cr.GetClusterName()).Observe(float64(deltaCreate))
+				ct.clusterTransitionCreateHistogramVec.Collect(ch)
 			}
 
 			if cr.GetCommonClusterStatus().HasUpdatingCondition() && cr.GetCommonClusterStatus().HasUpdatedCondition() {
@@ -198,6 +199,7 @@ func (ct *ClusterTransition) Collect(ch chan<- prometheus.Metric) error {
 
 				deltaUpdate := clusterTransitionUpdated - clusterTransitionUpdating
 				ct.clusterTransitionCreateHistogramVec.WithLabelValues(cr.GetClusterName()).Observe(float64(deltaUpdate))
+				ct.clusterTransitionCreateHistogramVec.Collect(ch)
 			}
 
 			//deleting figure out howto get deleted

--- a/service/collector/cluster_transition.go
+++ b/service/collector/cluster_transition.go
@@ -72,6 +72,7 @@ func NewClusterTransition(config ClusterTransitionConfig) (*ClusterTransition, e
 	ct := &ClusterTransition{
 		k8sClient:                  config.K8sClient,
 		logger:                     config.Logger,
+
 		newCommonClusterObjectFunc: config.NewCommonClusterObjectFunc,
 	}
 

--- a/service/collector/cluster_transition.go
+++ b/service/collector/cluster_transition.go
@@ -212,7 +212,7 @@ func (ct *ClusterTransition) Collect(ch chan<- prometheus.Metric) error {
 	for cluster, histogram := range ct.clusterTransitionCreateHistogramVec.Histograms() {
 		ch <- prometheus.MustNewConstHistogram(
 			clusterTransitionCreateDesc,
-			histogram.Count(), histogram.Sum(), histogram.Buckets(),
+			uint64(1), float64(1), histogram.Buckets(),
 			cluster,
 			releases[cluster],
 		)

--- a/service/collector/cluster_transition.go
+++ b/service/collector/cluster_transition.go
@@ -194,12 +194,11 @@ func (ct *ClusterTransition) Collect(ch chan<- prometheus.Metric) error {
 
 				if cr.GetCommonClusterStatus().HasCreatingCondition() && !cr.GetCommonClusterStatus().HasCreatedCondition() {
 					t1 := cr.GetCommonClusterStatus().GetCreatingCondition().LastTransitionTime.Time
-					maxInterval := createTransitionBuckets[len(createTransitionBuckets)-1]
 
 					// If the Creating condition is too old without having any
 					// Created condition given, we put the cluster into the last
 					// bucket and consider it invalid in that regard.
-					if time.Now().After(t1.Add(time.Duration(maxInterval)*time.Minute)) && !ok {
+					if time.Now().After(t1.Add(30*time.Minute)) && !ok {
 						err = ct.clusterTransitionCreateHistogramVec.Add(cr.GetName(), float64(999999999999))
 						if err != nil {
 							return microerror.Mask(err)
@@ -222,12 +221,11 @@ func (ct *ClusterTransition) Collect(ch chan<- prometheus.Metric) error {
 
 				if cr.GetCommonClusterStatus().HasUpdatingCondition() && !cr.GetCommonClusterStatus().HasUpdatedCondition() {
 					t1 := cr.GetCommonClusterStatus().GetUpdatingCondition().LastTransitionTime.Time
-					maxInterval := updateTransitionBuckets[len(updateTransitionBuckets)-1]
 
 					// If the Updating condition is too old without having any
 					// Updated condition given, we put the cluster into the last
 					// bucket and consider it invalid in that regard.
-					if time.Now().After(t1.Add(time.Duration(maxInterval)*time.Minute)) && !ok {
+					if time.Now().After(t1.Add(2*time.Hour)) && !ok {
 						err = ct.clusterTransitionUpdateHistogramVec.Add(cr.GetName(), float64(999999999999))
 						if err != nil {
 							return microerror.Mask(err)

--- a/service/collector/set.go
+++ b/service/collector/set.go
@@ -57,7 +57,14 @@ func NewSet(config SetConfig) (*Set, error) {
 
 	var clusterTransitionCollector *ClusterTransition
 	{
-		clusterTransitionCollector, err = NewClusterTransition()
+		c := ClusterTransitionConfig{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+
+			NewCommonClusterObjectFunc: config.NewCommonClusterObjectFunc,
+		}
+
+		clusterTransitionCollector, err = NewClusterTransition(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}

--- a/service/collector/set.go
+++ b/service/collector/set.go
@@ -18,7 +18,7 @@ type SetConfig struct {
 }
 
 // Set is basically only a wrapper for the operator's collector implementations.
-// It eases the iniitialization and prevents some weird import mess so we do not
+// It eases the initialization and prevents some weird import mess so we do not
 // have to alias packages.
 type Set struct {
 	*collector.Set

--- a/service/collector/set.go
+++ b/service/collector/set.go
@@ -55,12 +55,21 @@ func NewSet(config SetConfig) (*Set, error) {
 		}
 	}
 
+	var clusterTransitionCollector *ClusterTransition
+	{
+		clusterTransitionCollector, err = NewClusterTransition()
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var collectorSet *collector.Set
 	{
 		c := collector.SetConfig{
 			Collectors: []collector.Interface{
 				clusterCollector,
 				nodePoolCollector,
+				clusterTransitionCollector,
 			},
 			Logger: config.Logger,
 		}


### PR DESCRIPTION
Starting point for cluster transition metrics.

Tested with the latest release of cluster-operator 2.3.1 in ginger, can see now metrics how long it took.
```
# HELP cluster_operator_cluster_create_transition Latest cluster creation transition.
# TYPE cluster_operator_cluster_create_transition gauge
cluster_operator_cluster_create_transition{cluster_id="j7syb",release_version="11.5.0"} 1159
cluster_operator_cluster_create_transition{cluster_id="vh6p3",release_version="11.5.0"} 872
```

## Checklist

- [ ] Update changelog in CHANGELOG.md.
