### PR TITLE
Fix default cidr subnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed default value for calico subnet.
+
 ## [0.27.1] - 2021-04-21
 
 ### Changed

--- a/helm/cluster-operator/values.yaml
+++ b/helm/cluster-operator/values.yaml
@@ -44,7 +44,7 @@ registry:
 
 cni:
   mask: 16
-  subnet: 10.1.0.0/16
+  subnet: 10.1.0.0
 
 kubernetes:
   api:


### PR DESCRIPTION
The default value for the calico subnet should be an address and not a cidr.
In fact, this is what we have in all installations in the generated configmap:

```
$ kubectl --context=giantswarm-goku -n 2db3k get configmap 2db3k-cluster-values -o yaml
apiVersion: v1
data:
  values: |
    ...
    cluster:
      calico:
        CIDR: 10.1.0.0/16/16
...
```

Furthermore, that value is identical in all WCs in all MCs as the default is never overridden, making me question the fact that this value should exist at all.

## Checklist

- [x] Update changelog in CHANGELOG.md.
