### PR TITLE
Add `CNI_CONF_NAME` env to cilium app config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add `CNI_CONF_NAME` env to cilium app config.
+
 ## [4.5.0] - 2022-08-08
 
 ### Added

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -148,6 +148,12 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 				"ipam": map[string]interface{}{
 					"mode": "kubernetes",
 				},
+				"extraEnv": []map[string]string{
+					{
+						"name":  "CNI_CONF_NAME",
+						"value": "21-cilium.conf",
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
During upgrade to cilium, we need the cilium plugin to be lower priority than aws-cni.
We need this env var to be set for this to happen

## Checklist

- [x] Update changelog in CHANGELOG.md.
