### PR TITLE
Don't delete certconfigs not managed by cluster-operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Only delete CertConfigs that have the "managed-by" label set to "cluster-operator".
+
 ## [0.23.16] - 2020-08-18
 
 ### Changed

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,12 +1,12 @@
 package project
 
 var (
-	bundleVersion = "0.23.16"
+	bundleVersion = "0.23.16-dev"
 	description   = "The cluster-operator manages Kubernetes tenant cluster resources."
 	gitSHA        = "n/a"
 	name          = "cluster-operator"
 	source        = "https://github.com/giantswarm/cluster-operator"
-	version       = "0.23.16"
+	version       = "0.23.16-dev"
 )
 
 func BundleVersion() string {

--- a/service/controller/resource/certconfig/delete.go
+++ b/service/controller/resource/certconfig/delete.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
-	"github.com/giantswarm/azure-operator/service/controller/key"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/resource/crud"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/giantswarm/cluster-operator/pkg/label"
 	"github.com/giantswarm/cluster-operator/pkg/project"
 )
 
@@ -93,7 +93,7 @@ func (r *Resource) newDeleteChangeForUpdatePatch(ctx context.Context, obj, curre
 		// Existing CertConfig is not desired anymore so it should be deleted.
 		if IsNotFound(err) {
 			// Only delete a CertConfig if it is managed by ClusterOperator.
-			if currentCertConfig.Labels[key.LabelManagedBy] == project.Name() {
+			if currentCertConfig.Labels[label.ManagedBy] == project.Name() {
 				certConfigsToDelete = append(certConfigsToDelete, currentCertConfig)
 			}
 		} else if err != nil {


### PR DESCRIPTION
The legacy branch of cluster operator deletes all of the `CertConfig` objects that are not "desired" according to his list of "desired certconfigs".

This means that if a `CertConfig` gets created outside of Cluster Operator, it gets deleted.

I feel like this is wrong and this PR aims at solving this issue.

WDYT?