### PR TITLE
Don't add VersionBundle to new CertConfigs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
-
 ## [Unreleased]
+
+### Removed
+
+- Do not add `VersionBundle` to new `CertConfig` specs (`CertConfig`s are now versioned using a label).
 
 ## [3.5.1] - 2021-01-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Do not add `VersionBundle` to new `CertConfig` specs (`CertConfig`s are now versioned using a label).
+- Do not add `VersionBundle` to new `CertConfig` specs (`CertConfig`s are now versioned using a label). **This change requires using `cert-operator` 1.0.0 or later.**
 
 ## [3.5.1] - 2021-01-28
 

--- a/service/controller/resource/certconfig/desired.go
+++ b/service/controller/resource/certconfig/desired.go
@@ -109,9 +109,6 @@ func newCertConfig(certOperatorVersion string, cr apiv1alpha2.Cluster, cert core
 		},
 		Spec: corev1alpha1.CertConfigSpec{
 			Cert: cert,
-			VersionBundle: corev1alpha1.CertConfigSpecVersionBundle{
-				Version: certOperatorVersion,
-			},
 		},
 	}
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14205 and https://github.com/giantswarm/cert-operator/pull/364.

`cert-operator` now reconciles CertConfigs based on their `cert-operator.giantswarm.io/version` label, but legacy operators will still attempt to reconcile based on the `VersionBundle` version. This removes setting the VersionBundle so that it is not inadvertently set to a value which would be reconciled by an old `cert-operator`.

After this PR, a release using this `cluster-operator` _must_ also use `cert-operator` v1.0.0 or later

## Checklist

- [x] Update changelog in CHANGELOG.md.
