### PR TITLE
Fix linting issues

### DIFF
--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -46,7 +46,7 @@ func CertConfigCertOperatorVersion(cr v1alpha1.CertConfig) string {
 func DNSIP(clusterIPRange string) (string, error) {
 	ip, _, err := net.ParseCIDR(clusterIPRange)
 	if err != nil {
-		return "", microerror.Maskf(invalidConfigError, err.Error()) //nolint:all
+		return "", microerror.Maskf(invalidConfigError, "%s", err.Error())
 	}
 
 	// Only IPV4 CIDRs are supported.

--- a/service/internal/tenantclient/client.go
+++ b/service/internal/tenantclient/client.go
@@ -83,7 +83,7 @@ func (c *TenantClient) K8sClient(ctx context.Context, obj interface{}) (k8sclien
 
 		k8sClient, err = k8sclient.NewClients(c)
 		if err != nil {
-			return nil, microerror.Maskf(notAvailableError, err.Error()) //nolint:all
+			return nil, microerror.Maskf(notAvailableError, "%s", err.Error())
 		}
 	}
 


### PR DESCRIPTION

Fix linting issues with latest golangci-lint (would be caught in govet from go 1.24).