### PR TITLE
Assign app-operator with app-operator-konfigure configmap 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Use `app-operator-konfigure` configmap on the app-operator per cluster.
+- Use `app-operator-konfigure` configmap for the app-operator per workload cluster.
 
 ## [3.8.0] - 2021-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use `app-operator-konfigure` configmap on the app-operator per cluster.
+
 ## [3.8.0] - 2021-06-16
 
 

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 replace (
 	github.com/coreos/etcd v3.3.10+incompatible => github.com/coreos/etcd v3.3.25+incompatible
 	github.com/coreos/etcd v3.3.13+incompatible => github.com/coreos/etcd v3.3.25+incompatible
+	github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
 	github.com/gogo/protobuf v1.3.1 => github.com/gogo/protobuf v1.3.2
 	sigs.k8s.io/cluster-api => github.com/giantswarm/cluster-api v0.3.13-gs
 )

--- a/go.sum
+++ b/go.sum
@@ -147,7 +147,7 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1/go.mod h1:+hnT3ywWDTAFrW5aE+u2Sa/wT555ZqwoCS+pk3p6ry4=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=

--- a/service/controller/resource/app/desired.go
+++ b/service/controller/resource/app/desired.go
@@ -70,7 +70,12 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*g8s
 
 	// Define app CR for app-operator in the management cluster namespace.
 	appOperatorAppSpec := newAppOperatorAppSpec(cr, appOperatorComponent)
-	apps = append(apps, r.newApp(uniqueOperatorVersion, cr, appOperatorAppSpec, g8sv1alpha1.AppSpecUserConfig{}))
+	apps = append(apps, r.newApp(uniqueOperatorVersion, cr, appOperatorAppSpec, g8sv1alpha1.AppSpecUserConfig{
+		ConfigMap: g8sv1alpha1.AppSpecUserConfigConfigMap{
+			Name:      "app-operator-konfigure",
+			Namespace: "giantswarm",
+		},
+	}))
 
 	for _, appSpec := range appSpecs {
 		userConfig := newUserConfig(cr, appSpec, configMaps, secrets)


### PR DESCRIPTION
From app-operator 5.0.0, ir crashes since necessary values `provider.kind` has been not provided. We can easily solve this by assigning app-operator-konfigure cm.
## Checklist

- [x] Update changelog in CHANGELOG.md.
