### PR TITLE
Adding unit testing for various cases of cluster transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix cluster status computation to correctly display rollbacks, version changes and multiple updates.
+
 ### Added
 
-- Refactor cluster status computation and add unit tests for it.
+- Add unit tests for cluster status computation
 
 ## [3.5.1] - 2021-01-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Refactor cluster status computation and add unit tests for it.
+
 ## [3.5.1] - 2021-01-28
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/ghodss/yaml v1.0.0
-	github.com/giantswarm/apiextensions/v3 v3.18.2-0.20210218082518-d335c0b129ac
+	github.com/giantswarm/apiextensions/v3 v3.18.2
 	github.com/giantswarm/backoff v0.2.0
 	github.com/giantswarm/certs/v3 v3.1.0
 	github.com/giantswarm/errors v0.2.3

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/ghodss/yaml v1.0.0
-	github.com/giantswarm/apiextensions/v3 v3.18.1
+	github.com/giantswarm/apiextensions/v3 v3.18.2-0.20210218082518-d335c0b129ac
 	github.com/giantswarm/backoff v0.2.0
 	github.com/giantswarm/certs/v3 v3.1.0
 	github.com/giantswarm/errors v0.2.3

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/giantswarm/apiextensions/v3 v3.13.0/go.mod h1:f+dFUDLroK50aCGzvpqPw/j
 github.com/giantswarm/apiextensions/v3 v3.17.0/go.mod h1:N4SS083wjVR3GEL/pqWycva4yUtYrlU5lUKhRtZJ7EY=
 github.com/giantswarm/apiextensions/v3 v3.18.1 h1:vbGH0u9MyPIum2QGm+ehTGm/9B1Na5zVCrCV5BMxCjg=
 github.com/giantswarm/apiextensions/v3 v3.18.1/go.mod h1:N4SS083wjVR3GEL/pqWycva4yUtYrlU5lUKhRtZJ7EY=
+github.com/giantswarm/apiextensions/v3 v3.18.2-0.20210218082518-d335c0b129ac h1:joSQRJgGxRF72yvnsNuCfBNi8C4AA7ynBqBOdpV0zwo=
+github.com/giantswarm/apiextensions/v3 v3.18.2-0.20210218082518-d335c0b129ac/go.mod h1:6KBexBTOZJ+amkorxw722t2HS57f+rf/8LeSSFfQNmo=
 github.com/giantswarm/app/v4 v4.0.0 h1:8PA0Hr6HRBbRS2KEWi5fSMq7rB4VdI2h0g9xI2ssLR4=
 github.com/giantswarm/app/v4 v4.0.0/go.mod h1:OiMkgrgxGtBNsTEHoF0hE9Sisn2onBxlc+dWHIBJPP4=
 github.com/giantswarm/backoff v0.2.0 h1:kdfAf83pZ/l8X0KiA2dJ2Wq19nS9hISijVn7ZRdFhfU=
@@ -825,6 +827,8 @@ golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344 h1:vGXIOMxbNfDTk/aXCmfdLgkrSV+Z2tcbze+pEc3v5W4=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20201021035429-f5854403a974 h1:IX6qOQeG5uLjB/hjjwjedwfjND0hgjPMMyO1RoIXQNI=
+golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -878,10 +882,13 @@ golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211 h1:9UQO31fZ+0aKQOFldThf7BKPMJTiBfWycGh/u3UoO88=
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e h1:AyodaIpKjppX+cBfTASF2E1US3H2JFBj920Ot3rtDjs=
 golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 h1:myAQVi0cGEoqQVR5POX+8RR2mrocKqNN1hmeMqhX27k=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -928,6 +935,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.0.1 h1:xyiBuvkD2g5n7cYzx6u2sxQvsAy4QJsZFCzGVdzOXZ0=
 gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=

--- a/go.sum
+++ b/go.sum
@@ -172,8 +172,8 @@ github.com/giantswarm/apiextensions/v3 v3.11.0/go.mod h1:f+dFUDLroK50aCGzvpqPw/j
 github.com/giantswarm/apiextensions/v3 v3.13.0 h1:Sqf/DZJhd4aMzCjrmUVD7xffRORpZSnC9dPPqjKG7Nc=
 github.com/giantswarm/apiextensions/v3 v3.13.0/go.mod h1:f+dFUDLroK50aCGzvpqPw/jCFCCgJqdEMf/xNSJBI+A=
 github.com/giantswarm/apiextensions/v3 v3.17.0/go.mod h1:N4SS083wjVR3GEL/pqWycva4yUtYrlU5lUKhRtZJ7EY=
-github.com/giantswarm/apiextensions/v3 v3.18.2-0.20210218082518-d335c0b129ac h1:joSQRJgGxRF72yvnsNuCfBNi8C4AA7ynBqBOdpV0zwo=
-github.com/giantswarm/apiextensions/v3 v3.18.2-0.20210218082518-d335c0b129ac/go.mod h1:6KBexBTOZJ+amkorxw722t2HS57f+rf/8LeSSFfQNmo=
+github.com/giantswarm/apiextensions/v3 v3.18.2 h1:sWsrdgp6oaWnEgdNFk74kBUUkY+UmI9HvhNxtZcgqIE=
+github.com/giantswarm/apiextensions/v3 v3.18.2/go.mod h1:6KBexBTOZJ+amkorxw722t2HS57f+rf/8LeSSFfQNmo=
 github.com/giantswarm/app/v4 v4.0.0 h1:8PA0Hr6HRBbRS2KEWi5fSMq7rB4VdI2h0g9xI2ssLR4=
 github.com/giantswarm/app/v4 v4.0.0/go.mod h1:OiMkgrgxGtBNsTEHoF0hE9Sisn2onBxlc+dWHIBJPP4=
 github.com/giantswarm/backoff v0.2.0 h1:kdfAf83pZ/l8X0KiA2dJ2Wq19nS9hISijVn7ZRdFhfU=

