### PR TITLE
Add AllowedLabels to clusterconfigmap resource to prevent unnecessary updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add `AllowedLabels` to clusterconfigmap resource to prevent unnecessary updates.
+
 ## [3.7.0] - 2021-03-15
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/giantswarm/microerror v0.3.0
 	github.com/giantswarm/microkit v0.2.2
 	github.com/giantswarm/micrologger v0.5.0
-	github.com/giantswarm/operatorkit/v4 v4.2.1-0.20210316110728-641eaef56b35
+	github.com/giantswarm/operatorkit/v4 v4.2.1-0.20210316115038-eb52dc70ae50
 	github.com/giantswarm/resource/v2 v2.3.0
 	github.com/giantswarm/tenantcluster/v3 v3.0.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/giantswarm/microerror v0.3.0
 	github.com/giantswarm/microkit v0.2.2
 	github.com/giantswarm/micrologger v0.5.0
-	github.com/giantswarm/operatorkit/v4 v4.2.0
+	github.com/giantswarm/operatorkit/v4 v4.2.1-0.20210316102702-8d1e229c0043
 	github.com/giantswarm/resource/v2 v2.3.0
 	github.com/giantswarm/tenantcluster/v3 v3.0.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/giantswarm/microerror v0.3.0
 	github.com/giantswarm/microkit v0.2.2
 	github.com/giantswarm/micrologger v0.5.0
-	github.com/giantswarm/operatorkit/v4 v4.2.1-0.20210316120339-c8e724abc3af
+	github.com/giantswarm/operatorkit/v4 v4.3.0
 	github.com/giantswarm/resource/v2 v2.3.0
 	github.com/giantswarm/tenantcluster/v3 v3.0.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/giantswarm/microerror v0.3.0
 	github.com/giantswarm/microkit v0.2.2
 	github.com/giantswarm/micrologger v0.5.0
-	github.com/giantswarm/operatorkit/v4 v4.2.1-0.20210316102702-8d1e229c0043
+	github.com/giantswarm/operatorkit/v4 v4.2.1-0.20210316110728-641eaef56b35
 	github.com/giantswarm/resource/v2 v2.3.0
 	github.com/giantswarm/tenantcluster/v3 v3.0.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/giantswarm/microerror v0.3.0
 	github.com/giantswarm/microkit v0.2.2
 	github.com/giantswarm/micrologger v0.5.0
-	github.com/giantswarm/operatorkit/v4 v4.2.1-0.20210316115038-eb52dc70ae50
+	github.com/giantswarm/operatorkit/v4 v4.2.1-0.20210316120339-c8e724abc3af
 	github.com/giantswarm/resource/v2 v2.3.0
 	github.com/giantswarm/tenantcluster/v3 v3.0.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -210,8 +210,8 @@ github.com/giantswarm/micrologger v0.4.0/go.mod h1:xsD5laBXORMy/P34IHZMK0y/D1gTk
 github.com/giantswarm/micrologger v0.5.0 h1:/f2knkyf4bZw3L5F48R7VENiEKPb3Sjnzrg46+Ja5vk=
 github.com/giantswarm/micrologger v0.5.0/go.mod h1:J/jbt7A8eixqE40yq4JY8Hdbs/qeboe2FjHlq05UWjA=
 github.com/giantswarm/operatorkit/v4 v4.0.0/go.mod h1:9VLDXCofhooOPbRt3XCZQmMZJ0tW7X3x7G/2Sz3kb5o=
-github.com/giantswarm/operatorkit/v4 v4.2.1-0.20210316115038-eb52dc70ae50 h1:RelGFDSbBBNvVlP8O4Qzt8ZY5HYhw/lGCqpqdLDmwX8=
-github.com/giantswarm/operatorkit/v4 v4.2.1-0.20210316115038-eb52dc70ae50/go.mod h1:GawNk6JMw6fE7DnPof34SV1prRjiTToNMLorQzZFlJc=
+github.com/giantswarm/operatorkit/v4 v4.2.1-0.20210316120339-c8e724abc3af h1:F/FJ3JjCY8gCjIDFHRmdKVy1T1ah9KXR/qZ+3dErY94=
+github.com/giantswarm/operatorkit/v4 v4.2.1-0.20210316120339-c8e724abc3af/go.mod h1:GawNk6JMw6fE7DnPof34SV1prRjiTToNMLorQzZFlJc=
 github.com/giantswarm/resource/v2 v2.3.0 h1:AckykKu6WgNFMPl07roNdef9vfNlOzzRRRS8dxQ4sdM=
 github.com/giantswarm/resource/v2 v2.3.0/go.mod h1:g9xsouhdgSUvgKHTPeeOJa9GAVt0vrjkA/pLnjwRtBA=
 github.com/giantswarm/tenantcluster/v3 v3.0.0 h1:Vrx0LnItmvIUjvkJ10bkz+M8cEFOjrWl5HQv04VmJKg=

