### PR TITLE
Extend release component to return catalog as well as version

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA      = "n/a"
 	name        = "cluster-operator"
 	source      = "https://github.com/giantswarm/cluster-operator"
-	version     = "3.5.2-dev"
+	version     = "3.5.2-dev-ross"
 )
 
 func Description() string {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA      = "n/a"
 	name        = "cluster-operator"
 	source      = "https://github.com/giantswarm/cluster-operator"
-	version     = "3.5.2-dev-ross"
+	version     = "3.5.2-dev"
 )
 
 func Description() string {

--- a/service/controller/resource/app/desired.go
+++ b/service/controller/resource/app/desired.go
@@ -61,7 +61,12 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*g8s
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
-	appOperatorVersion := componentVersions[releaseversion.AppOperator]
+
+	appOperatorComponent := componentVersions[releaseversion.AppOperator]
+	appOperatorVersion := appOperatorComponent.Version
+	if appOperatorVersion == "" {
+		return nil, microerror.Maskf(notFoundError, "%#q component version not found", releaseversion.AppOperator)
+	}
 
 	for _, appSpec := range appSpecs {
 		userConfig := newUserConfig(cr, appSpec, configMaps, secrets)

--- a/service/controller/resource/app/error.go
+++ b/service/controller/resource/app/error.go
@@ -12,3 +12,12 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfigError(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}

--- a/service/controller/resource/appversionlabel/create.go
+++ b/service/controller/resource/appversionlabel/create.go
@@ -49,7 +49,12 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			if err != nil {
 				return microerror.Mask(err)
 			}
-			appOperatorVersion := componentVersions[releaseversion.AppOperator]
+
+			appOperatorComponent := componentVersions[releaseversion.AppOperator]
+			appOperatorVersion := appOperatorComponent.Version
+			if appOperatorVersion == "" {
+				return microerror.Maskf(notFoundError, "app-operator component version not found")
+			}
 
 			r.logger.Debugf(ctx, "updating version label for optional apps in tenant cluster %#q", key.ClusterID(&cr))
 

--- a/service/controller/resource/appversionlabel/error.go
+++ b/service/controller/resource/appversionlabel/error.go
@@ -10,3 +10,12 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}

--- a/service/controller/resource/certconfig/desired.go
+++ b/service/controller/resource/certconfig/desired.go
@@ -60,7 +60,12 @@ func (r *Resource) getDesiredState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
-	certOperatorVersion := componentVersions[releaseversion.CertOperator]
+	certOperatorComponent := componentVersions[releaseversion.CertOperator]
+	certOperatorVersion := certOperatorComponent.Version
+	if certOperatorVersion == "" {
+		return nil, microerror.Maskf(notFoundError, "cert-operator component version not found")
+	}
+
 	var certConfigs []*corev1alpha1.CertConfig
 	{
 		certConfigs = append(certConfigs, newCertConfig(certOperatorVersion, cr, r.newSpecForAPI(ctx, bd, cr)))

--- a/service/controller/resource/certconfig/desired.go
+++ b/service/controller/resource/certconfig/desired.go
@@ -63,7 +63,7 @@ func (r *Resource) getDesiredState(ctx context.Context, obj interface{}) (interf
 	certOperatorComponent := componentVersions[releaseversion.CertOperator]
 	certOperatorVersion := certOperatorComponent.Version
 	if certOperatorVersion == "" {
-		return nil, microerror.Maskf(notFoundError, "cert-operator component version not found")
+		return nil, microerror.Maskf(notFoundError, "%#q component version not found", releaseversion.CertOperator)
 	}
 
 	var certConfigs []*corev1alpha1.CertConfig

--- a/service/controller/resource/statuscondition/create.go
+++ b/service/controller/resource/statuscondition/create.go
@@ -156,7 +156,12 @@ func (r *Resource) computeCreateClusterStatusConditions(ctx context.Context, cl 
 	var desiredVersion string
 	{
 		currentVersion = status.LatestVersion()
-		desiredVersion = componentVersions[providerOperator]
+
+		providerComponent := componentVersions[providerOperator]
+		desiredVersion = providerComponent.Version
+		if desiredVersion == "" {
+			return microerror.Maskf(notFoundError, "component version not found for %#q", providerOperator)
+		}
 	}
 
 	// Count total number of all masters and number of ready masters that

--- a/service/controller/resource/statuscondition/error.go
+++ b/service/controller/resource/statuscondition/error.go
@@ -12,3 +12,12 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}

--- a/service/controller/resource/updateinfrarefs/create.go
+++ b/service/controller/resource/updateinfrarefs/create.go
@@ -50,8 +50,15 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	// Syncing the provider operator version label, e.g. for aws-operator,
 	// kvm-operator or the like.
 	{
+		o := fmt.Sprintf("%s-operator", r.provider)
 		l := fmt.Sprintf("%s-operator.giantswarm.io/version", r.provider)
-		d := componentVersions[fmt.Sprintf("%s-operator", r.provider)]
+		cv := componentVersions[o]
+
+		d := cv.Version
+		if d == "" {
+			return microerror.Maskf(notFoundError, "component version not found for %#q", o)
+		}
+
 		c, ok := ir.GetLabels()[l]
 		if ok && d != "" && d != c {
 			labels := ir.GetLabels()

--- a/service/controller/resource/updateinfrarefs/error.go
+++ b/service/controller/resource/updateinfrarefs/error.go
@@ -12,3 +12,12 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}

--- a/service/internal/releaseversion/release_version.go
+++ b/service/internal/releaseversion/release_version.go
@@ -58,7 +58,7 @@ func (rv *ReleaseVersion) Apps(ctx context.Context, obj interface{}) (map[string
 	return apps, nil
 }
 
-func (rv *ReleaseVersion) ComponentVersion(ctx context.Context, obj interface{}) (map[string]string, error) {
+func (rv *ReleaseVersion) ComponentVersion(ctx context.Context, obj interface{}) (map[string]ReleaseComponent, error) {
 	cr, err := meta.Accessor(obj)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -68,9 +68,12 @@ func (rv *ReleaseVersion) ComponentVersion(ctx context.Context, obj interface{})
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
-	components := make(map[string]string, len(release.Spec.Components))
+	components := make(map[string]ReleaseComponent, len(release.Spec.Components))
 	for _, v := range release.Spec.Components {
-		components[v.Name] = v.Version
+		components[v.Name] = ReleaseComponent{
+			Catalog: v.Catalog,
+			Version: v.Version,
+		}
 	}
 	return components, nil
 }

--- a/service/internal/releaseversion/spec.go
+++ b/service/internal/releaseversion/spec.go
@@ -15,12 +15,19 @@ type Interface interface {
 	// AppVersion provides the version of each app in a release.
 	Apps(ctx context.Context, obj interface{}) (map[string]ReleaseApp, error)
 	// ComponentVersion provides the version of each component in a release.
-	ComponentVersion(ctx context.Context, obj interface{}) (map[string]string, error)
+	ComponentVersion(ctx context.Context, obj interface{}) (map[string]ReleaseComponent, error)
 }
 
 type ReleaseApp struct {
 	// Catalog of the app.
 	Catalog string `json:"catalog"`
 	// Version of the app.
+	Version string `json:"version"`
+}
+
+type ReleaseComponent struct {
+	// Catalog of the component.
+	Catalog string `json:"catalog"`
+	// Version of the component.
 	Version string `json:"version"`
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14163

This is prep for cluster-operator creating an app-operator app CR per cluster.

Currently for components we just return the version. This extends the internal resource to also return the catalog. So we can test app-operator via editing the release CR.