--- a/go.sum
+++ b/go.sum
@@ -172,8 +172,6 @@ github.com/giantswarm/apiextensions/v3 v3.11.0/go.mod h1:f+dFUDLroK50aCGzvpqPw/j
 github.com/giantswarm/apiextensions/v3 v3.13.0 h1:Sqf/DZJhd4aMzCjrmUVD7xffRORpZSnC9dPPqjKG7Nc=
 github.com/giantswarm/apiextensions/v3 v3.13.0/go.mod h1:f+dFUDLroK50aCGzvpqPw/jCFCCgJqdEMf/xNSJBI+A=
 github.com/giantswarm/apiextensions/v3 v3.17.0/go.mod h1:N4SS083wjVR3GEL/pqWycva4yUtYrlU5lUKhRtZJ7EY=
-github.com/giantswarm/apiextensions/v3 v3.18.1 h1:vbGH0u9MyPIum2QGm+ehTGm/9B1Na5zVCrCV5BMxCjg=
-github.com/giantswarm/apiextensions/v3 v3.18.1/go.mod h1:N4SS083wjVR3GEL/pqWycva4yUtYrlU5lUKhRtZJ7EY=
 github.com/giantswarm/apiextensions/v3 v3.18.2-0.20210218082518-d335c0b129ac h1:joSQRJgGxRF72yvnsNuCfBNi8C4AA7ynBqBOdpV0zwo=
 github.com/giantswarm/apiextensions/v3 v3.18.2-0.20210218082518-d335c0b129ac/go.mod h1:6KBexBTOZJ+amkorxw722t2HS57f+rf/8LeSSFfQNmo=
 github.com/giantswarm/app/v4 v4.0.0 h1:8PA0Hr6HRBbRS2KEWi5fSMq7rB4VdI2h0g9xI2ssLR4=

--- a/service/controller/resource/statuscondition/create.go
+++ b/service/controller/resource/statuscondition/create.go
@@ -117,7 +117,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		r.logger.Debugf(ctx, "found %d MachineDeployments for tenant cluster", len(mdList.Items))
 	}
 
-	err = r.computeCreateClusterStatusConditions(ctx, cl, uc, nodes, cpList.Items, mdList.Items)
+	err = r.computeClusterStatusConditions(ctx, cl, uc, nodes, cpList.Items, mdList.Items)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -141,7 +141,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	return nil
 }
 