--- a/go.sum
+++ b/go.sum
@@ -210,8 +210,8 @@ github.com/giantswarm/micrologger v0.4.0/go.mod h1:xsD5laBXORMy/P34IHZMK0y/D1gTk
 github.com/giantswarm/micrologger v0.5.0 h1:/f2knkyf4bZw3L5F48R7VENiEKPb3Sjnzrg46+Ja5vk=
 github.com/giantswarm/micrologger v0.5.0/go.mod h1:J/jbt7A8eixqE40yq4JY8Hdbs/qeboe2FjHlq05UWjA=
 github.com/giantswarm/operatorkit/v4 v4.0.0/go.mod h1:9VLDXCofhooOPbRt3XCZQmMZJ0tW7X3x7G/2Sz3kb5o=
-github.com/giantswarm/operatorkit/v4 v4.2.1-0.20210316120339-c8e724abc3af h1:F/FJ3JjCY8gCjIDFHRmdKVy1T1ah9KXR/qZ+3dErY94=
-github.com/giantswarm/operatorkit/v4 v4.2.1-0.20210316120339-c8e724abc3af/go.mod h1:GawNk6JMw6fE7DnPof34SV1prRjiTToNMLorQzZFlJc=
+github.com/giantswarm/operatorkit/v4 v4.3.0 h1:TRqMWRWvDFwklLXMvvIBOlGAlCFAr9b+TC9aWUoGwrg=
+github.com/giantswarm/operatorkit/v4 v4.3.0/go.mod h1:e9XafHbBUQnsgMAdfhnAk6oOtvvOY/voLM+cdejwiMI=
 github.com/giantswarm/resource/v2 v2.3.0 h1:AckykKu6WgNFMPl07roNdef9vfNlOzzRRRS8dxQ4sdM=
 github.com/giantswarm/resource/v2 v2.3.0/go.mod h1:g9xsouhdgSUvgKHTPeeOJa9GAVt0vrjkA/pLnjwRtBA=
 github.com/giantswarm/tenantcluster/v3 v3.0.0 h1:Vrx0LnItmvIUjvkJ10bkz+M8cEFOjrWl5HQv04VmJKg=

--- a/go.sum
+++ b/go.sum
@@ -210,8 +210,8 @@ github.com/giantswarm/micrologger v0.4.0/go.mod h1:xsD5laBXORMy/P34IHZMK0y/D1gTk
 github.com/giantswarm/micrologger v0.5.0 h1:/f2knkyf4bZw3L5F48R7VENiEKPb3Sjnzrg46+Ja5vk=
 github.com/giantswarm/micrologger v0.5.0/go.mod h1:J/jbt7A8eixqE40yq4JY8Hdbs/qeboe2FjHlq05UWjA=
 github.com/giantswarm/operatorkit/v4 v4.0.0/go.mod h1:9VLDXCofhooOPbRt3XCZQmMZJ0tW7X3x7G/2Sz3kb5o=
-github.com/giantswarm/operatorkit/v4 v4.2.1-0.20210316102702-8d1e229c0043 h1:mH7qmkJoFqAl7xpw1WBdMSxZON+7YX08uMmNPHHEdQQ=
-github.com/giantswarm/operatorkit/v4 v4.2.1-0.20210316102702-8d1e229c0043/go.mod h1:GawNk6JMw6fE7DnPof34SV1prRjiTToNMLorQzZFlJc=
+github.com/giantswarm/operatorkit/v4 v4.2.1-0.20210316110728-641eaef56b35 h1:+kc62w9quyHulIPZzT5PRabH+OHpSkfTqaGZ7WAbcFU=
+github.com/giantswarm/operatorkit/v4 v4.2.1-0.20210316110728-641eaef56b35/go.mod h1:e9XafHbBUQnsgMAdfhnAk6oOtvvOY/voLM+cdejwiMI=
 github.com/giantswarm/resource/v2 v2.3.0 h1:AckykKu6WgNFMPl07roNdef9vfNlOzzRRRS8dxQ4sdM=
 github.com/giantswarm/resource/v2 v2.3.0/go.mod h1:g9xsouhdgSUvgKHTPeeOJa9GAVt0vrjkA/pLnjwRtBA=
 github.com/giantswarm/tenantcluster/v3 v3.0.0 h1:Vrx0LnItmvIUjvkJ10bkz+M8cEFOjrWl5HQv04VmJKg=

