### PR TITLE
Bump versions in project.go after 0.24.0 release

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,12 +1,12 @@
 package project
 
 var (
-	bundleVersion = "0.23.23-dev"
+	bundleVersion = "0.24.1-dev"
 	description   = "The cluster-operator manages Kubernetes tenant cluster resources."
 	gitSHA        = "n/a"
 	name          = "cluster-operator"
 	source        = "https://github.com/giantswarm/cluster-operator"
-	version       = "0.24.0"
+	version       = "0.24.1-dev"
 )
 
 func BundleVersion() string {


### PR DESCRIPTION
The workflow to do this automatically failed, so bumping the version manually
https://github.com/giantswarm/cluster-operator/runs/1960962417?check_suite_focus=true

## Checklist

- [ ] Update changelog in CHANGELOG.md.
