### PR TITLE
Cilium proxy optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Allow disabling cilium's kube-proxy replacement feature by adding an annotation to the Cluster CR. 
+
 ## [5.1.0] - 2022-10-01
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/giantswarm/errors v0.3.0
 	github.com/giantswarm/exporterkit v1.0.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8smetadata v0.11.1
+	github.com/giantswarm/k8smetadata v0.14.0
 	github.com/giantswarm/kubeconfig/v4 v4.1.0
 	github.com/giantswarm/microendpoint v1.0.0
 	github.com/giantswarm/microerror v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -269,8 +269,8 @@ github.com/giantswarm/k8sclient/v5 v5.11.0 h1:LZwtscRz53Wz+hf0Sc7L1PEJdeUTDzgUja
 github.com/giantswarm/k8sclient/v5 v5.11.0/go.mod h1:3if9oaz3gwTKMuVNxU8vJfrzADyTuExOj+uu8N0+LsM=
 github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEPHWcvzsHk=
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
-github.com/giantswarm/k8smetadata v0.11.1 h1:GYdhg76Slhmm4QvjEn3/iJK9osvLHBZsIkGavDR3Ltg=
-github.com/giantswarm/k8smetadata v0.11.1/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
+github.com/giantswarm/k8smetadata v0.14.0 h1:fnjtS+AanST4di0mDfmL3AfX7EV8Zf5H4SIT7Ic43lY=
+github.com/giantswarm/k8smetadata v0.14.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/kubeconfig/v4 v4.1.0 h1:Ziq60FDlbigxRVJ47wLTdF3fx/Ao8gppe4CPmnEO6HM=
 github.com/giantswarm/kubeconfig/v4 v4.1.0/go.mod h1:cc01+1DLSnZh8csr33fPIWY/C97bXKMAL5k0Y1jpyYQ=
 github.com/giantswarm/microendpoint v1.0.0 h1:vW6VXPaWXBPZc9Q99FgPcjYprAKLItufKFcydBH47Xc=

--- a/service/controller/key/cilium.go
+++ b/service/controller/key/cilium.go
@@ -1,15 +1,12 @@
 package key
 
 import (
+	"github.com/giantswarm/k8smetadata/pkg/annotation"
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
-const (
-	ciliumForceDisableKubeProxyAnnotation = "cilium-force-disable-kube-proxy-replacement"
-)
-
 func ForceDisableCiliumKubeProxyReplacement(cluster apiv1beta1.Cluster) bool {
-	v, found := cluster.Annotations[ciliumForceDisableKubeProxyAnnotation]
+	v, found := cluster.Annotations[annotation.CiliumForceDisableKubeProxyAnnotation]
 
 	return found && v == "true"
 }

--- a/service/controller/key/cilium.go
+++ b/service/controller/key/cilium.go
@@ -1,0 +1,15 @@
+package key
+
+import (
+	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+const (
+	ciliumForceDisableKubeProxyAnnotation = "cilium-force-disable-kube-proxy-replacement"
+)
+
+func ForceDisableCiliumKubeProxyReplacement(cluster apiv1beta1.Cluster) bool {
+	v, found := cluster.Annotations[ciliumForceDisableKubeProxyAnnotation]
+
+	return found && v == "true"
+}

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -121,6 +121,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 		ciliumValues["kubeProxyReplacement"] = "strict"
 		ciliumValues["k8sServiceHost"] = key.APIEndpoint(&cr, bd)
 		ciliumValues["k8sServicePort"] = "443"
+		ciliumValues["cleanupKubeProxy"] = true
 	}
 
 	configMapSpecs := []configMapSpec{


### PR DESCRIPTION
Allow disabling cilium's kube-proxy replacement feature by adding an annotation to the Cluster CR. 

While upgrading from aws-cni to cilium, we need to wait for all aws-cni nodes to be gone before we can switch on cilium's kube-proxy feature. We allow aws-operator drive this feature, via an annotation on the Cluster CR.

This PR makes cluster-operator consider such annotation to change cilium app's settings accordingly.

## Checklist

- [x] Update changelog in CHANGELOG.md.
