### PR TITLE
Cni install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Set `chartOperator.cni.install` to true to allow installing CNI as app.
+- Set `bootstrapMode.enabled` to true to allow installing CNI as app.
 
 ## [4.3.0] - 2022-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Set `bootstrapMode.enabled` to true to allow installing CNI as app.
+- Set `chartOperator.cni.install` to true to allow installing CNI as app.
 
 ## [4.3.0] - 2022-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set `chartOperator.cni.install` to true to allow installing CNI as app.
+
 ## [4.3.0] - 2022-06-02
 
 ### Changed

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -104,9 +104,10 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 					"irsa":      strconv.FormatBool(irsa),
 				},
 				"baseDomain": key.TenantEndpoint(&cr, bd),
-				// For Chart-operator to run before CNI and kube-proxy are enabled.
-				"bootstrapMode": map[string]interface{}{
-					"enabled": true,
+				"chartOperator": map[string]interface{}{
+					"cni": map[string]interface{}{
+						"install": true,
+					},
 				},
 				"cluster": map[string]interface{}{
 					"calico": map[string]interface{}{

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -104,6 +104,11 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 					"irsa":      strconv.FormatBool(irsa),
 				},
 				"baseDomain": key.TenantEndpoint(&cr, bd),
+				"chartOperator": map[string]interface{}{
+					"cni": map[string]interface{}{
+						"install": true,
+					},
+				},
 				"cluster": map[string]interface{}{
 					"calico": map[string]interface{}{
 						"CIDR": podCIDR,

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -104,10 +104,9 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 					"irsa":      strconv.FormatBool(irsa),
 				},
 				"baseDomain": key.TenantEndpoint(&cr, bd),
-				"chartOperator": map[string]interface{}{
-					"cni": map[string]interface{}{
-						"install": true,
-					},
+				// For Chart-operator to run before CNI and kube-proxy are enabled.
+				"bootstrapMode": map[string]interface{}{
+					"enabled": true,
 				},
 				"cluster": map[string]interface{}{
 					"calico": map[string]interface{}{


### PR DESCRIPTION
In order to be able to install the CNI as a managed app in workload clusters, we need to deploy `chart-opeartor` in a special mode.

In capi, we do this: https://github.com/giantswarm/cluster-apps-operator/blob/bbc36714017d76f31fc1af577c31a130fe527b11/service/controller/resource/clusterconfigmap/desired.go#L85

This PR does the same for legacy clusters.


## Checklist

- [x] Update changelog in CHANGELOG.md.
