### PR TITLE
Handle deletion gracefully when basedomain isn't present anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Handle error basedomain not found gracefully, so that G8sControlPlane CR and MachineDeployment CRs can be deleted
+
 ## [2.3.1] - 2020-07-14
 
 ### Fixed

--- a/service/controller/resource/controlplanestatus/resource.go
+++ b/service/controller/resource/controlplanestatus/resource.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/giantswarm/cluster-operator/pkg/label"
 	"github.com/giantswarm/cluster-operator/service/controller/key"
+	"github.com/giantswarm/cluster-operator/service/internal/basedomain"
 	"github.com/giantswarm/cluster-operator/service/internal/nodecount"
 	"github.com/giantswarm/cluster-operator/service/internal/tenantclient"
 )
@@ -73,6 +74,12 @@ func (r *Resource) ensure(ctx context.Context, obj interface{}) error {
 	masterNodes, err := r.nodeCount.MasterCount(ctx, cr)
 	if tenantclient.IsNotAvailable(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not getting master nodes for tenant cluster %#q", key.ClusterID(cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		resourcecanceledcontext.SetCanceled(ctx)
+		return nil
+	} else if basedomain.IsNotFound(err) {
+		// in case of a cluster deletion AWSCluster CR does not exist anymore, handle basedomain error gracefully
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not getting basedomain for tenant client %#q", key.ClusterID(cr)))
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		resourcecanceledcontext.SetCanceled(ctx)
 		return nil


### PR DESCRIPTION
Tenantclient is using the basedomain from AWS Cluster CR in handler MachineDeploymentStatus and ControlPlaneStatus. 

This PR handles basedomain error not found gracefully in case AWS Cluster CR is already deleted. 
More info: https://github.com/giantswarm/giantswarm/issues/12368

## Checklist

- [x] Update changelog in CHANGELOG.md.