### PR TITLE
Fixing app finalizer part

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Don't remove finalizer for in-cluster apps when cluster is being deleted.
+
 ## [5.5.0] - 2023-02-02
 
 ### Fixed
@@ -37,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Allow disabling cilium's kube-proxy replacement feature by adding an annotation to the Cluster CR. 
+- Allow disabling cilium's kube-proxy replacement feature by adding an annotation to the Cluster CR.
 
 ## [5.1.0] - 2022-10-01
 

--- a/service/controller/resource/appfinalizer/delete.go
+++ b/service/controller/resource/appfinalizer/delete.go
@@ -24,9 +24,10 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 	}
 
 	// We keep the finalizer for the app-operator app CR so the resources in
-	// the management cluster are deleted.
+	// the management cluster are deleted. We also keep finalizer of the in-cluster
+	// App CRs for they need to be processed correctly by the unique App Operator.
 	o := metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s!=%s", label.AppKubernetesName, "app-operator"),
+		LabelSelector: fmt.Sprintf("%s!=%s,%s!=%s", label.AppKubernetesName, "app-operator", label.AppOperatorVersion, "0.0.0"),
 	}
 
 	r.logger.Debugf(ctx, "finding apps to remove finalizers for")


### PR DESCRIPTION
## Description

When cluster namespace is being deleted, sometimes the in-cluster App CRs (like Observability Bundle, or Security Pack) that are being deleted with it, do no seem be caught up by the unique App Operator. In result, it never attempts to remove the corresponding Chart CRs, nor ConfigMaps and Secrets from the `giantswarm` namespace. This feels like kind of a race condition, for removing the finalizer result in immediate removal of an App CR, and I think sometimes the [Reconcile](https://github.com/giantswarm/operatorkit/blob/2cd5ed8f98431fd0e5a5beaed271ae31b258e5c3/pkg/controller/controller.go#L307) function has nothing to get, and quits. The solution would be to skip the in-cluster apps when deleting finalizers.

Towards: https://github.com/giantswarm/giantswarm/issues/25731

## Checklist

- [x] Update changelog in CHANGELOG.md.