--- a/go.sum
+++ b/go.sum
@@ -210,8 +210,8 @@ github.com/giantswarm/micrologger v0.4.0/go.mod h1:xsD5laBXORMy/P34IHZMK0y/D1gTk
 github.com/giantswarm/micrologger v0.5.0 h1:/f2knkyf4bZw3L5F48R7VENiEKPb3Sjnzrg46+Ja5vk=
 github.com/giantswarm/micrologger v0.5.0/go.mod h1:J/jbt7A8eixqE40yq4JY8Hdbs/qeboe2FjHlq05UWjA=
 github.com/giantswarm/operatorkit/v4 v4.0.0/go.mod h1:9VLDXCofhooOPbRt3XCZQmMZJ0tW7X3x7G/2Sz3kb5o=
-github.com/giantswarm/operatorkit/v4 v4.2.1-0.20210316110728-641eaef56b35 h1:+kc62w9quyHulIPZzT5PRabH+OHpSkfTqaGZ7WAbcFU=
-github.com/giantswarm/operatorkit/v4 v4.2.1-0.20210316110728-641eaef56b35/go.mod h1:e9XafHbBUQnsgMAdfhnAk6oOtvvOY/voLM+cdejwiMI=
+github.com/giantswarm/operatorkit/v4 v4.2.1-0.20210316115038-eb52dc70ae50 h1:RelGFDSbBBNvVlP8O4Qzt8ZY5HYhw/lGCqpqdLDmwX8=
+github.com/giantswarm/operatorkit/v4 v4.2.1-0.20210316115038-eb52dc70ae50/go.mod h1:GawNk6JMw6fE7DnPof34SV1prRjiTToNMLorQzZFlJc=
 github.com/giantswarm/resource/v2 v2.3.0 h1:AckykKu6WgNFMPl07roNdef9vfNlOzzRRRS8dxQ4sdM=
 github.com/giantswarm/resource/v2 v2.3.0/go.mod h1:g9xsouhdgSUvgKHTPeeOJa9GAVt0vrjkA/pLnjwRtBA=
 github.com/giantswarm/tenantcluster/v3 v3.0.0 h1:Vrx0LnItmvIUjvkJ10bkz+M8cEFOjrWl5HQv04VmJKg=

--- a/go.sum
+++ b/go.sum
@@ -168,6 +168,7 @@ github.com/giantswarm/apiextensions/v2 v2.0.0/go.mod h1:/qSx5jA2F5um0ipvVDMZJz+r
 github.com/giantswarm/apiextensions/v3 v3.4.0/go.mod h1:MMLkRJta4mbTbrikP9LewADiCL+55LmsagyhdTU7XAY=
 github.com/giantswarm/apiextensions/v3 v3.11.0/go.mod h1:f+dFUDLroK50aCGzvpqPw/jCFCCgJqdEMf/xNSJBI+A=
 github.com/giantswarm/apiextensions/v3 v3.13.0/go.mod h1:f+dFUDLroK50aCGzvpqPw/jCFCCgJqdEMf/xNSJBI+A=
+github.com/giantswarm/apiextensions/v3 v3.17.0/go.mod h1:N4SS083wjVR3GEL/pqWycva4yUtYrlU5lUKhRtZJ7EY=
 github.com/giantswarm/apiextensions/v3 v3.18.1/go.mod h1:N4SS083wjVR3GEL/pqWycva4yUtYrlU5lUKhRtZJ7EY=
 github.com/giantswarm/apiextensions/v3 v3.19.0 h1:+rw3omC3pKtxLi53gc46sMuQ3LnYNXuPDK3SLS+mnug=
 github.com/giantswarm/apiextensions/v3 v3.19.0/go.mod h1:6KBexBTOZJ+amkorxw722t2HS57f+rf/8LeSSFfQNmo=
