### PR TITLE
Enable kube-proxy replacement mode in Cilium app.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Enable kube-proxy replacement mode in Cilium app.
+- Enable bootstrap mode for chart operator.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Enable kube-proxy replacement mode in Cilium app.
+
 ### Added
 
 - Add `vpc ID` to WC configmap on AWS.

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -161,6 +161,9 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 						"value": "21-cilium.conf",
 					},
 				},
+				"kubeProxyReplacement": "strict",
+				"k8sServiceHost":       key.TenantEndpoint(&cr, bd),
+				"k8sServicePort":       "443",
 			},
 		},
 	}

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -109,8 +109,8 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 				},
 				"baseDomain": key.TenantEndpoint(&cr, bd),
 				"chartOperator": map[string]interface{}{
-					"cni": map[string]interface{}{
-						"install": true,
+					"bootstrapMode": map[string]interface{}{
+						"enabled": true,
 					},
 				},
 				"cluster": map[string]interface{}{

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -108,10 +108,8 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 					"vpcID":     vpcID,
 				},
 				"baseDomain": key.TenantEndpoint(&cr, bd),
-				"chartOperator": map[string]interface{}{
-					"bootstrapMode": map[string]interface{}{
-						"enabled": true,
-					},
+				"bootstrapMode": map[string]interface{}{
+					"enabled": true,
 				},
 				"cluster": map[string]interface{}{
 					"calico": map[string]interface{}{

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -162,7 +162,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 					},
 				},
 				"kubeProxyReplacement": "strict",
-				"k8sServiceHost":       key.TenantEndpoint(&cr, bd),
+				"k8sServiceHost":       key.APIEndpoint(&cr, bd),
 				"k8sServicePort":       "443",
 			},
 		},


### PR DESCRIPTION
This PR ensures chart operator is installed in bootstrapMode and adds required settings to cilium app needed to run it as a kube-proxy replacement.


## Checklist

- [x] Update changelog in CHANGELOG.md.
