### PR TITLE
Fix clusterIPRange value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Updated OperatorKit to v4.3.1 for Kubernetes 1.20 support.
+- Fix `clusterIPRange` value in configmap.
 
 ## [3.7.1] - 2021-03-17
 

--- a/helm/cluster-operator/templates/configmap.yaml
+++ b/helm/cluster-operator/templates/configmap.yaml
@@ -20,7 +20,7 @@ data:
           cidr: '{{ .Values.cni.mask }}'
         kubernetes:
           api:
-            clusterIPRange: '{{ .Values.kubernetes.api.clusterAPIRange }}'
+            clusterIPRange: '{{ .Values.kubernetes.api.clusterIPRange }}'
           domain: '{{ .Values.kubernetes.clusterDomain }}'
         vault:
           certificate:


### PR DESCRIPTION
The variable is called `clusterIPRange`, not `clusterAPIRange`.
https://github.com/giantswarm/config/blob/main/installations/alpaca/apps/cluster-operator/configmap-values.yaml.patch#L7

## Checklist

- [x] Update changelog in CHANGELOG.md.
