### PR TITLE
Use app-operator-konfigure configmap for per cluster instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use `app-operator-konfigure` configmap for the app-operator per workload cluster.
+
 ### Fixed
 
 - Fixed default value for calico subnet.

--- a/service/controller/key/types.go
+++ b/service/controller/key/types.go
@@ -10,7 +10,8 @@ type AppSpec struct {
 	ClusterAPIOnly bool
 	// ConfigMapName overrides the name, otherwise the cluster values configmap
 	// is used.
-	ConfigMapName string
+	ConfigMapName      string
+	ConfigMapNamespace string
 	// Whether app is installed for legacy clusters only.
 	// InCluster determines if the app CR should use in cluster. Otherwise the
 	// cluster kubeconfig is specified.

--- a/service/controller/resource/app/desired.go
+++ b/service/controller/resource/app/desired.go
@@ -191,7 +191,12 @@ func (r *Resource) newApp(clusterConfig v1alpha1.ClusterGuestConfig, appSpec key
 	var config g8sv1alpha1.AppSpecConfig
 
 	if appSpec.InCluster {
-		config = g8sv1alpha1.AppSpecConfig{}
+		config = g8sv1alpha1.AppSpecConfig{
+			ConfigMap: g8sv1alpha1.AppSpecConfigConfigMap{
+				Name:      appSpec.ConfigMapName,
+				Namespace: appSpec.ConfigMapNamespace,
+			},
+		}
 	} else {
 		config = g8sv1alpha1.AppSpecConfig{
 			ConfigMap: g8sv1alpha1.AppSpecConfigConfigMap{
@@ -364,13 +369,16 @@ func newAppOperatorAppSpec(clusterConfig v1alpha1.ClusterGuestConfig, component 
 	spec := key.AppSpec{
 		App: appOperatorComponentName,
 		// Override app name to include the cluster ID.
-		AppName:         fmt.Sprintf("%s-%s", appOperatorComponentName, clusterConfig.ID),
-		Catalog:         component.Catalog,
-		Chart:           appOperatorComponentName,
-		InCluster:       true,
-		Namespace:       clusterConfig.ID,
-		UseUpgradeForce: false,
-		Version:         component.Version,
+		AppName: fmt.Sprintf("%s-%s", appOperatorComponentName, clusterConfig.ID),
+		Catalog: component.Catalog,
+		Chart:   appOperatorComponentName,
+		// Use config map with management cluster config.
+		ConfigMapName:      "app-operator-konfigure",
+		ConfigMapNamespace: "giantswarm",
+		InCluster:          true,
+		Namespace:          clusterConfig.ID,
+		UseUpgradeForce:    false,
+		Version:            component.Version,
 	}
 
 	// Setting the reference allows us to deploy from a test catalog.


### PR DESCRIPTION
Needed to use app-operator 5.2.0 in KVM and Azure platform releases.

## Checklist

- [x] Update changelog in CHANGELOG.md.
