### PR TITLE
create external dns cluster values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Create `external-dns-cluster-values` configmap on cluster creation.
+
 ## [5.8.0] - 2023-09-01
 
 ### Added

--- a/service/controller/key/provider.go
+++ b/service/controller/key/provider.go
@@ -1,5 +1,11 @@
 package key
 
+import "strings"
+
 func IsAWS(provider string) bool {
 	return provider == "aws"
+}
+
+func IsAWSChina(region string) bool {
+	return strings.HasPrefix(region, "cn-")
 }

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -149,7 +149,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 			"--aws-batch-change-interval=10s",
 		}
 		externalDnsValues["aws"] = map[string]interface{}{
-			"batchChangeInterval": "null",
+			"batchChangeInterval": nil,
 		}
 		externalDnsValues["serviceAccount"] = map[string]interface{}{
 			"annotations": map[string]interface{}{

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -151,13 +151,15 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 		externalDnsValues["aws"] = map[string]interface{}{
 			"batchChangeInterval": nil,
 		}
-		externalDnsValues["serviceAccount"] = map[string]interface{}{
-			"annotations": map[string]interface{}{
-				"eks.amazonaws.com/role-arn": fmt.Sprintf("arn:aws:iam::%s:role/%s-Route53Manager-Role", accountID, key.ClusterID(&cr)),
-			},
-		}
 		externalDnsValues["domainFilters"] = []string{
 			key.TenantEndpoint(&cr, bd),
+		}
+		if !key.IsAWSChina(awsCluster.Spec.Provider.Region) {
+			externalDnsValues["serviceAccount"] = map[string]interface{}{
+				"annotations": map[string]interface{}{
+					"eks.amazonaws.com/role-arn": fmt.Sprintf("arn:aws:iam::%s:role/%s-Route53Manager-Role", accountID, key.ClusterID(&cr)),
+				},
+			}
 		}
 	}
 

--- a/service/controller/resource/clusterconfigmap/types.go
+++ b/service/controller/resource/clusterconfigmap/types.go
@@ -1,7 +1,9 @@
 package clusterconfigmap
 
 type configMapSpec struct {
-	Name      string
-	Namespace string
-	Values    map[string]interface{}
+	Name        string
+	Namespace   string
+	Values      map[string]interface{}
+	Labels      map[string]string
+	Annotations map[string]string
 }


### PR DESCRIPTION
- allow adding labels and annotations from configmap spec
- add external-dns-cluster-values configmap

external-dns v3 requires explicit declaration of certain values. Starting on v2.38 those values can be used already for an easy migration.

This new configmap (`external-dns-cluster-values`) would be added as a extraConfigs with priority 130 automatically by cluster-operator.

Towards https://github.com/giantswarm/giantswarm/issues/26527

## Checklist

- [ ] Update changelog in CHANGELOG.md.
