### PR TITLE
Add cluster values for IRSA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add cluster values for IRSA.
+
 ## [4.1.0] - 2022-04-27
 
 ### Changed

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -253,6 +253,7 @@ func newClusterResources(config ClusterConfig) ([]resource.Interface, error) {
 	{
 		c := clusterconfigmap.Config{
 			BaseDomain: config.BaseDomain,
+			CtrlClient: config.K8sClient.CtrlClient(),
 			K8sClient:  config.K8sClient.K8sClient(),
 			Logger:     config.Logger,
 			PodCIDR:    config.PodCIDR,

--- a/service/controller/resource/clusterconfigmap/resource.go
+++ b/service/controller/resource/clusterconfigmap/resource.go
@@ -4,6 +4,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"k8s.io/client-go/kubernetes"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/cluster-operator/v4/service/internal/basedomain"
 	"github.com/giantswarm/cluster-operator/v4/service/internal/podcidr"
@@ -18,6 +19,7 @@ const (
 // resource.
 type Config struct {
 	BaseDomain basedomain.Interface
+	CtrlClient ctrlClient.Client
 	K8sClient  kubernetes.Interface
 	Logger     micrologger.Logger
 	PodCIDR    podcidr.Interface
@@ -30,6 +32,7 @@ type Config struct {
 // Resource implements the clusterConfigMap resource.
 type Resource struct {
 	baseDomain basedomain.Interface
+	ctrlClient ctrlClient.Client
 	k8sClient  kubernetes.Interface
 	logger     micrologger.Logger
 	podCIDR    podcidr.Interface
@@ -46,7 +49,10 @@ type Resource struct {
 //
 func New(config Config) (*Resource, error) {
 	if config.BaseDomain == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+		return nil, microerror.Maskf(invalidConfigError, "%T.BaseDomain must not be empty", config)
+	}
+	if config.CtrlClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
 	}
 	if config.K8sClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
@@ -70,6 +76,7 @@ func New(config Config) (*Resource, error) {
 
 	r := &Resource{
 		baseDomain: config.BaseDomain,
+		ctrlClient: config.CtrlClient,
 		k8sClient:  config.K8sClient,
 		logger:     config.Logger,
 		podCIDR:    config.PodCIDR,


### PR DESCRIPTION
Issue: https://github.com/giantswarm/roadmap/issues/1101

To make use of IRSA for our apps we need to ensure some additional information:

AccountID: this is needed for the IRSA annotation we set on the service account for our apps, e.g. external-dns.
IRSA: this value is picked up if we enable IRSA for our apps. E.g. for external to distinguish if kiam is used or not. See PR: https://github.com/giantswarm/external-dns-app/pull/168

```
kg describe cm external-dns-chart-values
Name:         external-dns-chart-values
Namespace:    giantswarm
Labels:       giantswarm.io/managed-by=app-operator
Annotations:  giantswarm.io/notes: DO NOT EDIT. Values managed by app-operator.

Data
====
values:
----
NetExporter:
  DNSCheck:
    TCP:
      Disabled: false
  Hosts: giantswarm.io.,kubernetes.default.svc.cluster.local.
  NTPServers: 0.flatcar.pool.ntp.org,1.flatcar.pool.ntp.org
aws:
  accountID: "REDACTED"
  irsa: "true"
...
```
## Checklist

- [x] Update changelog in CHANGELOG.md.