### PR TITLE
Add selector to operatorkit Controller for AzureClusterConfig 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+
 - Add selector to operatorkit Controller for AzureClusterConfig to avoid reconciling CRs not owned by this operator. 
 
 ## [0.27.2] - 2021-08-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Add selector to operatorkit Controller for AzureClusterConfig to avoid reconciling CRs not owned by this operator. 
+
 ## [0.27.2] - 2021-08-31
 
 ### Changed

--- a/service/controller/azure/legacy_cluster.go
+++ b/service/controller/azure/legacy_cluster.go
@@ -11,8 +11,11 @@ import (
 	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/tenantcluster/v2/pkg/tenantcluster"
 	"github.com/spf13/afero"
+	"k8s.io/apimachinery/pkg/labels"
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/giantswarm/cluster-operator/pkg/label"
+	"github.com/giantswarm/cluster-operator/pkg/project"
 	"github.com/giantswarm/cluster-operator/service/internal/cluster"
 )
 
@@ -87,8 +90,10 @@ func NewLegacyCluster(config LegacyClusterConfig) (*LegacyCluster, error) {
 			NewRuntimeObjectFunc: func() pkgruntime.Object {
 				return new(v1alpha1.AzureClusterConfig)
 			},
-
 			Name: config.ProjectName,
+			Selector: labels.SelectorFromSet(map[string]string{
+				label.OperatorVersion: project.Version(),
+			}),
 		}
 
 		clusterController, err = controller.New(c)


### PR DESCRIPTION
Currently this opeator is reconciling all azureclusterconfig CRs, regardless of any labels that might specify the operator version.
This PR adds a selector to make it only reconcile CRs whose operator version matches

## Checklist

- [x] Update changelog in CHANGELOG.md.