-func (r *Resource) computeCreateClusterStatusConditions(ctx context.Context, cl apiv1alpha2.Cluster, cr infrastructurev1alpha2.CommonClusterObject, nodes []corev1.Node, controlPlanes []infrastructurev1alpha2.G8sControlPlane, machineDeployments []apiv1alpha2.MachineDeployment) error {
+func (r *Resource) computeClusterStatusConditions(ctx context.Context, cl apiv1alpha2.Cluster, cr infrastructurev1alpha2.CommonClusterObject, nodes []corev1.Node, controlPlanes []infrastructurev1alpha2.G8sControlPlane, machineDeployments []apiv1alpha2.MachineDeployment) error {
 	var desiredVersion string
 	var nodesReady bool
 
@@ -158,10 +158,10 @@ func (r *Resource) computeCreateClusterStatusConditions(ctx context.Context, cl 
 		nodesReady = sameMasterCount && sameWorkerCount && sameVersion
 	}
 
-	return r.writeCreateClusterStatusConditions(ctx, cl, cr, nodesReady, desiredVersion)
+	return r.writeClusterStatusConditions(ctx, cl, cr, nodesReady, desiredVersion)
 }
 
-func (r *Resource) writeCreateClusterStatusConditions(ctx context.Context, cl apiv1alpha2.Cluster, cr infrastructurev1alpha2.CommonClusterObject, nodesReady bool, desiredVersion string) error {
+func (r *Resource) writeClusterStatusConditions(ctx context.Context, cl apiv1alpha2.Cluster, cr infrastructurev1alpha2.CommonClusterObject, nodesReady bool, desiredVersion string) error {
 	status := cr.GetCommonClusterStatus()
 	// After initialization the most likely implication is the tenant cluster
 	// being in a creation status. In case no other conditions are given and no

--- a/service/controller/resource/statuscondition/create.go
+++ b/service/controller/resource/statuscondition/create.go
@@ -142,23 +142,84 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 }
 
 func (r *Resource) computeCreateClusterStatusConditions(ctx context.Context, cl apiv1alpha2.Cluster, cr infrastructurev1alpha2.CommonClusterObject, nodes []corev1.Node, controlPlanes []infrastructurev1alpha2.G8sControlPlane, machineDeployments []apiv1alpha2.MachineDeployment) error {
-	componentVersions, err := r.releaseVersion.ComponentVersion(ctx, cr)
+	var desiredVersion string
+	var nodesReady bool
+
+	desiredVersion, err := r.getDesiredVersion(ctx, cr)
 	if err != nil {
 		return microerror.Mask(err)
 	}
-
-	providerOperator := fmt.Sprintf("%s-operator", r.provider)
-	providerOperatorVersionLabel := fmt.Sprintf("%s-operator.giantswarm.io/version", r.provider)
-
-	status := cr.GetCommonClusterStatus()
-
-	var currentVersion string
-	var desiredVersion string
 	{
-		currentVersion = status.LatestVersion()
-		desiredVersion = componentVersions[providerOperator]
+		providerOperatorVersionLabel := fmt.Sprintf("%s-operator.giantswarm.io/version", r.provider)
+		sameVersion := allNodesHaveVersion(nodes, desiredVersion, providerOperatorVersionLabel)
+		sameMasterCount := allMasterNodesReady(controlPlanes)
+		sameWorkerCount := allWorkerNodesReady(machineDeployments)
+
+		nodesReady = sameMasterCount && sameWorkerCount && sameVersion
 	}
 
+	return r.writeCreateClusterStatusConditions(ctx, cl, cr, nodesReady, desiredVersion)
+}
+
+func (r *Resource) writeCreateClusterStatusConditions(ctx context.Context, cl apiv1alpha2.Cluster, cr infrastructurev1alpha2.CommonClusterObject, nodesReady bool, desiredVersion string) error {
+	status := cr.GetCommonClusterStatus()
+	// After initialization the most likely implication is the tenant cluster
+	// being in a creation status. In case no other conditions are given and no
+	// versions are set, we set the tenant cluster status to a creating
+	// condition.
+	if computeCreatingCondition(status) {
+		status.Conditions = status.WithCreatingCondition()
+		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("setting %#q status condition", infrastructurev1alpha2.ClusterStatusConditionCreating))
+		r.event.Emit(ctx, &cl, "ClusterInCreation", fmt.Sprintf("cluster creation is in condition %s", infrastructurev1alpha2.ClusterStatusConditionCreating))
+	}
+
+	// Once the tenant cluster is created we set the according status condition so
+	// the cluster status reflects the transitioning from creating to created.
+	if computeCreatedCondition(status, nodesReady) {
+		status.Conditions = status.WithCreatedCondition()
+		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("setting %#q status condition", infrastructurev1alpha2.ClusterStatusConditionCreated))
+		r.event.Emit(ctx, &cl, "ClusterCreated", fmt.Sprintf("cluster is in condition %s", infrastructurev1alpha2.ClusterStatusConditionCreated))
+	}
+
+	// When we notice the current and the desired tenant cluster version differs,
+	// an update is about to be processed. So we set the status condition
+	// indicating the tenant cluster is updating now.
+	if computeUpdatingCondition(status, desiredVersion) {
+		status.Conditions = status.WithUpdatingCondition()
+		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("setting %#q status condition", infrastructurev1alpha2.ClusterStatusConditionUpdating))
+		r.event.Emit(ctx, &cl, "ClusterIsUpdating", fmt.Sprintf("cluster is in condition %s", infrastructurev1alpha2.ClusterStatusConditionUpdating))
+	}
+
+	// Set the status cluster condition to updated when an update successfully
+	// took place. Precondition for this is the tenant cluster is updating and all
+	// nodes being known and all nodes having the same versions.
+	if computeUpdatedCondition(status, nodesReady) {
+		status.Conditions = status.WithUpdatedCondition()
+		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("setting %#q status condition", infrastructurev1alpha2.ClusterStatusConditionUpdated))
+		r.event.Emit(ctx, &cl, "ClusterUpdated", fmt.Sprintf("cluster is in condition %s", infrastructurev1alpha2.ClusterStatusConditionUpdated))
+	}
+
+	// Check all node versions held by the cluster status and add the version the
+	// tenant cluster successfully migrated to, to the historical list of versions.
+	if computeVersionChange(status, nodesReady, desiredVersion) {
+		status.Versions = status.WithNewVersion(desiredVersion)
+		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("setting status versions with new version: %q", desiredVersion))
+		r.event.Emit(ctx, &cl, "ClusterVersionUpdated", fmt.Sprintf("cluster status set with new version: %q", desiredVersion))
+	}
+	cr.SetCommonClusterStatus(status)
+	return nil
+}
+
+func (r *Resource) getDesiredVersion(ctx context.Context, cr infrastructurev1alpha2.CommonClusterObject) (string, error) {
+	componentVersions, err := r.releaseVersion.ComponentVersion(ctx, cr)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+	providerOperator := fmt.Sprintf("%s-operator", r.provider)
+	return componentVersions[providerOperator], nil
+}
+
+func allMasterNodesReady(controlPlanes []infrastructurev1alpha2.G8sControlPlane) bool {
 	// Count total number of all masters and number of ready masters that
 	// belong to this cluster.
 	var desiredMasterReplicas int
@@ -172,7 +233,10 @@ func (r *Resource) computeCreateClusterStatusConditions(ctx context.Context, cl 
 			readyMasterReplicas += int(cp.Status.ReadyReplicas)
 		}
 	}
+	return readyMasterReplicas == desiredMasterReplicas
+}
 
+func allWorkerNodesReady(machineDeployments []apiv1alpha2.MachineDeployment) bool {
 	// Count total number of all workers and number of Ready workers that
 	// belong to this cluster.
 	var desiredWorkerReplicas int
@@ -186,90 +250,7 @@ func (r *Resource) computeCreateClusterStatusConditions(ctx context.Context, cl 
 			readyWorkerReplicas += int(md.Status.ReadyReplicas)
 		}
 	}