@@ -188,6 +189,7 @@ github.com/giantswarm/exporterkit v0.2.1/go.mod h1:LkZNK+2qTcbHspbizA6JBBXpQW99u
 github.com/giantswarm/k8sclient/v4 v4.0.0 h1:K18A0FomGjxTMElcGrjO3uLkYobUtcNh8e8PhTgFr2w=
 github.com/giantswarm/k8sclient/v4 v4.0.0/go.mod h1:jTwQ8q0YbJJu3ZxbjoI6hkXeuvKm15xyI/c+zwxnUH0=
 github.com/giantswarm/k8sclient/v5 v5.0.0/go.mod h1:OhlknCs1Wgc0ErjWBgeZDGe4Y6aThus21nQOXPAq4rQ=
+github.com/giantswarm/k8sclient/v5 v5.10.0/go.mod h1:HHSHvERGfLhNqTsqKBUQSQ5VXGhLfVRojplYwio6jDU=
 github.com/giantswarm/k8sclient/v5 v5.11.0 h1:LZwtscRz53Wz+hf0Sc7L1PEJdeUTDzgUjai4+9EbNjY=
 github.com/giantswarm/k8sclient/v5 v5.11.0/go.mod h1:3if9oaz3gwTKMuVNxU8vJfrzADyTuExOj+uu8N0+LsM=
 github.com/giantswarm/kubeconfig/v2 v2.0.0 h1:FC6SsWZN6LXy2D6drTz2W1ULWxYHJECB6O/oYY2oK6s=
@@ -208,8 +210,8 @@ github.com/giantswarm/micrologger v0.4.0/go.mod h1:xsD5laBXORMy/P34IHZMK0y/D1gTk
 github.com/giantswarm/micrologger v0.5.0 h1:/f2knkyf4bZw3L5F48R7VENiEKPb3Sjnzrg46+Ja5vk=
 github.com/giantswarm/micrologger v0.5.0/go.mod h1:J/jbt7A8eixqE40yq4JY8Hdbs/qeboe2FjHlq05UWjA=
 github.com/giantswarm/operatorkit/v4 v4.0.0/go.mod h1:9VLDXCofhooOPbRt3XCZQmMZJ0tW7X3x7G/2Sz3kb5o=
-github.com/giantswarm/operatorkit/v4 v4.2.0 h1:/5nVso9Yg599oP1jqYGiMHysjKes/cV//HAM0tCpQos=
-github.com/giantswarm/operatorkit/v4 v4.2.0/go.mod h1:O0F9yfY0qpxOb0oXt2G8Yt4cu3nRQlfwl+wFWdFBb48=
+github.com/giantswarm/operatorkit/v4 v4.2.1-0.20210316102702-8d1e229c0043 h1:mH7qmkJoFqAl7xpw1WBdMSxZON+7YX08uMmNPHHEdQQ=
+github.com/giantswarm/operatorkit/v4 v4.2.1-0.20210316102702-8d1e229c0043/go.mod h1:GawNk6JMw6fE7DnPof34SV1prRjiTToNMLorQzZFlJc=
 github.com/giantswarm/resource/v2 v2.3.0 h1:AckykKu6WgNFMPl07roNdef9vfNlOzzRRRS8dxQ4sdM=
 github.com/giantswarm/resource/v2 v2.3.0/go.mod h1:g9xsouhdgSUvgKHTPeeOJa9GAVt0vrjkA/pLnjwRtBA=
 github.com/giantswarm/tenantcluster/v3 v3.0.0 h1:Vrx0LnItmvIUjvkJ10bkz+M8cEFOjrWl5HQv04VmJKg=

--- a/pkg/label/app.go
+++ b/pkg/label/app.go
@@ -1,0 +1,7 @@
+package label
+
+const (
+	// AppOperatorWatching is the label added to configmaps by app-operator when
+	// it is watching for values changes.
+	AppOperatorWatching = "app-operator.giantswarm.io/watching"
+)

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -272,6 +272,9 @@ func newClusterResources(config ClusterConfig) ([]resource.Interface, error) {
 			K8sClient: config.K8sClient.K8sClient(),
 			Logger:    config.Logger,
 
+			AllowedLabels: []string{
+				label.AppOperatorWatching,
+			},
 			Name:        clusterconfigmap.Name,
 			StateGetter: clusterConfigMapGetter,
 		}


### PR DESCRIPTION
Towards giantswarm/giantswarm#14163

Extends the clusterconfigmap resource to allow the label below which is added by app-operator so it can watch for changes.

```
labels:
  app-operator.giantswarm.io/watching: "true"
```

## Checklist

- [x] Update changelog in CHANGELOG.md.
