### PR TITLE
Store kubeconfig in .data.value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Store kubeconfig copy in `.data.value` field of the Secret.
+
 ## [4.0.2] - 2022-04-14
 
 ### Fixed

--- a/service/controller/resource/kubeconfig/desired.go
+++ b/service/controller/resource/kubeconfig/desired.go
@@ -56,7 +56,10 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 				},
 			},
 			Data: map[string][]byte{
+				// used by legacy Giant Swarm operators
 				"kubeConfig": b,
+				// used by Flux; de-facto industry standard
+				"value": b,
 			},
 		}
 	}


### PR DESCRIPTION
Both CAPI, Flux, and a number of upstream projects expect to find
kubeconfig under .data.value key in the Secret. This change increases
the size of the secret, however it is still negligible (9K to 18K).

This will enable us to reference our kubeconfig secrets in Flux to deploy
directly to Workload Clusters in legacy setups.

## Checklist

- [x] Update changelog in CHANGELOG.md.