-
-	// After initialization the most likely implication is the tenant cluster
-	// being in a creation status. In case no other conditions are given and no
-	// versions are set, we set the tenant cluster status to a creating
-	// condition.
-	{
-		notCreating := !status.HasCreatingCondition()
-		conditionsEmpty := len(status.Conditions) == 0
-		versionsEmpty := len(status.Versions) == 0
-
-		if notCreating && conditionsEmpty && versionsEmpty {
-			status.Conditions = status.WithCreatingCondition()
-			r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("setting %#q status condition", infrastructurev1alpha2.ClusterStatusConditionCreating))
-			r.event.Emit(ctx, &cl, "ClusterInCreation", fmt.Sprintf("cluster creation is in condition %s", infrastructurev1alpha2.ClusterStatusConditionCreating))
-		}
-	}
-
-	// Once the tenant cluster is created we set the according status condition so
-	// the cluster status reflects the transitioning from creating to created.
-	{
-		isCreating := status.HasCreatingCondition()
-		notCreated := !status.HasCreatedCondition()
-		sameMasterCount := readyMasterReplicas == desiredMasterReplicas
-		sameWorkerCount := readyWorkerReplicas == desiredWorkerReplicas
-		sameVersion := allNodesHaveVersion(nodes, desiredVersion, providerOperatorVersionLabel)
-
-		if isCreating && notCreated && sameMasterCount && sameWorkerCount && sameVersion {
-			status.Conditions = status.WithCreatedCondition()
-			r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("setting %#q status condition", infrastructurev1alpha2.ClusterStatusConditionCreated))
-			r.event.Emit(ctx, &cl, "ClusterCreated", fmt.Sprintf("cluster is in condition %s", infrastructurev1alpha2.ClusterStatusConditionCreated))
-		}
-	}
-
-	// When we notice the current and the desired tenant cluster version differs,
-	// an update is about to be processed. So we set the status condition
-	// indicating the tenant cluster is updating now.
-	{
-		isCreated := status.HasCreatedCondition()
-		notUpdating := !status.HasUpdatingCondition()
-		versionDiffers := currentVersion != "" && currentVersion != desiredVersion
-
-		if isCreated && notUpdating && versionDiffers {
-			status.Conditions = status.WithUpdatingCondition()
-			r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("setting %#q status condition", infrastructurev1alpha2.ClusterStatusConditionUpdating))
-			r.event.Emit(ctx, &cl, "ClusterIsUpdating", fmt.Sprintf("cluster is in condition %s", infrastructurev1alpha2.ClusterStatusConditionUpdating))
-		}
-	}
-
-	// Set the status cluster condition to updated when an update successfully
-	// took place. Precondition for this is the tenant cluster is updating and all
-	// nodes being known and all nodes having the same versions.
-	{
-		isUpdating := status.HasUpdatingCondition()
-		notUpdated := !status.HasUpdatedCondition()
-		sameMasterCount := readyMasterReplicas != 0 && readyMasterReplicas == desiredMasterReplicas
-		sameWorkerCount := readyWorkerReplicas != 0 && readyWorkerReplicas == desiredWorkerReplicas
-		sameVersion := allNodesHaveVersion(nodes, desiredVersion, providerOperatorVersionLabel)
-
-		if isUpdating && notUpdated && sameMasterCount && sameWorkerCount && sameVersion {
-			status.Conditions = status.WithUpdatedCondition()
-			r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("setting %#q status condition", infrastructurev1alpha2.ClusterStatusConditionUpdated))
-			r.event.Emit(ctx, &cl, "ClusterUpdated", fmt.Sprintf("cluster is in condition %s", infrastructurev1alpha2.ClusterStatusConditionUpdated))
-		}
-	}
-
-	// Check all node versions held by the cluster status and add the version the
-	// tenant cluster successfully migrated to, to the historical list of versions.
-	{
-		hasTransitioned := status.HasCreatedCondition() || status.HasUpdatedCondition()
-		notSet := !status.HasVersion(desiredVersion)
-		sameMasterCount := readyMasterReplicas != 0 && readyMasterReplicas == desiredMasterReplicas
-		sameWorkerCount := readyWorkerReplicas != 0 && readyWorkerReplicas == desiredWorkerReplicas
-		sameVersion := allNodesHaveVersion(nodes, desiredVersion, providerOperatorVersionLabel)
-
-		if hasTransitioned && notSet && sameMasterCount && sameWorkerCount && sameVersion {
-			status.Versions = status.WithNewVersion(desiredVersion)
-			r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("setting status versions with new version: %q", desiredVersion))
-			r.event.Emit(ctx, &cl, "ClusterVersionUpdated", fmt.Sprintf("cluster status set with new version: %q", desiredVersion))
-		}
-	}
-
-	cr.SetCommonClusterStatus(status)
-
-	return nil
+	return readyWorkerReplicas == desiredWorkerReplicas
 }
 
 func allNodesHaveVersion(nodes []corev1.Node, version string, providerOperatorVersionLabel string) bool {
@@ -285,4 +266,42 @@ func allNodesHaveVersion(nodes []corev1.Node, version string, providerOperatorVe
 	}
 
 	return true
+}
+
+func computeCreatingCondition(status infrastructurev1alpha2.CommonClusterStatus) bool {
+	notCreating := !status.HasCreatingCondition()
+	conditionsEmpty := len(status.Conditions) == 0
+	versionsEmpty := len(status.Versions) == 0
+
+	return notCreating && conditionsEmpty && versionsEmpty
+}
+
+func computeCreatedCondition(status infrastructurev1alpha2.CommonClusterStatus, nodesReady bool) bool {
+	isCreating := status.HasCreatingCondition()
+	notCreated := !status.HasCreatedCondition()
+
+	return isCreating && notCreated && nodesReady
+}
+
+func computeUpdatingCondition(status infrastructurev1alpha2.CommonClusterStatus, desiredVersion string) bool {
+	currentVersion := status.LatestVersion()
+	isCreated := status.HasCreatedCondition()
+	notUpdating := !status.HasUpdatingCondition()
+	versionDiffers := currentVersion != "" && currentVersion != desiredVersion
+
+	return isCreated && notUpdating && versionDiffers
+}
+
+func computeUpdatedCondition(status infrastructurev1alpha2.CommonClusterStatus, nodesReady bool) bool {
+	isUpdating := status.HasUpdatingCondition()
+	notUpdated := !status.HasUpdatedCondition()
+
+	return isUpdating && notUpdated && nodesReady
+}
+
+func computeVersionChange(status infrastructurev1alpha2.CommonClusterStatus, nodesReady bool, desiredVersion string) bool {
+	hasTransitioned := status.HasCreatedCondition() || status.HasUpdatedCondition()
+	notSet := !status.HasVersion(desiredVersion)
+
+	return hasTransitioned && notSet && nodesReady
 }

