### PR TITLE
Add `provider` field to `external dns` configmap.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add `provider` field to `external dns` configmap.
+
 ## [5.10.0] - 2023-10-17
 
 ### Changed

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -109,6 +109,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 		"txtOwnerId":       "giantswarm-io-external-dns",
 		"txtPrefix":        key.ClusterID(&cr),
 		"annotationFilter": "giantswarm.io/external-dns=managed",
+		"provider":         r.provider,
 		"sources": []string{
 			"service",
 		},


### PR DESCRIPTION
For some reason external-dns fails to install because of lack of provider field in the config.

## Checklist

- [x] Update changelog in CHANGELOG.md.
