### PR TITLE
Add cluster CA to cluster values configmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Check if `kiam-watchdog` app has to be enabled.
+- Add cluster CA to cluster values configmap for apps like dex that need to
+verify it.
 
 ## [3.10.0] - 2021-08-30
 

--- a/service/controller/key/common.go
+++ b/service/controller/key/common.go
@@ -6,6 +6,10 @@ import (
 	"github.com/giantswarm/cluster-operator/v3/pkg/label"
 )
 
+func APISecretName(getter LabelsGetter) string {
+	return fmt.Sprintf("%s-api", ClusterID(getter))
+}
+
 // ClusterConfigMapName returns the cluster name used in the configMap
 // generated for this tenant cluster.
 func ClusterConfigMapName(getter LabelsGetter) string {

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -39,9 +39,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 			return nil, microerror.Mask(err)
 		}
 
-		r.logger.Debugf(ctx, "SECRET %#v", apiSecret)
-		r.logger.Debugf(ctx, "CA %#q", apiSecret.StringData["ca"])
-		clusterCA = apiSecret.StringData["ca"]
+		clusterCA = string(apiSecret.Data["ca"])
 	}
 
 	var podCIDR string

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -39,6 +39,8 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 			return nil, microerror.Mask(err)
 		}
 
+		r.logger.Debugf(ctx, "SECRET %#v", apiSecret)
+		r.logger.Debugf(ctx, "CA %#q", apiSecret.StringData["ca"])
 		clusterCA = apiSecret.StringData["ca"]
 	}
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/545

Some apps like dex that talk to the Kubernetes API need to read the API CA in order to trust on it (we used self signed certs).

This adds it to the cluster values configmap so it's available to all apps.

## Checklist

- [x] Update changelog in CHANGELOG.md.
