### PR TITLE
legacy; Use catalog from release spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.25.1] - 2021-03-17
 
+### Added
+
+- Assign app catalog name from the component in release CR.
+
 ### Fixed
 
 - Add `AllowedLabels` to clusterconfigmap resource to prevent unnecessary updates.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
-	github.com/giantswarm/apiextensions v0.2.0
+	github.com/giantswarm/apiextensions v0.2.1-0.20210324165038-360688c8588a
 	github.com/giantswarm/apprclient v0.0.0-20191209123802-955b7e89e6e2
 	github.com/giantswarm/backoff v0.2.0
 	github.com/giantswarm/certs/v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,8 @@ github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 h1:Mn26/9ZMNWSw9C9ER
 github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/giantswarm/apiextensions v0.2.0 h1:6gnfXFRL/eGqPbYhM7jUckwmulx7jh6qJpEe06riIKA=
 github.com/giantswarm/apiextensions v0.2.0/go.mod h1:iw66G0WDcrQl9mi2m/6mov2fWTD6ZiT2+FC62b2Mczw=
+github.com/giantswarm/apiextensions v0.2.1-0.20210324165038-360688c8588a h1:e84Jr/rWkt342AgU3bnvFm81umPydKTyh47uAsZhQEE=
+github.com/giantswarm/apiextensions v0.2.1-0.20210324165038-360688c8588a/go.mod h1:iw66G0WDcrQl9mi2m/6mov2fWTD6ZiT2+FC62b2Mczw=
 github.com/giantswarm/apprclient v0.0.0-20191209123802-955b7e89e6e2 h1:AfmrYPVlmiZrEKvg2jVYVDpEVOZVQC7W+M1jiImTp1U=
 github.com/giantswarm/apprclient v0.0.0-20191209123802-955b7e89e6e2/go.mod h1:ajQ3Ibi4dmgMXu23nen/yFp1SaySeQDK3xvXZSKCnCc=
 github.com/giantswarm/backoff v0.2.0 h1:kdfAf83pZ/l8X0KiA2dJ2Wq19nS9hISijVn7ZRdFhfU=

--- a/service/controller/resource/app/desired.go
+++ b/service/controller/resource/app/desired.go
@@ -361,17 +361,24 @@ func (r *Resource) newAppSpecs(ctx context.Context, cr v1alpha1.ClusterGuestConf
 }
 
 func newAppOperatorAppSpec(clusterConfig v1alpha1.ClusterGuestConfig, component releasev1alpha1.ReleaseSpecComponent) key.AppSpec {
-	return key.AppSpec{
+	spec := key.AppSpec{
 		App: appOperatorComponentName,
 		// Override app name to include the cluster ID.
 		AppName:         fmt.Sprintf("%s-%s", appOperatorComponentName, clusterConfig.ID),
-		Catalog:         controlPlaneCatalog,
+		Catalog:         component.Catalog,
 		Chart:           appOperatorComponentName,
 		InCluster:       true,
 		Namespace:       clusterConfig.ID,
 		UseUpgradeForce: false,
 		Version:         component.Version,
 	}
+
+	// Setting the reference allows us to deploy from a test catalog.
+	if component.Reference != "" {
+		spec.Version = component.Reference
+	}
+
+	return spec
 }
 
 func (r *Resource) getReleaseComponent(releaseVersion, component string) (releasev1alpha1.ReleaseSpecComponent, error) {

--- a/service/controller/resource/app/resource.go
+++ b/service/controller/resource/app/resource.go
@@ -15,7 +15,6 @@ const (
 	Name = "app"
 
 	appOperatorComponentName = "app-operator"
-	controlPlaneCatalog      = "control-plane-catalog"
 	uniqueOperatorVersion    = "0.0.0"
 )
 


### PR DESCRIPTION
`legacy` branch doesn't use the app catalog name from release CRs. This is necessary to test our component. (e.g. app-operator in control-plane-test-catalog)

## Checklist

- [x] Update changelog in CHANGELOG.md.
