### PR TITLE
Fix labels on pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Change pod labels
+
 ## [3.2.0] - 2020-09-15
 
 ### Added

--- a/helm/cluster-operator/templates/deployment.yaml
+++ b/helm/cluster-operator/templates/deployment.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "labels.selector" . | nindent 8 }}
+        {{- include "labels.common" . | nindent 8 }}
       annotations:
         releaseRevision: {{ .Release.Revision | quote }}
     spec:


### PR DESCRIPTION
When alert-manager fires `OperatorkitErrorRateTooHighFirecracker` for cluster-operator we don't see which version has currently issues because of some missing labels like version on pods.

This will use common labels which also includes the [selector labels](https://github.com/giantswarm/cluster-operator/blob/master/helm/cluster-operator/templates/_helpers.tpl#L21).

Example of missing labels (latest cluster-operator):

```
kg describe pod cluster-operator-3-1-1-58ff885875-rqj9j
Name:         cluster-operator-3-1-1-58ff885875-rqj9j
...
Labels:       app.kubernetes.io/instance=cluster-operator-3.1.1
              app.kubernetes.io/name=cluster-operator
              pod-template-hash=58ff885875
...
```

## Checklist

- [x] Update changelog in CHANGELOG.md.