### PR TITLE
Automatically set `global.podSecurityStandards.enforced` to `true` fo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Automatically set `global.podSecurityStandards.enforced` to `true` for clusters >= 19.3.0.
+
 ## [5.9.0] - 2023-10-09
 
 ### Changed

--- a/service/controller/key/error.go
+++ b/service/controller/key/error.go
@@ -20,6 +20,15 @@ func IsNotFound(err error) bool {
 	return microerror.Cause(err) == notFoundError
 }
 
+var unknownReleaseError = &microerror.Error{
+	Kind: "unknownReleaseError",
+}
+
+// IsUnknownRelease asserts unknownReleaseError.
+func IsUnknownRelease(err error) bool {
+	return microerror.Cause(err) == unknownReleaseError
+}
+
 var wrongTypeError = &microerror.Error{
 	Kind: "wrongTypeError",
 }

--- a/service/controller/key/pss.go
+++ b/service/controller/key/pss.go
@@ -1,0 +1,22 @@
+package key
+
+import (
+	"github.com/blang/semver"
+	"github.com/giantswarm/microerror"
+)
+
+func IsPSSRelease(getter LabelsGetter) (bool, error) {
+	release := ReleaseVersion(getter)
+
+	if release == "" {
+		// Unable to get release from CR.
+		return false, microerror.Maskf(unknownReleaseError, "cannot determine release version from CR")
+	}
+
+	releaseVersion, err := semver.ParseTolerant(release)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	return releaseVersion.Major >= 19 && releaseVersion.Minor >= 3, nil
+}

--- a/service/controller/key/pss_test.go
+++ b/service/controller/key/pss_test.go
@@ -1,0 +1,66 @@
+package key
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cluster-api/api/v1beta1"
+
+	"github.com/giantswarm/cluster-operator/v5/pkg/label"
+)
+
+func TestIsPSSRelease(t *testing.T) {
+	tests := []struct {
+		name    string
+		getter  LabelsGetter
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:    "= 19.3.0",
+			getter:  getClusterWithLabelVersion("19.3.0"),
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "< 19.3.0",
+			getter:  getClusterWithLabelVersion("19.2.999999"),
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "19.3.0 test version",
+			getter:  getClusterWithLabelVersion("19.3.0-blah"),
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "> 19.3.0",
+			getter:  getClusterWithLabelVersion("19.3.1"),
+			want:    true,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := IsPSSRelease(tt.getter)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("IsPSSRelease() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("IsPSSRelease() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func getClusterWithLabelVersion(version string) *v1beta1.Cluster {
+	return &v1beta1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				label.ReleaseVersion: version,
+			},
+		},
+	}
+}

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -66,6 +66,14 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 		}
 	}
 
+	var pssEnforced bool
+	{
+		pssEnforced, err = key.IsPSSRelease(&cr)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	values := map[string]interface{}{
 		"baseDomain": key.TenantEndpoint(&cr, bd),
 		"bootstrapMode": map[string]interface{}{
@@ -92,7 +100,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 		},
 		"global": map[string]interface{}{
 			"podSecurityStandards": map[string]interface{}{
-				"enforced": false,
+				"enforced": pssEnforced,
 			},
 		},
 	}


### PR DESCRIPTION
…r clusters >= 19.3.0.

From cluster release 19.3.0 on we want to enforce PSS. This PR makes it happen

## Checklist

- [x] Update changelog in CHANGELOG.md.
