### PR TITLE
Add cert-manager IRSA annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add necessary values for PSS policy warnings.
+- Add cert-manager IRSA annotation in cluster configmap.
 
 ### Removed
 

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -128,6 +128,15 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 			"region":    awsCluster.Spec.Provider.Region,
 			"vpcID":     vpcID,
 		}
+
+		// cert-manager IRSA SA annotation
+		if key.IRSAEnabled(awsCluster) {
+			values["serviceAccount"] = map[string]interface{}{
+				"annotations": map[string]interface{}{
+					"eks.amazonaws.com/role-arn": fmt.Sprintf("arn:aws:iam::%s:role/%s-CertManager-Role", accountID, key.ClusterID(&cr)),
+				},
+			}
+		}
 	}
 
 	ciliumValues := map[string]interface{}{


### PR DESCRIPTION
Part of giantswarm/roadmap#2000

This PR adds the cert-manager IRSA annotation directly because we removed business logic from the chart.

## Checklist

- [x] Update changelog in CHANGELOG.md.
