### PR TITLE
Check chart tarball for app name and -app app name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Check existence of chart tarball for `release` CR `apps`.
+- Check existence of chart tarball for `release` CR `apps` in catalog.
 
 ## [3.5.0] - 2021-01-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Check existence of chart tarball for `release` CR `apps`.
+
 ## [3.5.0] - 2021-01-05
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/giantswarm/apiextensions/v3 v3.14.0
+	github.com/giantswarm/appcatalog v0.3.2
 	github.com/giantswarm/certs/v3 v3.1.0
 	github.com/giantswarm/errors v0.2.3
 	github.com/giantswarm/exporterkit v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.14
 require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/giantswarm/apiextensions/v3 v3.14.1
-	github.com/giantswarm/appcatalog v0.3.2
 	github.com/giantswarm/certs/v3 v3.1.0
 	github.com/giantswarm/errors v0.2.3
 	github.com/giantswarm/exporterkit v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/giantswarm/apiextensions/v3 v3.15.1
+	github.com/giantswarm/backoff v0.2.0
 	github.com/giantswarm/certs/v3 v3.1.0
 	github.com/giantswarm/errors v0.2.3
 	github.com/giantswarm/exporterkit v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -175,6 +175,8 @@ github.com/giantswarm/apiextensions/v3 v3.14.0 h1:/o7Mj7Yl0rEkOrkZI9HElsJDTeUhFa
 github.com/giantswarm/apiextensions/v3 v3.14.0/go.mod h1:4XD4M9+H2xhalpdXPB8x0MIA6NhYzXGIS5eb7Q7pMz0=
 github.com/giantswarm/app/v4 v4.0.0 h1:8PA0Hr6HRBbRS2KEWi5fSMq7rB4VdI2h0g9xI2ssLR4=
 github.com/giantswarm/app/v4 v4.0.0/go.mod h1:OiMkgrgxGtBNsTEHoF0hE9Sisn2onBxlc+dWHIBJPP4=
+github.com/giantswarm/appcatalog v0.3.2 h1:pH0ASrizU7QcAK4oZtrPXAi4pqMFJOsjCPRLY0uLFEo=
+github.com/giantswarm/appcatalog v0.3.2/go.mod h1:cjOuCqi8gWudFY0ogbp4ukSV4Vff6kfInR9VdrX+7yI=
 github.com/giantswarm/backoff v0.2.0 h1:kdfAf83pZ/l8X0KiA2dJ2Wq19nS9hISijVn7ZRdFhfU=
 github.com/giantswarm/backoff v0.2.0/go.mod h1:Z3WRsFilSJ5H5VlFa4XhraoPr+9pmZgYasoY2OSfNOk=
 github.com/giantswarm/certs/v3 v3.0.0/go.mod h1:fkmIW3moxlrldZhN99fnbBohsDJaki/WCHeNyIN2sr8=

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,6 @@ github.com/giantswarm/apiextensions/v3 v3.14.1 h1:P9jBH8T4bgtq1e+2aFbSb4hmJZ6OFT
 github.com/giantswarm/apiextensions/v3 v3.14.1/go.mod h1:4XD4M9+H2xhalpdXPB8x0MIA6NhYzXGIS5eb7Q7pMz0=
 github.com/giantswarm/app/v4 v4.0.0 h1:8PA0Hr6HRBbRS2KEWi5fSMq7rB4VdI2h0g9xI2ssLR4=
 github.com/giantswarm/app/v4 v4.0.0/go.mod h1:OiMkgrgxGtBNsTEHoF0hE9Sisn2onBxlc+dWHIBJPP4=
-github.com/giantswarm/appcatalog v0.3.2 h1:pH0ASrizU7QcAK4oZtrPXAi4pqMFJOsjCPRLY0uLFEo=
-github.com/giantswarm/appcatalog v0.3.2/go.mod h1:cjOuCqi8gWudFY0ogbp4ukSV4Vff6kfInR9VdrX+7yI=
 github.com/giantswarm/backoff v0.2.0 h1:kdfAf83pZ/l8X0KiA2dJ2Wq19nS9hISijVn7ZRdFhfU=
 github.com/giantswarm/backoff v0.2.0/go.mod h1:Z3WRsFilSJ5H5VlFa4XhraoPr+9pmZgYasoY2OSfNOk=
 github.com/giantswarm/certs/v3 v3.0.0/go.mod h1:fkmIW3moxlrldZhN99fnbBohsDJaki/WCHeNyIN2sr8=