--- a/service/controller/resource/statuscondition/create.go
+++ b/service/controller/resource/statuscondition/create.go
@@ -286,22 +286,24 @@ func computeCreatedCondition(status infrastructurev1alpha2.CommonClusterStatus, 
 func computeUpdatingCondition(status infrastructurev1alpha2.CommonClusterStatus, desiredVersion string) bool {
 	currentVersion := status.LatestVersion()
 	isCreated := status.HasCreatedCondition()
-	notUpdating := !status.HasUpdatingCondition()
+	notUpdating := status.LatestCondition() != infrastructurev1alpha2.ClusterStatusConditionUpdating
 	versionDiffers := currentVersion != "" && currentVersion != desiredVersion
 
 	return isCreated && notUpdating && versionDiffers
 }
 
 func computeUpdatedCondition(status infrastructurev1alpha2.CommonClusterStatus, nodesReady bool) bool {
-	isUpdating := status.HasUpdatingCondition()
-	notUpdated := !status.HasUpdatedCondition()
+	isUpdating := status.LatestCondition() == infrastructurev1alpha2.ClusterStatusConditionUpdating
+	notUpdated := status.LatestCondition() != infrastructurev1alpha2.ClusterStatusConditionUpdated
 
 	return isUpdating && notUpdated && nodesReady
 }
 
 func computeVersionChange(status infrastructurev1alpha2.CommonClusterStatus, nodesReady bool, desiredVersion string) bool {
-	hasTransitioned := status.HasCreatedCondition() || status.HasUpdatedCondition()
-	notSet := !status.HasVersion(desiredVersion)
+	isCreated := status.LatestCondition() == infrastructurev1alpha2.ClusterStatusConditionCreated
+	isUpdated := status.LatestCondition() == infrastructurev1alpha2.ClusterStatusConditionUpdated
+	hasTransitioned := isCreated || isUpdated
+	notSet := status.LatestVersion() != desiredVersion
 
 	return hasTransitioned && notSet && nodesReady
 }

--- a/service/controller/resource/statuscondition/create_test.go
+++ b/service/controller/resource/statuscondition/create_test.go
@@ -197,8 +197,6 @@ func TestComputeClusterStatusConditions(t *testing.T) {
 			expectVersion:   "8.7.6",
 		},
 		// We rolled back
-		// TODO: when we roll back, the version does currently not appear in the history again.
-		// this is because of how the function withVersion() in apiextensions works
 		{
 			name: "case 10",
 
@@ -217,7 +215,7 @@ func TestComputeClusterStatusConditions(t *testing.T) {
 			operatorVersion: "8.7.5",
 
 			expectCondition: "Updated",
-			expectVersion:   "8.7.6",
+			expectVersion:   "8.7.5",
 		},
 	}
 

--- a/service/controller/resource/statuscondition/create_test.go
+++ b/service/controller/resource/statuscondition/create_test.go
@@ -24,7 +24,7 @@ type nodeConfig struct {
 	readyReplicas int
 }
 
-func TestComputeCreateClusterStatusConditions(t *testing.T) {
+func TestComputeClusterStatusConditions(t *testing.T) {
 	testCases := []struct {
 		name string
 
@@ -283,7 +283,7 @@ func TestComputeCreateClusterStatusConditions(t *testing.T) {
 				provider:                   "aws",
 			}
 
-			err = r.computeCreateClusterStatusConditions(ctx, cl, &cluster, nodes, cps, mds)
+			err = r.computeClusterStatusConditions(ctx, cl, &cluster, nodes, cps, mds)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -315,5 +315,423 @@ func newCommonClusterObjectFunc(provider string) func() infrastructurev1alpha2.C
 	// Deal with different providers in here once they reach Cluster API.
 	return func() infrastructurev1alpha2.CommonClusterObject {
 		return new(infrastructurev1alpha2.AWSCluster)
+	}
+}
+
+func TestComputeCreatingCondition(t *testing.T) {
+	testCases := []struct {
+		name string
+
+		status         infrastructurev1alpha2.CommonClusterStatus
+		expectedResult bool
+	}{
+		// There are no previous versions or conditions in the status
+		{
+			name: "case 0",
+
+			status: infrastructurev1alpha2.CommonClusterStatus{
+				Conditions: []infrastructurev1alpha2.CommonClusterStatusCondition{},
+				Versions:   []infrastructurev1alpha2.CommonClusterStatusVersion{},
+			},
+			expectedResult: true,
+		},
+		// There are previous versions in the status
+		{
+			name: "case 1",
+
+			status: infrastructurev1alpha2.CommonClusterStatus{
+				Conditions: []infrastructurev1alpha2.CommonClusterStatusCondition{},
+				Versions: []infrastructurev1alpha2.CommonClusterStatusVersion{
+					unittest.GetVersion(5, "8.7.6"),
+				},
+			},
+			expectedResult: false,
+		},
+		// There are previous conditions in the status
+		{
+			name: "case 2",
+
+			status: infrastructurev1alpha2.CommonClusterStatus{
+				Conditions: []infrastructurev1alpha2.CommonClusterStatusCondition{
+					unittest.GetCreatingCondition(90),
+				},
+				Versions: []infrastructurev1alpha2.CommonClusterStatusVersion{},
+			},
+			expectedResult: false,
+		},
+		// There are previous conditions and versions in the status
+		{
+			name: "case 3",
+
+			status: infrastructurev1alpha2.CommonClusterStatus{
+				Conditions: []infrastructurev1alpha2.CommonClusterStatusCondition{
+					unittest.GetCreatingCondition(90),
+				},
+				Versions: []infrastructurev1alpha2.CommonClusterStatusVersion{
+					unittest.GetVersion(60, "8.7.6"),
+				},
+			},
+			expectedResult: false,
+		},
+		// There are previous conditions and versions in the status
+		{
+			name: "case 4",
+
+			status: infrastructurev1alpha2.CommonClusterStatus{
+				Conditions: []infrastructurev1alpha2.CommonClusterStatusCondition{
+					unittest.GetUpdatedCondition(10),
+					unittest.GetUpdatingCondition(30),
+					unittest.GetCreatedCondition(60),
+					unittest.GetCreatingCondition(90),
+				},
+				Versions: []infrastructurev1alpha2.CommonClusterStatusVersion{
+					unittest.GetVersion(60, "8.7.5"),
+					unittest.GetVersion(60, "8.7.6"),
+				},
+			},
+			expectedResult: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			result := computeCreatingCondition(tc.status)
+			if result != tc.expectedResult {
+				t.Fatalf("expected %v, got %v", tc.expectedResult, result)
+			}
+		})
+	}
+}
+func TestComputeCreatedCondition(t *testing.T) {
+	testCases := []struct {
+		name string
+
+		status     infrastructurev1alpha2.CommonClusterStatus
+		nodesReady bool
+
+		expectedResult bool
+	}{
+		// the cluster is creating and nodes are ready
+		{
+			name: "case 0",
+
+			status: infrastructurev1alpha2.CommonClusterStatus{
+				Conditions: []infrastructurev1alpha2.CommonClusterStatusCondition{
+					unittest.GetCreatingCondition(90),
+				},
+			},
+			nodesReady: true,
+
+			expectedResult: true,
+		},
+		// the cluster is creating but nodes are not ready
+		{
+			name: "case 1",
+
+			status: infrastructurev1alpha2.CommonClusterStatus{
+				Conditions: []infrastructurev1alpha2.CommonClusterStatusCondition{
+					unittest.GetCreatingCondition(90),
+				},
+			},
+			nodesReady: false,
+
+			expectedResult: false,
+		},
+		// The cluster already has a created condition
+		{
+			name: "case 2",
+
+			status: infrastructurev1alpha2.CommonClusterStatus{
+				Conditions: []infrastructurev1alpha2.CommonClusterStatusCondition{
+					unittest.GetCreatedCondition(60),
+					unittest.GetCreatingCondition(90),
+				},
+			},
+			nodesReady: true,
+
+			expectedResult: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			result := computeCreatedCondition(tc.status, tc.nodesReady)
+			if result != tc.expectedResult {
+				t.Fatalf("expected %v, got %v", tc.expectedResult, result)
+			}
+		})
+	}
+}
+func TestComputeUpdatingCondition(t *testing.T) {
+	testCases := []struct {
+		name string
+
+		status         infrastructurev1alpha2.CommonClusterStatus
+		desiredVersion string
+
+		expectedResult bool
+	}{
+		// the cluster is created and not in updating state but the desired version differs from the current version
+		{
+			name: "case 0",
+
+			status: infrastructurev1alpha2.CommonClusterStatus{
+				Conditions: []infrastructurev1alpha2.CommonClusterStatusCondition{
+					unittest.GetCreatedCondition(60),
+					unittest.GetCreatingCondition(90),
+				},
+				Versions: []infrastructurev1alpha2.CommonClusterStatusVersion{
+					unittest.GetVersion(60, "8.7.5"),
+				},
+			},
+			desiredVersion: "8.7.6",
+
+			expectedResult: true,
+		},
+		// the cluster does not have a created condition
+		{
+			name: "case 1",
+
+			status: infrastructurev1alpha2.CommonClusterStatus{
+				Conditions: []infrastructurev1alpha2.CommonClusterStatusCondition{
+					unittest.GetCreatingCondition(90),
+				},
+				Versions: []infrastructurev1alpha2.CommonClusterStatusVersion{
+					unittest.GetVersion(60, "8.7.5"),
+				},
+			},
+			desiredVersion: "8.7.6",
+
+			expectedResult: false,
+		},
+		// the cluster is already updating
+		{
+			name: "case 2",
+
+			status: infrastructurev1alpha2.CommonClusterStatus{
+				Conditions: []infrastructurev1alpha2.CommonClusterStatusCondition{
+					unittest.GetUpdatingCondition(30),
+					unittest.GetCreatedCondition(60),
+					unittest.GetCreatingCondition(90),
+				},
+				Versions: []infrastructurev1alpha2.CommonClusterStatusVersion{
+					unittest.GetVersion(60, "8.7.5"),
+				},
+			},
+			desiredVersion: "8.7.6",
+
+			expectedResult: false,
+		},
+		// the version is already changed
+		{
+			name: "case 3",
+
+			status: infrastructurev1alpha2.CommonClusterStatus{
+				Conditions: []infrastructurev1alpha2.CommonClusterStatusCondition{
+					unittest.GetCreatedCondition(60),
+					unittest.GetCreatingCondition(90),
+				},
+				Versions: []infrastructurev1alpha2.CommonClusterStatusVersion{
+					unittest.GetVersion(60, "8.7.6"),
+				},
+			},
+			desiredVersion: "8.7.6",
+
+			expectedResult: false,
+		},
+		// the version is already present and cluster is already updating
+		{
+			name: "case 4",
+
+			status: infrastructurev1alpha2.CommonClusterStatus{
+				Conditions: []infrastructurev1alpha2.CommonClusterStatusCondition{
+					unittest.GetUpdatingCondition(30),
+					unittest.GetCreatedCondition(60),
+					unittest.GetCreatingCondition(90),
+				},
+				Versions: []infrastructurev1alpha2.CommonClusterStatusVersion{
+					unittest.GetVersion(60, "8.7.5"),
+					unittest.GetVersion(60, "8.7.6"),
+				},
+			},
+			desiredVersion: "8.7.6",
+
+			expectedResult: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			result := computeUpdatingCondition(tc.status, tc.desiredVersion)
+			if result != tc.expectedResult {
+				t.Fatalf("expected %v, got %v", tc.expectedResult, result)
+			}
+		})
+	}
+}
+func TestComputeUpdatedCondition(t *testing.T) {
+	testCases := []struct {
+		name string
+
+		status     infrastructurev1alpha2.CommonClusterStatus
+		nodesReady bool
+
+		expectedResult bool
+	}{
+		// the cluster is updating and nodes are ready
+		// TODO this should also work a second time
+		{
+			name: "case 0",
+
+			status: infrastructurev1alpha2.CommonClusterStatus{
+				Conditions: []infrastructurev1alpha2.CommonClusterStatusCondition{
+					unittest.GetUpdatingCondition(30),
+					unittest.GetCreatedCondition(60),
+					unittest.GetCreatingCondition(90),
+				},
+			},
+			nodesReady: true,
+
+			expectedResult: true,
+		},
+		// the cluster is updating and nodes are not ready
+		{
+			name: "case 1",
+
+			status: infrastructurev1alpha2.CommonClusterStatus{
+				Conditions: []infrastructurev1alpha2.CommonClusterStatusCondition{
+					unittest.GetUpdatingCondition(30),
+					unittest.GetCreatedCondition(60),
+					unittest.GetCreatingCondition(90),
+				},
+			},
+			nodesReady: false,
+
+			expectedResult: false,
+		},
+		// the cluster is already updated
+		{
+			name: "case 1",
+
+			status: infrastructurev1alpha2.CommonClusterStatus{
+				Conditions: []infrastructurev1alpha2.CommonClusterStatusCondition{
+					unittest.GetUpdatedCondition(10),
+					unittest.GetUpdatingCondition(30),
+					unittest.GetCreatedCondition(60),
+					unittest.GetCreatingCondition(90),
+				},
+			},
+			nodesReady: true,
+
+			expectedResult: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			result := computeUpdatedCondition(tc.status, tc.nodesReady)
+			if result != tc.expectedResult {
+				t.Fatalf("expected %v, got %v", tc.expectedResult, result)
+			}
+		})
+	}
+}
+
+func TestComputeVersionChange(t *testing.T) {
+	testCases := []struct {
+		name string
+
+		status         infrastructurev1alpha2.CommonClusterStatus
+		nodesReady     bool
+		desiredVersion string
+
+		expectedResult bool
+	}{
+		// the cluster has transitioned, nodes are ready but the version is not set yet
+		{
+			name: "case 0",
+
+			status: infrastructurev1alpha2.CommonClusterStatus{
+				Conditions: []infrastructurev1alpha2.CommonClusterStatusCondition{
+					unittest.GetUpdatedCondition(10),
+					unittest.GetUpdatingCondition(30),
+					unittest.GetCreatedCondition(60),
+					unittest.GetCreatingCondition(90),
+				},
+				Versions: []infrastructurev1alpha2.CommonClusterStatusVersion{
+					unittest.GetVersion(60, "8.7.5"),
+				},
+			},
+			nodesReady:     true,
+			desiredVersion: "8.7.6",
+
+			expectedResult: true,
+		},
+		// the cluster has not transitioned yet
+		// TODO this should also work for updates
+		{
+			name: "case 1",
+
+			status: infrastructurev1alpha2.CommonClusterStatus{
+				Conditions: []infrastructurev1alpha2.CommonClusterStatusCondition{
+					unittest.GetCreatingCondition(90),
+				},
+				Versions: []infrastructurev1alpha2.CommonClusterStatusVersion{},
+			},
+			nodesReady:     true,
+			desiredVersion: "8.7.5",
+
+			expectedResult: false,
+		},
+		// the nodes are not ready yet
+		{
+			name: "case 2",
+
+			status: infrastructurev1alpha2.CommonClusterStatus{
+				Conditions: []infrastructurev1alpha2.CommonClusterStatusCondition{
+					unittest.GetUpdatedCondition(10),
+					unittest.GetUpdatingCondition(30),
+					unittest.GetCreatedCondition(60),
+					unittest.GetCreatingCondition(90),
+				},
+				Versions: []infrastructurev1alpha2.CommonClusterStatusVersion{
+					unittest.GetVersion(60, "8.7.5"),
+				},
+			},
+			nodesReady:     false,
+			desiredVersion: "8.7.6",
+
+			expectedResult: false,
+		},
+		// the version is already set
+		{
+			name: "case 3",
+
+			status: infrastructurev1alpha2.CommonClusterStatus{
+				Conditions: []infrastructurev1alpha2.CommonClusterStatusCondition{
+					unittest.GetUpdatedCondition(10),
+					unittest.GetUpdatingCondition(30),
+					unittest.GetCreatedCondition(60),
+					unittest.GetCreatingCondition(90),
+				},
+				Versions: []infrastructurev1alpha2.CommonClusterStatusVersion{
+					unittest.GetVersion(60, "8.7.5"),
+					unittest.GetVersion(60, "8.7.6"),
+				},
+			},
+			nodesReady:     true,
+			desiredVersion: "8.7.6",
+
+			expectedResult: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			result := computeVersionChange(tc.status, tc.nodesReady, tc.desiredVersion)
+			if result != tc.expectedResult {
+				t.Fatalf("expected %v, got %v", tc.expectedResult, result)
+			}
+		})
 	}
 }

