### PR TITLE
Legacy; drop ensuring CRDs from controllers 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Dropped ensuring cluster CRDs from controllers.
+
 ## [0.27.0] - 2021-04-15
 
 ### Changed

--- a/service/controller/aws/legacy_cluster.go
+++ b/service/controller/aws/legacy_cluster.go
@@ -81,7 +81,6 @@ func NewLegacyCluster(config LegacyClusterConfig) (*LegacyCluster, error) {
 	var clusterController *controller.Controller
 	{
 		c := controller.Config{
-			CRD:       v1alpha1.NewAWSClusterConfigCRD(),
 			K8sClient: config.K8sClient,
 			Logger:    config.Logger,
 			ResourceSets: []*controller.ResourceSet{

--- a/service/controller/azure/legacy_cluster.go
+++ b/service/controller/azure/legacy_cluster.go
@@ -79,7 +79,6 @@ func NewLegacyCluster(config LegacyClusterConfig) (*LegacyCluster, error) {
 	var clusterController *controller.Controller
 	{
 		c := controller.Config{
-			CRD:       v1alpha1.NewAzureClusterConfigCRD(),
 			K8sClient: config.K8sClient,
 			Logger:    config.Logger,
 			ResourceSets: []*controller.ResourceSet{

--- a/service/controller/kvm/legacy_cluster.go
+++ b/service/controller/kvm/legacy_cluster.go
@@ -79,7 +79,6 @@ func NewLegacyCluster(config LegacyClusterConfig) (*LegacyCluster, error) {
 	var clusterController *controller.Controller
 	{
 		c := controller.Config{
-			CRD:       v1alpha1.NewKVMClusterConfigCRD(),
 			K8sClient: config.K8sClient,
 			Logger:    config.Logger,
 			ResourceSets: []*controller.ResourceSet{


### PR DESCRIPTION
An issue has arisen from the old legacy branch in cluster-operator, 
```
E 04/20 13:15:55 stop controller boot retries due to too many errors | operatorkit/controller/controller.go:194 | controller=cluster-operator
        /go/pkg/mod/github.com/giantswarm/backoff@v0.2.0/retry.go:23
        /go/pkg/mod/github.com/giantswarm/operatorkit@v0.2.1/controller/controller.go:184
        /go/pkg/mod/github.com/giantswarm/operatorkit@v0.2.1/controller/controller.go:242
        /go/pkg/mod/github.com/giantswarm/k8sclient@v0.2.0/k8scrdclient/k8scrdclient.go:61
        /go/pkg/mod/github.com/giantswarm/k8sclient@v0.2.0/k8scrdclient/k8scrdclient.go:195
        /go/pkg/mod/github.com/giantswarm/backoff@v0.2.0/retry.go:13
        /go/pkg/mod/github.com/giantswarm/k8sclient@v0.2.0/k8scrdclient/k8scrdclient.go:178
        not established error: spec.preserveUnknownFields: Invalid value: true: must be false
``` 

Since we don't want to ensure CRDs from each operator, we need to delete `CRD` from controllers.
## Checklist

- [ ] Update changelog in CHANGELOG.md.
