### PR TITLE
Fix handing over app-of-apps to WC app-operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,11 @@
 *.swp
 
 # build result
-cluster-operator
+/cluster-operator*
 !helm/cluster-operator
 
 # don't apply earlier restrictions under vendor
 !vendor/**
+
+.idea
+

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@
 !vendor/**
 
 .idea
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Do not update "app-operator.giantswarm.io/version" label on app-operators when their value is 0.0.0 (aka they are reconciled by the management cluster app-operator). This is a use-case for App Bundles for example, because the App CRs they contain should be created in the MC so should be reconciled by the MC app-operator.
+
 ## [4.2.0] - 2022-05-25
 
 ### Added

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -14,6 +14,10 @@ const (
 	// defaultDNSLastOctet is the last octect for the DNS service IP, the first
 	// 3 octets come from the cluster IP range.
 	defaultDNSLastOctet = 10
+
+	// UniqueOperatorVersion This is a special version used to indicate that the App CR
+	// should be reconciled by the workload cluster app-operator.
+	UniqueOperatorVersion = "0.0.0"
 )
 
 // AppUserConfigMapName returns the name of the user values configmap for the

--- a/service/controller/resource/app/desired.go
+++ b/service/controller/resource/app/desired.go
@@ -76,7 +76,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*g8s
 
 	// Define app CR for app-operator in the management cluster namespace.
 	appOperatorAppSpec := newAppOperatorAppSpec(cr, appOperatorComponent)
-	apps = append(apps, r.newApp(uniqueOperatorVersion, cr, appOperatorAppSpec, g8sv1alpha1.AppSpecUserConfig{
+	apps = append(apps, r.newApp(UniqueOperatorVersion, cr, appOperatorAppSpec, g8sv1alpha1.AppSpecUserConfig{
 		ConfigMap: g8sv1alpha1.AppSpecUserConfigConfigMap{
 			Name:      "app-operator-konfigure",
 			Namespace: "giantswarm",

--- a/service/controller/resource/app/desired.go
+++ b/service/controller/resource/app/desired.go
@@ -76,7 +76,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*g8s
 
 	// Define app CR for app-operator in the management cluster namespace.
 	appOperatorAppSpec := newAppOperatorAppSpec(cr, appOperatorComponent)
-	apps = append(apps, r.newApp(UniqueOperatorVersion, cr, appOperatorAppSpec, g8sv1alpha1.AppSpecUserConfig{
+	apps = append(apps, r.newApp(key.UniqueOperatorVersion, cr, appOperatorAppSpec, g8sv1alpha1.AppSpecUserConfig{
 		ConfigMap: g8sv1alpha1.AppSpecUserConfigConfigMap{
 			Name:      "app-operator-konfigure",
 			Namespace: "giantswarm",

--- a/service/controller/resource/app/resource.go
+++ b/service/controller/resource/app/resource.go
@@ -13,8 +13,6 @@ import (
 const (
 	// Name is the identifier of the resource.
 	Name = "app"
-
-	UniqueOperatorVersion = "0.0.0"
 )
 
 // Config represents the configuration used to create a new chartconfig service.

--- a/service/controller/resource/app/resource.go
+++ b/service/controller/resource/app/resource.go
@@ -14,7 +14,7 @@ const (
 	// Name is the identifier of the resource.
 	Name = "app"
 
-	uniqueOperatorVersion = "0.0.0"
+	UniqueOperatorVersion = "0.0.0"
 )
 
 // Config represents the configuration used to create a new chartconfig service.

--- a/service/controller/resource/appversionlabel/create.go
+++ b/service/controller/resource/appversionlabel/create.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/giantswarm/cluster-operator/v4/pkg/project"
 	"github.com/giantswarm/cluster-operator/v4/service/controller/key"
+	appResource "github.com/giantswarm/cluster-operator/v4/service/controller/resource/app"
 	"github.com/giantswarm/cluster-operator/v4/service/internal/releaseversion"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -65,8 +66,8 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			for _, app := range apps {
 				currentVersion := app.Labels[label.AppOperatorVersion]
 
-				if currentVersion != appOperatorVersion {
-					patches := []patch{}
+				if currentVersion != appResource.UniqueOperatorVersion && currentVersion != appOperatorVersion {
+					var patches []patch
 
 					if len(app.Labels) == 0 {
 						patches = append(patches, patch{

--- a/service/controller/resource/appversionlabel/create.go
+++ b/service/controller/resource/appversionlabel/create.go
@@ -66,6 +66,10 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			for _, app := range apps {
 				currentVersion := app.Labels[label.AppOperatorVersion]
 
+				// Do not update "app-operator.giantswarm.io/version" label on app-operators when their value is 0.0.0
+				// (aka they are reconciled by the management cluster app-operator). This is a use-case for App Bundles
+				// for example, because the App CRs they contain should be created in the management cluster so should
+				// be reconciled by the management cluster app-operator.
 				if currentVersion != appResource.UniqueOperatorVersion && currentVersion != appOperatorVersion {
 					var patches []patch
 

--- a/service/controller/resource/appversionlabel/create.go
+++ b/service/controller/resource/appversionlabel/create.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/giantswarm/cluster-operator/v4/pkg/project"
 	"github.com/giantswarm/cluster-operator/v4/service/controller/key"
-	appResource "github.com/giantswarm/cluster-operator/v4/service/controller/resource/app"
 	"github.com/giantswarm/cluster-operator/v4/service/internal/releaseversion"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -104,11 +103,11 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	return nil
 }
 
-//shouldUpdateAppOperatorVersionLabel When the current version is 0.0.0  aka they are reconciled by the management
-//cluster app-operator. This is a use-case for App Bundles  for example, because the App CRs they contain should be
-//created in the management cluster so should be reconciled by the management cluster app-operator.
+// shouldUpdateAppOperatorVersionLabel When the current version is 0.0.0  aka they are reconciled by the management
+// cluster app-operator. This is a use-case for App Bundles  for example, because the App CRs they contain should be
+// created in the management cluster so should be reconciled by the management cluster app-operator.
 func shouldUpdateAppOperatorVersionLabel(currentVersion string, componentVersion string) bool {
-	if currentVersion == appResource.UniqueOperatorVersion {
+	if currentVersion == key.UniqueOperatorVersion {
 		return false
 	}
 

--- a/service/controller/resource/appversionlabel/create.go
+++ b/service/controller/resource/appversionlabel/create.go
@@ -66,11 +66,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			for _, app := range apps {
 				currentVersion := app.Labels[label.AppOperatorVersion]
 
-				// Do not update "app-operator.giantswarm.io/version" label on app-operators when their value is 0.0.0
-				// (aka they are reconciled by the management cluster app-operator). This is a use-case for App Bundles
-				// for example, because the App CRs they contain should be created in the management cluster so should
-				// be reconciled by the management cluster app-operator.
-				if currentVersion != appResource.UniqueOperatorVersion && currentVersion != appOperatorVersion {
+				if shouldUpdateAppOperatorVersionLabel(currentVersion, appOperatorVersion) {
 					var patches []patch
 
 					if len(app.Labels) == 0 {
@@ -106,4 +102,15 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	return nil
+}
+
+//shouldUpdateAppOperatorVersionLabel When the current version is 0.0.0  aka they are reconciled by the management
+//cluster app-operator. This is a use-case for App Bundles  for example, because the App CRs they contain should be
+//created in the management cluster so should be reconciled by the management cluster app-operator.
+func shouldUpdateAppOperatorVersionLabel(currentVersion string, componentVersion string) bool {
+	if currentVersion == appResource.UniqueOperatorVersion {
+		return false
+	}
+
+	return currentVersion != componentVersion
 }

--- a/service/controller/resource/appversionlabel/create_test.go
+++ b/service/controller/resource/appversionlabel/create_test.go
@@ -1,0 +1,53 @@
+package appversionlabel
+
+import (
+	"testing"
+)
+
+func Test_AppVersionLabelCreate(t *testing.T) {
+	testCases := []struct {
+		description      string
+		currentVersion   string
+		componentVersion string
+		expectedOutcome  bool
+	}{
+		{
+			description:      "Version is the same",
+			currentVersion:   "5.11.0",
+			componentVersion: "5.11.0",
+			expectedOutcome:  false,
+		},
+		{
+			description:      "Version should be updated (e.g. cluster was updated to a new release)",
+			currentVersion:   "5.9.0",
+			componentVersion: "5.11.0",
+			expectedOutcome:  true,
+		},
+		{
+			description:      "Version should not be updated (e.g. App CR is an Ap Bundle handled by the MC app-operator)",
+			currentVersion:   "0.0.0",
+			componentVersion: "5.11.0",
+			expectedOutcome:  false,
+		},
+		{
+			description:      "Should be able to hand over App CRs to the MC app-operator tho",
+			currentVersion:   "5.9.0",
+			componentVersion: "0.0.0",
+			expectedOutcome:  true,
+		},
+		{
+			description:      "Special case for same version",
+			currentVersion:   "0.0.0",
+			componentVersion: "0.0.0",
+			expectedOutcome:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			if shouldUpdateAppOperatorVersionLabel(tc.currentVersion, tc.componentVersion) != tc.expectedOutcome {
+				t.Fatalf("Expected to update label: %v, but it would turn out the other way", tc.expectedOutcome)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Context

The label updating mechanism is there to handle cluster upgrades when the cluster components get updated, e.g. app-operator was updated from 5.8.0 to 5.9.0. In that case the normal WC App CRs needs to have their label updated so the new 5.9.0 app-operator will start handling them.

However app-of-apps should be managed by the unique app-operator that - indicated by the special `0.0.0` value for the label - because WC app-opearator  uses kubeconfig against the WC cluster, but the App CRs in app-of-apps needs to be created in the MC. So in this case - or when otherwise explicitly set for an App CR to be managed by the unique operator - it should not force the App CR to be managed by the WC app-operator.

## Checklist

- [x] Update changelog in CHANGELOG.md.