--- a/service/internal/unittest/default_cluster.go
+++ b/service/internal/unittest/default_cluster.go
@@ -72,3 +72,40 @@ func DefaultCluster() infrastructurev1alpha2.AWSCluster {
 
 	return cr
 }
+
+func GetCreatingCondition(minutesAgo time.Duration) infrastructurev1alpha2.CommonClusterStatusCondition {
+	return infrastructurev1alpha2.CommonClusterStatusCondition{
+		LastTransitionTime: metav1.NewTime(time.Now().Add(-minutesAgo * time.Minute)),
+		Condition:          infrastructurev1alpha2.ClusterStatusConditionCreating,
+	}
+}
+func GetCreatedCondition(minutesAgo time.Duration) infrastructurev1alpha2.CommonClusterStatusCondition {
+	return infrastructurev1alpha2.CommonClusterStatusCondition{
+		LastTransitionTime: metav1.NewTime(time.Now().Add(-minutesAgo * time.Minute)),
+		Condition:          infrastructurev1alpha2.ClusterStatusConditionCreated,
+	}
+}
+func GetDeletedCondition(minutesAgo time.Duration) infrastructurev1alpha2.CommonClusterStatusCondition {
+	return infrastructurev1alpha2.CommonClusterStatusCondition{
+		LastTransitionTime: metav1.NewTime(time.Now().Add(-minutesAgo * time.Minute)),
+		Condition:          infrastructurev1alpha2.ClusterStatusConditionDeleting,
+	}
+}
+func GetDeletingCondition(minutesAgo time.Duration) infrastructurev1alpha2.CommonClusterStatusCondition {
+	return infrastructurev1alpha2.CommonClusterStatusCondition{
+		LastTransitionTime: metav1.NewTime(time.Now().Add(-minutesAgo * time.Minute)),
+		Condition:          infrastructurev1alpha2.ClusterStatusConditionDeleted,
+	}
+}
+func GetUpdatingCondition(minutesAgo time.Duration) infrastructurev1alpha2.CommonClusterStatusCondition {
+	return infrastructurev1alpha2.CommonClusterStatusCondition{
+		LastTransitionTime: metav1.NewTime(time.Now().Add(-minutesAgo * time.Minute)),
+		Condition:          infrastructurev1alpha2.ClusterStatusConditionUpdating,
+	}
+}
+func GetUpdatedCondition(minutesAgo time.Duration) infrastructurev1alpha2.CommonClusterStatusCondition {
+	return infrastructurev1alpha2.CommonClusterStatusCondition{
+		LastTransitionTime: metav1.NewTime(time.Now().Add(-minutesAgo * time.Minute)),
+		Condition:          infrastructurev1alpha2.ClusterStatusConditionUpdated,
+	}
+}

--- a/service/internal/unittest/default_cluster.go
+++ b/service/internal/unittest/default_cluster.go
@@ -109,3 +109,9 @@ func GetUpdatedCondition(minutesAgo time.Duration) infrastructurev1alpha2.Common
 		Condition:          infrastructurev1alpha2.ClusterStatusConditionUpdated,
 	}
 }
+func GetVersion(minutesAgo time.Duration, version string) infrastructurev1alpha2.CommonClusterStatusVersion {
+	return infrastructurev1alpha2.CommonClusterStatusVersion{
+		LastTransitionTime: metav1.NewTime(time.Now().Add(-minutesAgo * time.Minute)),
+		Version:            version,
+	}
+}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/15468

This adds a unit test for `computeCreateClusterStatusConditions`. We can specify the condition and version history of the cluster to see how the conditions are set in different scenarios.

## Checklist

- [ ] Update changelog in CHANGELOG.md.
