### PR TITLE
Fix release version check for PSS enforcement.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix release version check for PSS enforcement.
+
 ## [5.11.0] - 2024-04-24
 
 ### Changed

--- a/service/controller/key/pss.go
+++ b/service/controller/key/pss.go
@@ -18,5 +18,5 @@ func IsPSSRelease(getter LabelsGetter) (bool, error) {
 		return false, microerror.Mask(err)
 	}
 
-	return releaseVersion.Major >= 19 && releaseVersion.Minor >= 3, nil
+	return releaseVersion.Major >= 20 || (releaseVersion.Major >= 19 && releaseVersion.Minor >= 3), nil
 }

--- a/service/controller/key/pss_test.go
+++ b/service/controller/key/pss_test.go
@@ -40,6 +40,12 @@ func TestIsPSSRelease(t *testing.T) {
 			want:    true,
 			wantErr: false,
 		},
+		{
+			name:    "v20.0.0",
+			getter:  getClusterWithLabelVersion("20.0.0"),
+			want:    true,
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Enforce PSS for v20 clusters

## Checklist

- [x] Update changelog in CHANGELOG.md.
