### PR TITLE
Remove Helm major version label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated backward incompatible Kubernetes dependencies to v1.18.5.
 
+### Removed
+
+- Remove Helm major version label for chart-operator app CR as it is not used.
+
 ## [2.3.2] - 2020-07-31
 
 - Handle error basedomain not found gracefully, so that G8sControlPlane CR and MachineDeployment CRs can be deleted

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/giantswarm/cluster-operator/v3
 go 1.14
 
 require (
-	github.com/Masterminds/semver v1.5.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/giantswarm/apiextensions/v2 v2.1.0
 	github.com/giantswarm/certs/v3 v3.0.0

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,6 @@ github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKz
 github.com/Joker/jade v1.0.1-0.20190614124447-d475f43051e7/go.mod h1:6E6s8o2AE4KhCrqr6GRJjdC/gNfTdxkIXvuGZZda2VM=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
-github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
-github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=

--- a/pkg/label/app.go
+++ b/pkg/label/app.go
@@ -3,7 +3,4 @@ package label
 const (
 	// App is a standard label for tenant resources.
 	App = "app"
-
-	// AppOperatorHelmMajorVersion is a label for chart-operator app CRs.
-	AppOperatorHelmMajorVersion = "app-operator.giantswarm.io/helm-major-version"
 )

--- a/pkg/label/version.go
+++ b/pkg/label/version.go
@@ -1,9 +1,6 @@
 package label
 
 const (
-	// AppOperatorVersion sets the version label for app custom resources managed
-	// by the operator.
-	AppOperatorVersion = "app-operator.giantswarm.io/version"
 	// CertOperatorVersion sets the version label for CertConfig CRs managed by
 	// cert-operator.
 	CertOperatorVersion = "cert-operator.giantswarm.io/version"

--- a/service/controller/resource/app/desired.go
+++ b/service/controller/resource/app/desired.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/Masterminds/semver"
 	"github.com/ghodss/yaml"
 	g8sv1alpha1 "github.com/giantswarm/apiextensions/v2/pkg/apis/application/v1alpha1"
 	"github.com/giantswarm/microerror"
@@ -61,28 +60,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*g8s
 		userConfig := newUserConfig(cr, appSpec, configMaps, secrets)
 
 		if !appSpec.LegacyOnly {
-			app := r.newApp(appOperatorVersion, cr, appSpec, userConfig)
-
-			// For chart-operator only we need to set the Helm major version
-			// label. This is so the correct instance of app-operator processes
-			// the CR.
-			if appSpec.App == chartOperatorAppName {
-				helmMajorVersion := "2"
-
-				version, err := semver.NewVersion(appSpec.Version)
-				if err != nil {
-					return nil, microerror.Mask(err)
-				}
-
-				// For chart-operator 1.0.0 and greater we use Helm 3.
-				if version.Major() >= 1 {
-					helmMajorVersion = "3"
-				}
-
-				app.Labels[label.AppOperatorHelmMajorVersion] = helmMajorVersion
-			}
-
-			apps = append(apps, app)
+			apps = append(apps, r.newApp(appOperatorVersion, cr, appSpec, userConfig))
 		}
 	}
 

--- a/service/controller/resource/app/desired.go
+++ b/service/controller/resource/app/desired.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	g8sv1alpha1 "github.com/giantswarm/apiextensions/v2/pkg/apis/application/v1alpha1"
+	"github.com/giantswarm/apiextensions/v2/pkg/label"
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -14,7 +15,7 @@ import (
 	apiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 
 	"github.com/giantswarm/cluster-operator/v3/pkg/annotation"
-	"github.com/giantswarm/cluster-operator/v3/pkg/label"
+	pkglabel "github.com/giantswarm/cluster-operator/v3/pkg/label"
 	"github.com/giantswarm/cluster-operator/v3/pkg/project"
 	"github.com/giantswarm/cluster-operator/v3/service/controller/key"
 	"github.com/giantswarm/cluster-operator/v3/service/internal/releaseversion"
@@ -149,12 +150,12 @@ func (r *Resource) newApp(appOperatorVersion string, cr apiv1alpha2.Cluster, app
 				annotation.ForceHelmUpgrade: strconv.FormatBool(appSpec.UseUpgradeForce),
 			},
 			Labels: map[string]string{
-				label.App:                appSpec.App,
+				pkglabel.App:             appSpec.App,
 				label.AppOperatorVersion: appOperatorVersion,
 				label.Cluster:            key.ClusterID(&cr),
 				label.ManagedBy:          project.Name(),
 				label.Organization:       key.OrganizationID(&cr),
-				label.ServiceType:        label.ServiceTypeManaged,
+				pkglabel.ServiceType:     pkglabel.ServiceTypeManaged,
 			},
 			Name:      appSpec.App,
 			Namespace: key.ClusterID(&cr),

--- a/service/controller/resource/app/resource.go
+++ b/service/controller/resource/app/resource.go
@@ -12,8 +12,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name                 = "app"
-	chartOperatorAppName = "chart-operator"
+	Name = "app"
 )
 
 // Config represents the configuration used to create a new chartconfig service.


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/12095

We thought we needed the Helm major version label for bootstrapping chart-operator when Helm 2 is used. However it is not used so removing it to clean up. 

This also gets the app-operator version label from apiextensions as it was added recently.


## Checklist

- [x] Update changelog in CHANGELOG.md.
