### PR TITLE
Cilium config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add cilium app config map.
+
 ## [4.4.0] - 2022-07-21
 
 ### Changed

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -143,7 +143,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 			Namespace: key.ClusterID(&cr),
 			Values: map[string]interface{}{
 				"defaultPolicies": map[string]interface{}{
-					"enabled": "true",
+					"enabled": true,
 				},
 				"ipam": map[string]interface{}{
 					"mode": "kubernetes",

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -138,6 +138,18 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 				},
 			},
 		},
+		{
+			Name:      "cilium-user-values",
+			Namespace: key.ClusterID(&cr),
+			Values: map[string]interface{}{
+				"defaultPolicies": map[string]interface{}{
+					"enabled": "true",
+				},
+				"ipam": map[string]interface{}{
+					"mode": "kubernetes",
+				},
+			},
+		},
 	}
 
 	var configMaps []*corev1.ConfigMap


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/1102

To run cilium-app on vintage clusters, we need to provide a custom config to the app, as the defaults are not working on legacy (and we can't change the defaults as we'd break capi).

We used to create a `cilium-user-values` CM in provider operators, but that generated a race condition that made possible for cilium app to be installed with wrong settings.

This PR adds the creation of a config map for the cilium app to change the needed settings.

## Checklist

- [x] Update changelog in CHANGELOG.md.
