### PR TITLE
Set both versions to 0.24.1 for new release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Align version bundle version and project version.
+
 ## [0.24.0] - 2021-02-23
 
 ### Changed

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,12 +1,12 @@
 package project
 
 var (
-	bundleVersion = "0.24.1-dev"
+	bundleVersion = "0.24.1"
 	description   = "The cluster-operator manages Kubernetes tenant cluster resources."
 	gitSHA        = "n/a"
 	name          = "cluster-operator"
 	source        = "https://github.com/giantswarm/cluster-operator"
-	version       = "0.24.1-dev"
+	version       = "0.24.1"
 )
 
 func BundleVersion() string {


### PR DESCRIPTION
Release automation does not handle the `bundleVersion` field, so it was not bumped in https://github.com/giantswarm/cluster-operator/pull/1343
## Checklist

- [x] Update changelog in CHANGELOG.md.
