### PR TITLE
Bugfix obj ref machinedeploymentstatus and controlplanestatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed condition where reference id does not match with G8sControlplane or MachineDeployment
+
 ## [3.0.0] - 2020-08-18
 
 ### Changed

--- a/service/controller/resource/controlplanestatus/resource.go
+++ b/service/controller/resource/controlplanestatus/resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/operatorkit/v2/pkg/controller/context/reconciliationcanceledcontext"
 	"github.com/giantswarm/operatorkit/v2/pkg/controller/context/resourcecanceledcontext"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/giantswarm/cluster-operator/v3/pkg/label"
 	"github.com/giantswarm/cluster-operator/v3/service/controller/key"
@@ -66,7 +67,7 @@ func (r *Resource) ensure(ctx context.Context, obj interface{}) error {
 			return microerror.Mask(err)
 		}
 
-		err = r.k8sClient.CtrlClient().Get(ctx, key.ObjRefToNamespacedName(key.ObjRefFromG8sControlPlane(cp)), cr)
+		err = r.k8sClient.CtrlClient().Get(ctx, types.NamespacedName{Name: cp.Name, Namespace: cp.Namespace}, cr)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/service/controller/resource/machinedeploymentstatus/resource.go
+++ b/service/controller/resource/machinedeploymentstatus/resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/giantswarm/operatorkit/v2/pkg/controller/context/finalizerskeptcontext"
 	"github.com/giantswarm/operatorkit/v2/pkg/controller/context/reconciliationcanceledcontext"
 	"github.com/giantswarm/operatorkit/v2/pkg/controller/context/resourcecanceledcontext"
+	"k8s.io/apimachinery/pkg/types"
 	apiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 
 	"github.com/giantswarm/cluster-operator/v3/pkg/label"
@@ -67,7 +68,7 @@ func (r *Resource) ensure(ctx context.Context, obj interface{}) error {
 			return microerror.Mask(err)
 		}
 
-		err = r.k8sClient.CtrlClient().Get(ctx, key.ObjRefToNamespacedName(key.ObjRefFromMachineDeployment(md)), cr)
+		err = r.k8sClient.CtrlClient().Get(ctx, types.NamespacedName{Name: md.Name, Namespace: md.Namespace}, cr)
 		if err != nil {
 			return microerror.Mask(err)
 		}


### PR DESCRIPTION
fixes condition where reference id does not match with machinedeployment or g8scontrolplane

## Checklist

- [x] Update changelog in CHANGELOG.md.