--- a/helm/cluster-operator/templates/rbac.yaml
+++ b/helm/cluster-operator/templates/rbac.yaml
@@ -60,6 +60,12 @@ rules:
     verbs:
       - "*"
   - apiGroups:
+      - application.giantswarm.io
+    resources:
+      - appcatalogs
+    verbs:
+      - get
+  - apiGroups:
       - "networking.k8s.io"
     resources:
       - networkpolicies

--- a/service/controller/resource/app/desired.go
+++ b/service/controller/resource/app/desired.go
@@ -16,6 +16,7 @@ import (
 	apiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 
 	"github.com/giantswarm/appcatalog"
+
 	"github.com/giantswarm/cluster-operator/v3/pkg/annotation"
 	pkglabel "github.com/giantswarm/cluster-operator/v3/pkg/label"
 	"github.com/giantswarm/cluster-operator/v3/pkg/project"

--- a/service/controller/resource/app/desired.go
+++ b/service/controller/resource/app/desired.go
@@ -211,7 +211,7 @@ func (r *Resource) chartName(ctx context.Context, appName, catalog, version stri
 		return "", microerror.Mask(fmt.Errorf("Could not find chart %s in %s catalog", appName, catalog))
 	}
 
-	appNameWithoutAppSuffix := strings.TrimRight(appName, "-app")
+	appNameWithoutAppSuffix := strings.TrimSuffix(appName, "-app")
 	appNameWithAppSuffix := fmt.Sprintf("%s-app", appNameWithoutAppSuffix)
 
 	for _, entry := range entries {

--- a/service/controller/resource/app/desired.go
+++ b/service/controller/resource/app/desired.go
@@ -208,16 +208,23 @@ func (r *Resource) chartName(ctx context.Context, appName, catalog, version stri
 		}
 	}
 
-	entries, ok := index.Entries[appName]
-	if !ok || len(entries) == 0 {
-		return "", microerror.Mask(fmt.Errorf("Could not find chart %s in %s catalog", appName, catalog))
-	}
-
 	appNameWithoutAppSuffix := strings.TrimSuffix(appName, "-app")
 	appNameWithAppSuffix := fmt.Sprintf("%s-app", appNameWithoutAppSuffix)
+	chartName := ""
+
+	entries, ok := index.Entries[appNameWithAppSuffix]
+	if !ok || len(entries) == 0 {
+		entries, ok = index.Entries[appNameWithoutAppSuffix]
+		if !ok || len(entries) == 0 {
+			return "", microerror.Mask(fmt.Errorf("Could not find chart %s in %s catalog", appName, catalog))
+		}
+		chartName = appNameWithoutAppSuffix
+	} else {
+		chartName = appNameWithAppSuffix
+	}
 
 	for _, entry := range entries {
-		if entry.Version == version && (entry.Name == appNameWithAppSuffix || entry.Name == appNameWithoutAppSuffix) {
+		if entry.Version == version && entry.Name == chartName {
 			return entry.Name, nil
 		}
 	}

--- a/service/controller/resource/app/types.go
+++ b/service/controller/resource/app/types.go
@@ -1,0 +1,10 @@
+package app
+
+type Index struct {
+	Entries map[string][]IndexEntry `json:"entries"`
+}
+
+type IndexEntry struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}


### PR DESCRIPTION
Towards giantswarm/giantswarm#9815

This PR introduces requesting the chart tarball of apps present in `apps` of a `release` CR to validate its presence in the catalog.

Since giantswarm/giantswarm#9815 it is possible to omit the `-app` suffix when creating apps. `chart-operator` always appended `-app` to the `name` value of an app in the `apps` list of a `release` CR. 

After this has been merged and released, it will be possible to use apps without the `-app` suffix in releases.

## Checklist

- [x] Update changelog in CHANGELOG.md.
