### PR TITLE
Set `cni.exclusive` to `false` in cilium app config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set `cni.exclusive` to `false` in cilium app config.
+
 ## [4.5.1] - 2022-08-09
 
 ### Changed

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -148,6 +148,9 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 				"ipam": map[string]interface{}{
 					"mode": "kubernetes",
 				},
+				"cni": map[string]interface{}{
+					"exclusive": false,
+				},
 				"extraEnv": []map[string]string{
 					{
 						"name":  "CNI_CONF_NAME",


### PR DESCRIPTION
Yet another needed setting for the cilium app while doing the switch away from aws-cni


## Checklist

- [x] Update changelog in CHANGELOG.md.
