### PR TITLE
Cilium nps azure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Don't enable Cilium network policies on Azure.
+
 ## [5.6.0] - 2023-04-03
 
 ### Added

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/giantswarm/apiextensions/v6/pkg/apis/infrastructure/v1alpha3"
 	"github.com/giantswarm/microerror"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -61,6 +61,14 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 		}
 	}
 
+	// enableCiliumNetworkPolicy is only enabled by default for AWS clusters.
+	var enableCiliumNetworkPolicy bool
+	{
+		if r.provider == "aws" {
+			enableCiliumNetworkPolicy = true
+		}
+	}
+
 	values := map[string]interface{}{
 		"baseDomain": key.TenantEndpoint(&cr, bd),
 		"bootstrapMode": map[string]interface{}{
@@ -83,7 +91,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 		"clusterDNSIP": r.dnsIP,
 		"clusterID":    key.ClusterID(&cr),
 		"ciliumNetworkPolicy": map[string]interface{}{
-			"enabled": true,
+			"enabled": enableCiliumNetworkPolicy,
 		},
 	}
 

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -55,16 +55,11 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 
 	// useProxyProtocol is only enabled by default for AWS clusters.
 	var useProxyProtocol bool
-	{
-		if r.provider == "aws" {
-			useProxyProtocol = true
-		}
-	}
-
 	// enableCiliumNetworkPolicy is only enabled by default for AWS clusters.
 	var enableCiliumNetworkPolicy bool
 	{
 		if r.provider == "aws" {
+			useProxyProtocol = true
 			enableCiliumNetworkPolicy = true
 		}
 	}


### PR DESCRIPTION
We didn't introduce cilium on Azure vintage, so we can't enable cilium network policies for azure

## Checklist

- [x] Update changelog in CHANGELOG.md.
